### PR TITLE
feat: add boolean response to jido_ai/skill

### DIFF
--- a/guides/agent-skill.md
+++ b/guides/agent-skill.md
@@ -89,7 +89,7 @@ end
 | `tools` | List of Jido Actions the agent can use | `[Jido.Actions.Weather, Jido.Actions.Search]` |
 | `chat_action` | The Jido Action to handle chat responses | `Jido.AI.Actions.Instructor.ChatResponse` |
 | `tool_action` | The Jido Action to handle tool-based responses | `Jido.AI.Actions.Langchain.ToolResponse` |
-| `boolean_action` | The Jido action to handle boolean responses | `Jido.AI.Actions.Langchain.BooleanResponse` |
+| `boolean_action` | The Jido action to handle boolean responses | `Jido.AI.Actions.Instructor.BooleanResponse` |
 
 ## Understanding Jido.AI.Skill
 

--- a/lib/examples/03_with_boolean.ex
+++ b/lib/examples/03_with_boolean.ex
@@ -18,20 +18,14 @@ defmodule Examples.BooleanAgent03 do
 
     Logger.info("Agent started successfully")
 
-    question = "Is 273 + 112 - 937 positive?"
-    Logger.info("Question: #{question}")
+    pos_question = "Is 273 + 112 - 937 positive?"
+    neg_question = "Is 273 + 112 - 937 negative?"
 
-    case Agent.boolean_response(pid, question) do
-      {:ok, %{result: bool_result, confidence: confidence}} ->
-        if bool_result,
-          do: Logger.info("Result: true (#{confidence}%)"),
-          else: Logger.info("Result: false (#{confidence}%)")
+    boolean_response(pid, pos_question)
+    boolean_response(pid, neg_question)
+  end
 
-      {:error, error} ->
-        Logger.error("Error: #{inspect(error, pretty: true)}")
-    end
-
-    question = "Is 273 + 112 - 937 negative?"
+  defp boolean_response(pid, question) do
     Logger.info("Question: #{question}")
 
     case Agent.boolean_response(pid, question) do

--- a/lib/jido_ai/skill.ex
+++ b/lib/jido_ai/skill.ex
@@ -125,7 +125,8 @@ defmodule Jido.AI.Skill do
     {:ok, updated_signal}
   end
 
-  def handle_signal(%Signal{type: "jido.ai.chat.response"} = signal, skill_opts) do
+  def handle_signal(%Signal{type: type} = signal, skill_opts)
+      when type in ["jido.ai.chat.response", "jido.ai.boolean.response"] do
     base_prompt = Keyword.get(skill_opts, :prompt)
     rendered_prompt = render_prompt(base_prompt, signal.data)
     model = Keyword.get(skill_opts, :model)
@@ -136,19 +137,6 @@ defmodule Jido.AI.Skill do
     }
 
     {:ok, %{signal | data: chat_response_params}}
-  end
-
-  def handle_signal(%Signal{type: "jido.ai.boolean.response"} = signal, skill_opts) do
-    base_prompt = Keyword.get(skill_opts, :prompt)
-    rendered_prompt = render_prompt(base_prompt, signal.data)
-    model = Keyword.get(skill_opts, :model)
-
-    boolean_response_params = %{
-      model: model,
-      prompt: rendered_prompt
-    }
-
-    {:ok, %{signal | data: boolean_response_params}}
   end
 
   defp render_prompt(base_prompt, signal_data) when is_binary(base_prompt) do


### PR DESCRIPTION
Boolean responses were not handled in `Jido.AI.Skill`, this PR fixes this, also `IO.inspect()` from `TOOL_RESPONSE_PARAMS` was removed(maybe we can replace it with logger?).