### PR TITLE
support ReqLLM.Response struct in ChatCompletion and preserve tool_results in map fallback

### DIFF
--- a/lib/jido_ai/actions/req_llm/chat_completion.ex
+++ b/lib/jido_ai/actions/req_llm/chat_completion.ex
@@ -102,6 +102,7 @@ defmodule Jido.AI.Actions.ReqLlm.ChatCompletion do
   require Logger
   alias Jido.AI.Model
   alias Jido.AI.Prompt
+  alias ReqLLM.Response, as: ReqResponse
 
   @impl true
   def on_before_validate_params(params) do
@@ -297,13 +298,15 @@ defmodule Jido.AI.Actions.ReqLlm.ChatCompletion do
     end
   end
 
-  defp format_response(%{content: content, tool_calls: tool_calls}) when is_list(tool_calls) do
+  defp format_response(%ReqResponse{} = response) do
+    content = ReqResponse.text(response) || ""
+    tool_calls = ReqResponse.tool_calls(response) || []
+
     formatted_tools =
       Enum.map(tool_calls, fn tool ->
         %{
           name: tool[:name] || tool["name"],
           arguments: tool[:arguments] || tool["arguments"],
-          # Will be populated after execution
           result: nil
         }
       end)
@@ -311,13 +314,23 @@ defmodule Jido.AI.Actions.ReqLlm.ChatCompletion do
     {:ok, %{content: content, tool_results: formatted_tools}}
   end
 
-  defp format_response(%{content: content}) do
-    {:ok, %{content: content, tool_results: []}}
-  end
-
   defp format_response(response) when is_map(response) do
-    # Fallback for other response formats
     content = response[:content] || response["content"] || ""
-    {:ok, %{content: content, tool_results: []}}
+    tool_calls = response[:tool_calls] || response["tool_calls"] || []
+
+    formatted_tools =
+      if is_list(tool_calls) do
+        Enum.map(tool_calls, fn tool ->
+          %{
+            name: tool[:name] || tool["name"],
+            arguments: tool[:arguments] || tool["arguments"],
+            result: nil
+          }
+        end)
+      else
+        []
+      end
+
+    {:ok, %{content: content, tool_results: formatted_tools}}
   end
 end


### PR DESCRIPTION
This PR updates `Jido.AI.Actions.ReqLlm.ChatCompletion` to properly handle `ReqLLM.Response` structs and maintains backward compatibility with map-based responses.

# About the error 

The Problem in main branch: Even on the latest main branch, the framework crashes during LLM interactions. This is due to the recent ReqLLM v1.0.0 update, which changed the response format from a plain Map to a %ReqLLM.Response{} Struct.

The code in Jido.AI.Actions.ReqLlm.ChatCompletion still uses bracket access (Access behavior), which structs do not implement, causing an immediate crash.


Error Message:

```elixir
** (UndefinedFunctionError) function ReqLLM.Response.fetch/2 is undefined (ReqLLM.Response does not implement the Access behaviour)
    (req_llm 1.0.0) ReqLLM.Response.fetch(%ReqLLM.Response{...}, :content)
    (elixir 1.17.2) lib/access.ex:326: Access.get/3
    (jido_ai 0.5.3) lib/jido_ai/actions/req_llm/chat_completion.ex:320: Jido.AI.Actions.ReqLlm.ChatCompletion.format_response/1
Affected Code: The issue is in 
lib/jido_ai/actions/req_llm/chat_completion.ex
 at line 320:
```

```elixir
# This fails because 'response' is a Struct in ReqLLM 1.0.0
content = response[:content] || response["content"] || ""
Steps to Reproduce:
```
 
## Changes
- Added `alias ReqLLM.Response, as: ReqResponse`.
- Refactored `format_response/1` to use:
  - `ReqResponse.text/1` for content
  - `ReqResponse.tool_calls/1` for tool calls
- Updated map fallback to preserve `tool_results` when `tool_calls` is present.
 
## Motivation
- `req_llm` migrated to structs; `jido_ai` assumed maps and used `[]` access, causing crashes.
- Using the official `ReqLLM.Response` API is safer and future-proof.
- Keeps compatibility with older `req_llm` versions that still return maps.
 
## Impact
- Internal-only changes to `ChatCompletion`.
