### PR TITLE
fix(chat_completion): handle ReqLLM.Response struct in format_response

### DIFF
--- a/lib/jido_ai/actions/req_llm/chat_completion.ex
+++ b/lib/jido_ai/actions/req_llm/chat_completion.ex
@@ -297,6 +297,24 @@ defmodule Jido.AI.Actions.ReqLlm.ChatCompletion do
     end
   end
 
+  # Handle ReqLLM.Response struct
+  defp format_response(%ReqLLM.Response{} = response) do
+    content = ReqLLM.Response.text(response) || ""
+    tool_calls = ReqLLM.Response.tool_calls(response) || []
+
+    formatted_tools =
+      Enum.map(tool_calls, fn tool ->
+        %{
+          name: tool[:name] || tool["name"],
+          arguments: tool[:arguments] || tool["arguments"],
+          # Will be populated after execution
+          result: nil
+        }
+      end)
+
+    {:ok, %{content: content, tool_results: formatted_tools}}
+  end
+
   defp format_response(%{content: content, tool_calls: tool_calls}) when is_list(tool_calls) do
     formatted_tools =
       Enum.map(tool_calls, fn tool ->


### PR DESCRIPTION
## Summary
Fixes `UndefinedFunctionError` when using ReqLLM 1.0.0 with ChatCompletion. The issue occurred because `format_response/1` tried to use Access protocol on a struct.

## Changes
- Add pattern match clause for `%ReqLLM.Response{}` struct
- Use `ReqLLM.Response.text/1` and `tool_calls/1` helper functions