### PR TITLE
Fix/doc-and-deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,11 @@ Jido AI is an extension of the Jido framework for building AI Agents and Workflo
 
 ## Installation
 
-> **Note:** You must install `instructor` from GitHub until a new version is released. Hex does not yet have a release of `instructor` that supports the `Instructor.Adapters.Anthropic` adapter.
-
 ```elixir
 def deps do
   [
-    {:jido, "~> 1.0.0"},
-    {:jido_ai, "~> 1.0.0"},
-
-    # Must install from github until a new version is released
-    {:instructor, github: "thmsmlr/instructor_ex"}
+    {:jido, "~> 1.2.0"},
+    {:jido_ai, "~> 0.5.2"},
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Jido.Ai.MixProject do
   use Mix.Project
 
-  @version "0.5.2"
+  @version "0.5.3"
   @source_url "https://github.com/agentjido/jido_ai"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -97,7 +97,7 @@ defmodule Jido.Ai.MixProject do
     else
       deps ++
         [
-          {:jido, "~> 1.1"}
+          {:jido, "~> 1.2.0"}
           # {:jido_memory, github: "agentjido/jido_memory"}
         ]
     end


### PR DESCRIPTION
I updated the documentation so there won’t be any issues when installing dependencies.
It’s no longer necessary to install the instructor dependencies from GitHub, since jido_ai already includes them as a dependency.