### PR TITLE
fix: remove calls to nonexistent ReqLLM.ToolCall.from_map/1

### DIFF
--- a/lib/jido_ai/helpers.ex
+++ b/lib/jido_ai/helpers.ex
@@ -290,7 +290,7 @@ defmodule Jido.AI.Helpers do
     %{
       type: type,
       text: Text.extract_from_content(response.message.content),
-      tool_calls: Enum.map(tool_calls, &ReqLLM.ToolCall.from_map/1)
+      tool_calls: tool_calls
     }
   end
 

--- a/lib/jido_ai/signal.ex
+++ b/lib/jido_ai/signal.ex
@@ -484,7 +484,7 @@ defmodule Jido.AI.Signal do
   # Private helpers for from_reqllm_response
 
   defp extract_response_tool_calls(%{message: %{tool_calls: tool_calls}}) when is_list(tool_calls) do
-    Enum.map(tool_calls, &ReqLLM.ToolCall.from_map/1)
+    tool_calls
   end
 
   defp extract_response_tool_calls(_), do: []


### PR DESCRIPTION
## Summary

- Remove calls to `ReqLLM.ToolCall.from_map/1` in `helpers.ex` and `signal.ex` — this function doesn't exist in `ReqLLM.ToolCall`, causing compile warnings on every build
- Tool calls from `response.message.tool_calls` are already `%ReqLLM.ToolCall{}` structs (normalized by req_llm), so the conversion was unnecessary

## Test plan

- [ ] `mix compile --warnings-as-errors` passes cleanly (previously emitted 2 warnings per app)
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)