### PR TITLE
Add usage data to ChatCompletion response

### DIFF
--- a/guides/user/chat-completion.md
+++ b/guides/user/chat-completion.md
@@ -174,7 +174,8 @@ The result map contains:
 ```elixir
 %{
   content: "The response text from the LLM",
-  tool_results: []  # List of tool calls if any
+  tool_results: [],  # List of tool calls if any
+  usage: %{...}      # Optional - token usage and cost data
 }
 ```
 
@@ -189,9 +190,30 @@ With tool calls:
       arguments: %{"location" => "Tokyo"},
       result: nil  # Populated after you execute the tool
     }
-  ]
+  ],
+  usage: %{input_tokens: 25, output_tokens: 15, total_tokens: 40, ...}
 }
 ```
+
+### Usage Data
+
+When the provider returns token usage, it is normalized into a consistent structure:
+
+```elixir
+%{
+  input_tokens: 15,
+  output_tokens: 25,
+  total_tokens: 40,
+  reasoning_tokens: 0,       # For reasoning models (o1, o3, Gemini thinking)
+  cached_tokens: 0,          # Tokens read from cache
+  cache_creation_tokens: 0,  # Tokens written to cache
+  input_cost: 0.00015,       # Cost in USD (when model has pricing data)
+  output_cost: 0.00075,
+  total_cost: 0.0009
+}
+```
+
+Cost fields are included when the model has pricing metadata available.
 
 ## Controlling Response Quality
 

--- a/test/jido_ai/actions/req_llm/chat_completion_test.exs
+++ b/test/jido_ai/actions/req_llm/chat_completion_test.exs
@@ -454,6 +454,118 @@ defmodule Jido.AI.Actions.ReqLlm.ChatCompletionTest do
       [tool] = result.tool_results
       assert tool.name == "test_tool"
     end
+
+    test "includes usage data from response" do
+      model = {:openai, [model: "gpt-4"]}
+      prompt = Prompt.new(:user, "Test")
+
+      response =
+        mock_chat_response("Response with usage",
+          input_tokens: 15,
+          output_tokens: 25,
+          total_tokens: 40
+        )
+
+      mock_generate_text(response)
+
+      {:ok, result} = ChatCompletion.run(%{model: model, prompt: prompt}, %{})
+
+      assert result.content == "Response with usage"
+      assert result.usage.input_tokens == 15
+      assert result.usage.output_tokens == 25
+      assert result.usage.total_tokens == 40
+    end
+
+    test "includes usage with tool calls" do
+      model = {:openai, [model: "gpt-4"]}
+      prompt = Prompt.new(:user, "Search for something")
+
+      response =
+        mock_chat_response("Searching",
+          input_tokens: 20,
+          output_tokens: 30,
+          total_tokens: 50,
+          tool_calls: [%{name: "search", arguments: %{"query" => "test"}}]
+        )
+
+      mock_generate_text(response)
+
+      {:ok, result} = ChatCompletion.run(%{model: model, prompt: prompt}, %{})
+
+      assert result.content == "Searching"
+      assert length(result.tool_results) == 1
+      assert result.usage.input_tokens == 20
+      assert result.usage.output_tokens == 30
+    end
+
+    test "handles response without usage gracefully" do
+      model = {:openai, [model: "gpt-4"]}
+      prompt = Prompt.new(:user, "Test")
+
+      mock_generate_text(%{content: "No usage data"})
+
+      {:ok, result} = ChatCompletion.run(%{model: model, prompt: prompt}, %{})
+
+      assert result.content == "No usage data"
+      refute Map.has_key?(result, :usage)
+    end
+
+    test "handles response with empty usage map" do
+      model = {:openai, [model: "gpt-4"]}
+      prompt = Prompt.new(:user, "Test")
+
+      mock_generate_text(%{content: "Empty usage", usage: %{}})
+
+      {:ok, result} = ChatCompletion.run(%{model: model, prompt: prompt}, %{})
+
+      assert result.content == "Empty usage"
+      refute Map.has_key?(result, :usage)
+    end
+
+    test "handles usage with string keys" do
+      model = {:openai, [model: "gpt-4"]}
+      prompt = Prompt.new(:user, "Test")
+
+      mock_generate_text(%{
+        "content" => "String keys",
+        "usage" => %{
+          "prompt_tokens" => 10,
+          "completion_tokens" => 20,
+          "total_tokens" => 30
+        }
+      })
+
+      {:ok, result} = ChatCompletion.run(%{model: model, prompt: prompt}, %{})
+
+      assert result.content == "String keys"
+      assert result.usage["prompt_tokens"] == 10
+      assert result.usage["completion_tokens"] == 20
+    end
+
+    test "includes extended usage fields when present" do
+      model = {:anthropic, [model: "claude-3-5-sonnet"]}
+      prompt = Prompt.new(:user, "Test")
+
+      response = %{
+        content: "Extended usage",
+        usage: %{
+          input_tokens: 100,
+          output_tokens: 200,
+          total_tokens: 300,
+          input_cost: 0.001,
+          output_cost: 0.006,
+          total_cost: 0.007
+        }
+      }
+
+      mock_generate_text(response)
+
+      {:ok, result} = ChatCompletion.run(%{model: model, prompt: prompt}, %{})
+
+      assert result.usage.input_tokens == 100
+      assert result.usage.output_tokens == 200
+      assert result.usage.total_cost == 0.007
+    end
   end
 
   describe "different providers" do


### PR DESCRIPTION
## Description

This adds usage data when it exists from ReqLLM to the ChatCompletion response

* Updates documentation to match
* Adds tests
* Updates mock helper to return data faithful to ReqLLM response


## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update


## Testing

- [x] Tests pass (`mix test`)
- [] Quality checks pass (`mix quality`)

Quality checks are not passing in merge-base but did not worsen from this change

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Closes #
