### PR TITLE
Enable flexible provider configuration (JSON mode)

### DIFF
--- a/lib/jido_ai/actions/req_llm/chat_completion.ex
+++ b/lib/jido_ai/actions/req_llm/chat_completion.ex
@@ -61,8 +61,7 @@ defmodule Jido.AI.Actions.ReqLlm.ChatCompletion do
       model: [
         type: {:custom, Jido.AI.Model, :validate_model_opts, []},
         required: true,
-        doc:
-          "The AI model to use (e.g., {:anthropic, [model: \"claude-3-sonnet-20240229\"]} or %Jido.AI.Model{})"
+        doc: "The AI model to use (e.g., {:anthropic, [model: \"claude-3-sonnet-20240229\"]} or %Jido.AI.Model{})"
       ],
       prompt: [
         type: {:custom, Jido.AI.Prompt, :validate_prompt_opts, []},
@@ -96,6 +95,12 @@ defmodule Jido.AI.Actions.ReqLlm.ChatCompletion do
         type: :boolean,
         default: false,
         doc: "Enable verbose logging"
+      ],
+      provider_options: [
+        type: :keyword_list,
+        required: false,
+        default: [],
+        doc: "Provider-specific options passed directly to ReqLLM"
       ]
     ]
 
@@ -155,7 +160,8 @@ defmodule Jido.AI.Actions.ReqLlm.ChatCompletion do
         frequency_penalty: nil,
         presence_penalty: nil,
         json_mode: false,
-        verbose: false
+        verbose: false,
+        provider_options: []
       }
       # Apply prompt options over defaults
       |> Map.merge(prompt_opts)
@@ -172,16 +178,15 @@ defmodule Jido.AI.Actions.ReqLlm.ChatCompletion do
           :frequency_penalty,
           :presence_penalty,
           :json_mode,
-          :verbose
+          :verbose,
+          :provider_options
         ])
       )
       # Always keep required params
       |> Map.merge(required_params)
 
     if params_with_defaults.verbose do
-      Logger.info(
-        "Running ReqLLM chat completion with params: #{inspect(params_with_defaults, pretty: true)}"
-      )
+      Logger.info("Running ReqLLM chat completion with params: #{inspect(params_with_defaults, pretty: true)}")
     end
 
     with {:ok, model} <- validate_model(params_with_defaults.model),
@@ -256,8 +261,13 @@ defmodule Jido.AI.Actions.ReqLlm.ChatCompletion do
           base_opts
       end
 
+    # Add explicit provider_options if present
+    # The caller is responsible for passing the correct options for the provider (e.g. response_format for OpenAI)
+    final_opts =
+      Keyword.merge(opts_with_tools, provider_options: Map.get(params, :provider_options, []))
+
     # ReqLLM handles authentication internally via environment variables
-    {:ok, opts_with_tools}
+    {:ok, final_opts}
   end
 
   defp add_opt_if_present(opts, _key, nil), do: opts


### PR DESCRIPTION
# Description

This pull request introduces support for passing provider-specific options directly to ReqLLM via a new provider_options parameter in the ChatCompletion action. This allows for greater flexibility when using different LLM providers (e.g., passing response_format for OpenAI or specific flags for Anthropic) without requiring hardcoded logic in the library.

It also refactors the response handling to correctly support ReqLLM.Response structs and streamlines parameter validation.

# Changes

## Features

Added provider_options (keyword list) to the ChatCompletion action schema.
Updated run_with_validated_params to whitelist and propagate provider_options to the ReqLLM call.
Removed implicit json_mode logic in favor of allowing the caller to pass explicit configuration via provider_options (e.g., response_format: %{type: "json_object"}).
## Fixes

Fixed KeyError and parameter stripping by correctly merging provider_options defaults.
Updated format_response/1 to correctly handle both ReqLLM.Response structs and legacy maps, preventing UndefinedFunctionError.
## Usage Example

```elixir
ChatCompletion.run(%{
  model: model,
  prompt: prompt,
  # Now you can pass provider-specific options directly
  provider_options: [
    response_format: %{type: "json_object"}
  ]
}, context)
```
