### PR TITLE
feat(memory): add per-agent memory system with ETS backend

### DIFF
--- a/lib/jido_ai/actions/memory/forget.ex
+++ b/lib/jido_ai/actions/memory/forget.ex
@@ -1,0 +1,69 @@
+defmodule Jido.AI.Actions.Memory.Forget do
+  @moduledoc """
+  Action to forget (delete) memory entries for the current agent.
+
+  Supports deletion by exact key or by tag matching.
+
+  ## Parameters
+
+  - `key` (optional) - Forget a specific memory by key
+  - `tags` (optional) - Forget all memories matching these tags
+
+  At least one of `key` or `tags` must be provided.
+
+  ## Returns
+
+      %{forgotten: true, deleted: 1}
+  """
+
+  use Jido.Action,
+    name: "memory_forget",
+    description: "Forget stored memories. Delete by exact key or by matching tags.",
+    category: "memory",
+    tags: ["memory", "forget", "delete"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        key: Zoi.string(description: "Forget a specific memory by key") |> Zoi.optional(),
+        tags:
+          Zoi.array(Zoi.string(), description: "Forget memories matching all these tags")
+          |> Zoi.optional()
+      })
+
+  alias Jido.AI.Memory
+
+  @impl Jido.Action
+  def run(%{key: key} = _params, context) when is_binary(key) do
+    agent_id = resolve_agent_id(context)
+
+    case Memory.forget(agent_id, %{key: key}) do
+      {:ok, count} ->
+        {:ok, %{forgotten: true, deleted: count}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def run(%{tags: tags} = _params, context) when is_list(tags) do
+    agent_id = resolve_agent_id(context)
+
+    case Memory.forget(agent_id, %{tags: tags}) do
+      {:ok, count} ->
+        {:ok, %{forgotten: true, deleted: count}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def run(_params, _context) do
+    {:error, "At least one of 'key' or 'tags' must be provided"}
+  end
+
+  defp resolve_agent_id(context) when is_map(context) do
+    Map.get(context, :agent_id) || "default"
+  end
+
+  defp resolve_agent_id(_), do: "default"
+end

--- a/lib/jido_ai/actions/memory/recall.ex
+++ b/lib/jido_ai/actions/memory/recall.ex
@@ -1,0 +1,84 @@
+defmodule Jido.AI.Actions.Memory.Recall do
+  @moduledoc """
+  Action to recall memory entries for the current agent.
+
+  Supports recall by exact key or by tag matching. When recalling by tags,
+  all specified tags must be present on the entry (AND semantics).
+
+  ## Parameters
+
+  - `key` (optional) - Recall a specific memory by key
+  - `tags` (optional) - Recall all memories matching these tags
+
+  At least one of `key` or `tags` must be provided.
+
+  ## Returns
+
+  By key:
+
+      %{found: true, key: "user_name", value: "Alice", tags: ["profile"]}
+
+  By tags:
+
+      %{found: true, count: 2, entries: [%{key: "k1", value: "v1", tags: [...]}, ...]}
+  """
+
+  use Jido.Action,
+    name: "memory_recall",
+    description: "Recall stored memories. Look up by exact key or search by tags.",
+    category: "memory",
+    tags: ["memory", "recall", "search"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        key: Zoi.string(description: "Recall a specific memory by key") |> Zoi.optional(),
+        tags:
+          Zoi.array(Zoi.string(), description: "Recall memories matching all these tags")
+          |> Zoi.optional()
+      })
+
+  alias Jido.AI.Memory
+
+  @impl Jido.Action
+  def run(%{key: key} = _params, context) when is_binary(key) do
+    agent_id = resolve_agent_id(context)
+
+    case Memory.recall(agent_id, %{key: key}) do
+      {:ok, nil} ->
+        {:ok, %{found: false, key: key}}
+
+      {:ok, entry} ->
+        {:ok, %{found: true, key: entry.key, value: entry.value, tags: entry.tags}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def run(%{tags: tags} = _params, context) when is_list(tags) do
+    agent_id = resolve_agent_id(context)
+
+    case Memory.recall(agent_id, %{tags: tags}) do
+      {:ok, entries} ->
+        formatted =
+          Enum.map(entries, fn e ->
+            %{key: e.key, value: e.value, tags: e.tags}
+          end)
+
+        {:ok, %{found: length(formatted) > 0, count: length(formatted), entries: formatted}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def run(_params, _context) do
+    {:error, "At least one of 'key' or 'tags' must be provided"}
+  end
+
+  defp resolve_agent_id(context) when is_map(context) do
+    Map.get(context, :agent_id) || "default"
+  end
+
+  defp resolve_agent_id(_), do: "default"
+end

--- a/lib/jido_ai/actions/memory/store.ex
+++ b/lib/jido_ai/actions/memory/store.ex
@@ -1,0 +1,57 @@
+defmodule Jido.AI.Actions.Memory.Store do
+  @moduledoc """
+  Action to store a memory entry scoped to the current agent.
+
+  The `agent_id` is automatically provided via tool context when used
+  as a ReAct tool — the LLM does not need to specify it.
+
+  ## Parameters
+
+  - `key` (required) - Memory key
+  - `value` (required) - Value to store (will be serialized as a string for LLM readability)
+  - `tags` (optional) - List of tags for categorization
+  - `metadata` (optional) - Arbitrary metadata map
+
+  ## Returns
+
+      %{stored: true, key: "user_name", tags: ["profile"]}
+  """
+
+  use Jido.Action,
+    name: "memory_store",
+    description: "Store a memory entry. Use this to remember facts, preferences, or any information for later recall.",
+    category: "memory",
+    tags: ["memory", "store"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        key: Zoi.string(description: "Memory key to store under"),
+        value: Zoi.string(description: "Value to remember"),
+        tags: Zoi.array(Zoi.string(), description: "Tags for categorization") |> Zoi.default([]),
+        metadata: Zoi.map(description: "Additional metadata") |> Zoi.default(%{})
+      })
+
+  alias Jido.AI.Memory
+
+  @impl Jido.Action
+  def run(params, context) do
+    agent_id = resolve_agent_id(context)
+
+    case Memory.store(agent_id, params.key, params.value,
+           tags: params.tags,
+           metadata: params.metadata
+         ) do
+      {:ok, _entry} ->
+        {:ok, %{stored: true, key: params.key, tags: params.tags}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp resolve_agent_id(context) when is_map(context) do
+    Map.get(context, :agent_id) || "default"
+  end
+
+  defp resolve_agent_id(_), do: "default"
+end

--- a/lib/jido_ai/examples/memory_agent.ex
+++ b/lib/jido_ai/examples/memory_agent.ex
@@ -1,0 +1,51 @@
+defmodule Jido.AI.Examples.MemoryAgent do
+  @moduledoc """
+  Demo agent with persistent memory across conversations.
+
+  Uses the `Jido.AI.Memory` system to store, recall, and forget facts.
+  Memory persists in ETS across multiple `ask_sync` calls on the same
+  agent instance, demonstrating cross-conversation recall.
+
+  ## Usage
+
+      {:ok, pid} = Jido.start_agent(MyApp.Jido, Jido.AI.Examples.MemoryAgent)
+
+      # Store something in conversation 1
+      {:ok, _} = Jido.AI.Examples.MemoryAgent.ask_sync(pid, "Remember that my name is Alice")
+
+      # Recall it in conversation 2
+      {:ok, _} = Jido.AI.Examples.MemoryAgent.ask_sync(pid, "What is my name?")
+
+  ## CLI Usage
+
+      mix run scripts/test_memory_agent.exs
+  """
+
+  use Jido.AI.ReActAgent,
+    name: "memory_agent",
+    description: "Agent with persistent memory for facts and preferences",
+    tools: [
+      Jido.AI.Actions.Memory.Store,
+      Jido.AI.Actions.Memory.Recall,
+      Jido.AI.Actions.Memory.Forget
+    ],
+    plugins: [Jido.AI.Skills.MemorySkill],
+    system_prompt: """
+    You are a helpful assistant with persistent memory.
+
+    You have three memory tools available:
+    - memory_store: Save a fact or preference for later. Use descriptive keys (e.g., "user_name", "favorite_color") and tag entries for easy recall (e.g., tags: ["preference", "personal"]).
+    - memory_recall: Look up stored memories by exact key or by tags.
+    - memory_forget: Delete stored memories by key or tags.
+
+    IMPORTANT RULES:
+    1. When the user tells you something about themselves (name, preferences, facts), ALWAYS use memory_store to save it immediately.
+    2. When the user asks about something you might have stored, ALWAYS use memory_recall first to check.
+    3. Use clear, descriptive keys like "user_name", "favorite_color", "home_city".
+    4. Tag entries meaningfully: ["personal"], ["preference"], ["fact"], etc.
+    5. After storing, confirm what you remembered.
+    6. After recalling, use the information naturally in your response.
+    7. If recall returns found: false, say you don't have that information stored.
+    """,
+    max_iterations: 6
+end

--- a/lib/jido_ai/memory.ex
+++ b/lib/jido_ai/memory.ex
@@ -1,0 +1,85 @@
+defmodule Jido.AI.Memory do
+  @moduledoc """
+  Simple per-agent memory with pluggable backends.
+
+  Provides a behaviour for memory backends and delegates to the configured
+  backend (ETS by default). Memory is scoped per-agent using `agent_id`.
+
+  ## Configuration
+
+      config :jido_ai, Jido.AI.Memory,
+        backend: Jido.AI.Memory.Backends.ETS
+
+  ## Usage
+
+      alias Jido.AI.Memory
+
+      # Store a memory
+      {:ok, entry} = Memory.store("agent_1", "user_name", "Alice", tags: ["profile"])
+
+      # Recall by key
+      {:ok, entry} = Memory.recall("agent_1", %{key: "user_name"})
+
+      # Recall by tags
+      {:ok, entries} = Memory.recall("agent_1", %{tags: ["profile"]})
+
+      # Forget by key
+      {:ok, 1} = Memory.forget("agent_1", %{key: "user_name"})
+
+  ## Implementing a Backend
+
+  Implement the `Jido.AI.Memory` behaviour callbacks:
+
+      defmodule MyApp.Memory.RedisBackend do
+        @behaviour Jido.AI.Memory
+
+        @impl true
+        def store(agent_id, key, value, opts), do: ...
+
+        @impl true
+        def recall(agent_id, query, opts), do: ...
+
+        @impl true
+        def forget(agent_id, query, opts), do: ...
+      end
+  """
+
+  alias Jido.AI.Memory.Entry
+
+  @type agent_id :: String.t()
+  @type key :: String.t()
+  @type recall_query :: %{optional(:key) => key(), optional(:tags) => [String.t()]}
+
+  @callback store(agent_id(), key(), term(), keyword()) ::
+              {:ok, Entry.t()} | {:error, term()}
+
+  @callback recall(agent_id(), recall_query(), keyword()) ::
+              {:ok, Entry.t() | nil} | {:ok, [Entry.t()]} | {:error, term()}
+
+  @callback forget(agent_id(), recall_query(), keyword()) ::
+              {:ok, non_neg_integer()} | {:error, term()}
+
+  @spec store(agent_id(), key(), term(), keyword()) :: {:ok, Entry.t()} | {:error, term()}
+  def store(agent_id, key, value, opts \\ []) do
+    backend().store(agent_id, key, value, opts)
+  end
+
+  @spec recall(agent_id(), recall_query(), keyword()) ::
+          {:ok, Entry.t() | nil} | {:ok, [Entry.t()]} | {:error, term()}
+  def recall(agent_id, query, opts \\ []) do
+    backend().recall(agent_id, query, opts)
+  end
+
+  @spec forget(agent_id(), recall_query(), keyword()) ::
+          {:ok, non_neg_integer()} | {:error, term()}
+  def forget(agent_id, query, opts \\ []) do
+    backend().forget(agent_id, query, opts)
+  end
+
+  @doc "Returns the configured memory backend module."
+  @spec backend() :: module()
+  def backend do
+    Application.get_env(:jido_ai, __MODULE__, [])
+    |> Keyword.get(:backend, Jido.AI.Memory.Backends.ETS)
+  end
+end

--- a/lib/jido_ai/memory/backends/ets.ex
+++ b/lib/jido_ai/memory/backends/ets.ex
@@ -1,0 +1,162 @@
+defmodule Jido.AI.Memory.Backends.ETS do
+  @moduledoc """
+  ETS-based memory backend.
+
+  Stores memory entries in a named ETS table with `{agent_id, key}` composite keys.
+  The table is created on first use as a public named table.
+
+  This backend is suitable for development, testing, and single-node deployments.
+  For persistence across restarts or multi-node setups, implement a custom backend.
+
+  ## Configuration
+
+      config :jido_ai, Jido.AI.Memory,
+        backend: Jido.AI.Memory.Backends.ETS,
+        backend_opts: [table: :my_custom_table]
+  """
+
+  @behaviour Jido.AI.Memory
+
+  alias Jido.AI.Memory.Entry
+
+  @default_table :jido_ai_memory
+
+  @impl true
+  def store(agent_id, key, value, opts) do
+    tab = ensure_table!(opts)
+    now = DateTime.utc_now()
+    tags = Keyword.get(opts, :tags, [])
+    metadata = Keyword.get(opts, :metadata, %{})
+
+    entry =
+      case :ets.lookup(tab, {agent_id, key}) do
+        [{{^agent_id, ^key}, %Entry{} = existing}] ->
+          %{existing | value: value, tags: tags, metadata: metadata, updated_at: now}
+
+        [] ->
+          Entry.new(%{
+            agent_id: agent_id,
+            key: key,
+            value: value,
+            tags: tags,
+            metadata: metadata
+          })
+      end
+
+    :ets.insert(tab, {{agent_id, key}, entry})
+    {:ok, entry}
+  end
+
+  @impl true
+  def recall(agent_id, %{key: key}, opts) when is_binary(key) do
+    tab = ensure_table!(opts)
+
+    case :ets.lookup(tab, {agent_id, key}) do
+      [{{^agent_id, ^key}, entry}] -> {:ok, entry}
+      [] -> {:ok, nil}
+    end
+  end
+
+  def recall(agent_id, %{tags: tags}, opts) when is_list(tags) do
+    tab = ensure_table!(opts)
+
+    entries =
+      :ets.tab2list(tab)
+      |> Enum.flat_map(fn
+        {{^agent_id, _key}, %Entry{} = entry} -> [entry]
+        _ -> []
+      end)
+      |> Enum.filter(&tags_match?(&1, tags))
+
+    {:ok, entries}
+  end
+
+  def recall(_agent_id, _query, _opts), do: {:error, :invalid_query}
+
+  @impl true
+  def forget(agent_id, %{key: key}, opts) when is_binary(key) do
+    tab = ensure_table!(opts)
+
+    count =
+      case :ets.lookup(tab, {agent_id, key}) do
+        [_] ->
+          :ets.delete(tab, {agent_id, key})
+          1
+
+        [] ->
+          0
+      end
+
+    {:ok, count}
+  end
+
+  def forget(agent_id, %{tags: tags}, opts) when is_list(tags) do
+    tab = ensure_table!(opts)
+
+    keys_to_delete =
+      :ets.tab2list(tab)
+      |> Enum.flat_map(fn
+        {{^agent_id, key}, %Entry{} = entry} ->
+          if tags_match?(entry, tags), do: [{agent_id, key}], else: []
+
+        _ ->
+          []
+      end)
+
+    Enum.each(keys_to_delete, &:ets.delete(tab, &1))
+    {:ok, length(keys_to_delete)}
+  end
+
+  def forget(_agent_id, _query, _opts), do: {:error, :invalid_query}
+
+  defp tags_match?(%Entry{tags: entry_tags}, required_tags) do
+    Enum.all?(required_tags, &(&1 in entry_tags))
+  end
+
+  defp table_name(opts) do
+    backend_opts =
+      Application.get_env(:jido_ai, Jido.AI.Memory, [])
+      |> Keyword.get(:backend_opts, [])
+
+    Keyword.get(opts, :table) ||
+      Keyword.get(backend_opts, :table, @default_table)
+  end
+
+  defp ensure_table!(opts) do
+    tab = table_name(opts)
+
+    case :ets.whereis(tab) do
+      :undefined ->
+        create_table(tab)
+
+      _tid ->
+        :ok
+    end
+
+    tab
+  end
+
+  defp create_table(tab) do
+    parent = self()
+
+    spawn(fn ->
+      try do
+        :ets.new(tab, [:named_table, :set, :public, read_concurrency: true])
+      rescue
+        ArgumentError -> :ok
+      end
+
+      send(parent, {:table_ready, tab})
+
+      receive do
+        :stop -> :ok
+      end
+    end)
+
+    receive do
+      {:table_ready, ^tab} -> :ok
+    after
+      5_000 -> raise "Timeout waiting for ETS table #{tab}"
+    end
+  end
+end

--- a/lib/jido_ai/memory/entry.ex
+++ b/lib/jido_ai/memory/entry.ex
@@ -1,0 +1,54 @@
+defmodule Jido.AI.Memory.Entry do
+  @moduledoc """
+  A single memory record scoped to an agent.
+
+  Entries are the fundamental unit of agent memory, storing a value
+  associated with a key, optional tags for categorization, and
+  arbitrary metadata.
+
+  ## Fields
+
+  - `:agent_id` - The agent this memory belongs to
+  - `:key` - Unique key within the agent's memory space
+  - `:value` - The stored value (any term)
+  - `:tags` - List of string tags for categorization and recall
+  - `:metadata` - Arbitrary metadata map
+  - `:inserted_at` - When the entry was first created
+  - `:updated_at` - When the entry was last modified
+  """
+
+  @type t :: %__MODULE__{
+          agent_id: String.t(),
+          key: String.t(),
+          value: term(),
+          tags: [String.t()],
+          metadata: map(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  defstruct [
+    :agent_id,
+    :key,
+    :value,
+    :inserted_at,
+    :updated_at,
+    tags: [],
+    metadata: %{}
+  ]
+
+  @spec new(map()) :: t()
+  def new(attrs) when is_map(attrs) do
+    now = DateTime.utc_now()
+
+    %__MODULE__{
+      agent_id: Map.fetch!(attrs, :agent_id),
+      key: Map.fetch!(attrs, :key),
+      value: Map.get(attrs, :value),
+      tags: Map.get(attrs, :tags, []),
+      metadata: Map.get(attrs, :metadata, %{}),
+      inserted_at: Map.get(attrs, :inserted_at, now),
+      updated_at: Map.get(attrs, :updated_at, now)
+    }
+  end
+end

--- a/lib/jido_ai/memory/signal.ex
+++ b/lib/jido_ai/memory/signal.ex
@@ -1,0 +1,77 @@
+defmodule Jido.AI.Memory.Signal do
+  @moduledoc """
+  Signal types for memory operations.
+
+  These signals are emitted when memory is stored, recalled, or forgotten,
+  enabling observability and event-driven reactions to memory changes.
+
+  ## Signal Types
+
+  - `Stored` - Emitted when a memory entry is created or updated (`memory.stored`)
+  - `Recalled` - Emitted when memory is recalled (`memory.recalled`)
+  - `Forgotten` - Emitted when memory entries are deleted (`memory.forgotten`)
+  """
+
+  defmodule Stored do
+    @moduledoc """
+    Signal emitted when a memory entry is stored.
+
+    ## Data Fields
+
+    - `:agent_id` (required) - The agent that owns the memory
+    - `:key` (required) - The memory key
+    - `:tags` (optional) - Tags associated with the entry
+    """
+
+    use Jido.Signal,
+      type: "memory.stored",
+      default_source: "/memory",
+      schema: [
+        agent_id: [type: :string, required: true, doc: "Agent that owns the memory"],
+        key: [type: :string, required: true, doc: "Memory key"],
+        tags: [type: {:list, :string}, default: [], doc: "Tags associated with the entry"]
+      ]
+  end
+
+  defmodule Recalled do
+    @moduledoc """
+    Signal emitted when memory is recalled.
+
+    ## Data Fields
+
+    - `:agent_id` (required) - The agent whose memory was queried
+    - `:query` (required) - The recall query used
+    - `:count` (required) - Number of entries returned
+    """
+
+    use Jido.Signal,
+      type: "memory.recalled",
+      default_source: "/memory",
+      schema: [
+        agent_id: [type: :string, required: true, doc: "Agent whose memory was queried"],
+        query: [type: :map, required: true, doc: "The recall query"],
+        count: [type: :integer, required: true, doc: "Number of entries returned"]
+      ]
+  end
+
+  defmodule Forgotten do
+    @moduledoc """
+    Signal emitted when memory entries are deleted.
+
+    ## Data Fields
+
+    - `:agent_id` (required) - The agent whose memory was modified
+    - `:query` (required) - The forget query used
+    - `:deleted` (required) - Number of entries deleted
+    """
+
+    use Jido.Signal,
+      type: "memory.forgotten",
+      default_source: "/memory",
+      schema: [
+        agent_id: [type: :string, required: true, doc: "Agent whose memory was modified"],
+        query: [type: :map, required: true, doc: "The forget query"],
+        deleted: [type: :integer, required: true, doc: "Number of entries deleted"]
+      ]
+  end
+end

--- a/lib/jido_ai/plugins/memory.ex
+++ b/lib/jido_ai/plugins/memory.ex
@@ -1,0 +1,45 @@
+defmodule Jido.AI.Skills.MemorySkill do
+  @moduledoc """
+  Plugin that provides memory tools to an agent.
+
+  Exposes Store, Recall, and Forget actions as tools that can be used
+  by ReAct agents to remember and retrieve information across conversations.
+
+  ## Usage with ReActAgent
+
+      use Jido.AI.ReActAgent,
+        name: "my_agent",
+        tools: [
+          Jido.AI.Actions.Memory.Store,
+          Jido.AI.Actions.Memory.Recall,
+          Jido.AI.Actions.Memory.Forget
+        ],
+        plugins: [Jido.AI.Skills.MemorySkill]
+
+  Or use `tools_from_skills/1` to auto-extract:
+
+      @skills [Jido.AI.Skills.MemorySkill]
+
+      use Jido.AI.ReActAgent,
+        name: "my_agent",
+        tools: Jido.AI.ReActAgent.tools_from_skills(@skills),
+        plugins: @skills
+  """
+
+  use Jido.Plugin,
+    name: "ai_memory",
+    description: "Per-agent memory with pluggable backend (ETS default)",
+    category: "ai",
+    tags: ["memory", "state", "recall"],
+    state_key: :__memory_skill__,
+    actions: [
+      Jido.AI.Actions.Memory.Store,
+      Jido.AI.Actions.Memory.Recall,
+      Jido.AI.Actions.Memory.Forget
+    ]
+
+  @impl Jido.Plugin
+  def mount(_agent, _config) do
+    {:ok, %{}}
+  end
+end

--- a/scripts/test_memory_agent.exs
+++ b/scripts/test_memory_agent.exs
@@ -1,0 +1,159 @@
+# Memory Agent Demo
+#
+# Demonstrates that Jido.AI.Memory persists across separate conversations
+# on the same agent instance.
+#
+# Run with: mix run scripts/test_memory_agent.exs
+#
+# Flow:
+#   1. Store facts via natural language (agent uses memory_store tool)
+#   2. Ask about stored facts in a NEW conversation (agent uses memory_recall tool)
+#   3. Forget a fact, then confirm it's gone
+#   4. Verify the ETS backend directly to show what's stored
+
+Logger.configure(level: :warning)
+
+defmodule Colors do
+  def cyan(text), do: "\e[36m#{text}\e[0m"
+  def green(text), do: "\e[32m#{text}\e[0m"
+  def yellow(text), do: "\e[33m#{text}\e[0m"
+  def red(text), do: "\e[31m#{text}\e[0m"
+  def dim(text), do: "\e[2m#{text}\e[0m"
+  def bold(text), do: "\e[1m#{text}\e[0m"
+end
+
+# Attach telemetry handler for streaming tokens
+:telemetry.attach(
+  "memory-agent-stream",
+  [:jido, :agent_server, :signal, :start],
+  fn _event, _measurements, metadata, _config ->
+    case metadata do
+      %{signal_type: "react.llm.delta"} ->
+        if delta = get_in(metadata, [:signal, :data, :delta]) do
+          IO.write(delta)
+        end
+
+      _ ->
+        :ok
+    end
+  end,
+  nil
+)
+
+IO.puts("\n" <> Colors.bold("=" |> String.duplicate(60)))
+IO.puts(Colors.bold("  Jido.AI.Memory Demo — Cross-Conversation Recall"))
+IO.puts(Colors.bold("=" |> String.duplicate(60)))
+
+# Start Jido and the memory agent
+{:ok, _jido} = Jido.start_link(name: MemoryDemo.Jido)
+alias Jido.AI.Examples.MemoryAgent
+{:ok, pid} = Jido.start_agent(MemoryDemo.Jido, MemoryAgent)
+IO.puts(Colors.green("✓ MemoryAgent started\n"))
+
+timeout = [timeout: 60_000]
+
+# ── Phase 1: Store facts ──────────────────────────────────────────────
+IO.puts(Colors.cyan("━━━ Phase 1: Storing facts ━━━"))
+
+store_prompts = [
+  "My name is Alice and I live in Portland.",
+  "My favorite color is teal and I love hiking."
+]
+
+for {prompt, i} <- Enum.with_index(store_prompts, 1) do
+  IO.puts("\n" <> Colors.yellow("[Store #{i}] ") <> prompt)
+  IO.puts(Colors.dim("─" |> String.duplicate(50)))
+
+  case MemoryAgent.ask_sync(pid, prompt, timeout) do
+    {:ok, reply} ->
+      IO.puts("\n" <> Colors.green("Agent: ") <> reply)
+
+    {:error, reason} ->
+      IO.puts("\n" <> Colors.red("ERROR: #{inspect(reason)}"))
+  end
+
+  IO.puts("")
+end
+
+# ── Phase 2: Recall in new conversations ──────────────────────────────
+IO.puts(Colors.cyan("━━━ Phase 2: Recalling across conversations ━━━"))
+IO.puts(Colors.dim("(Each ask is a fresh ReAct conversation — memory persists in ETS)"))
+
+recall_prompts = [
+  "What is my name?",
+  "Where do I live?",
+  "What's my favorite color and hobby?"
+]
+
+for {prompt, i} <- Enum.with_index(recall_prompts, 1) do
+  IO.puts("\n" <> Colors.yellow("[Recall #{i}] ") <> prompt)
+  IO.puts(Colors.dim("─" |> String.duplicate(50)))
+
+  case MemoryAgent.ask_sync(pid, prompt, timeout) do
+    {:ok, reply} ->
+      IO.puts("\n" <> Colors.green("Agent: ") <> reply)
+
+    {:error, reason} ->
+      IO.puts("\n" <> Colors.red("ERROR: #{inspect(reason)}"))
+  end
+
+  IO.puts("")
+end
+
+# ── Phase 3: Forget and verify ────────────────────────────────────────
+IO.puts(Colors.cyan("━━━ Phase 3: Forget and verify ━━━"))
+
+IO.puts("\n" <> Colors.yellow("[Forget] ") <> "Forget my favorite color.")
+IO.puts(Colors.dim("─" |> String.duplicate(50)))
+
+case MemoryAgent.ask_sync(pid, "Forget my favorite color.", timeout) do
+  {:ok, reply} ->
+    IO.puts("\n" <> Colors.green("Agent: ") <> reply)
+
+  {:error, reason} ->
+    IO.puts("\n" <> Colors.red("ERROR: #{inspect(reason)}"))
+end
+
+IO.puts("")
+
+IO.puts("\n" <> Colors.yellow("[Verify] ") <> "What is my favorite color?")
+IO.puts(Colors.dim("─" |> String.duplicate(50)))
+
+case MemoryAgent.ask_sync(pid, "What is my favorite color?", timeout) do
+  {:ok, reply} ->
+    IO.puts("\n" <> Colors.green("Agent: ") <> reply)
+
+  {:error, reason} ->
+    IO.puts("\n" <> Colors.red("ERROR: #{inspect(reason)}"))
+end
+
+# ── Phase 4: Inspect ETS directly ─────────────────────────────────────
+IO.puts("\n\n" <> Colors.cyan("━━━ Phase 4: Raw ETS contents ━━━"))
+IO.puts(Colors.dim("(Direct view of what the agent stored in memory)\n"))
+
+case :ets.whereis(:jido_ai_memory) do
+  :undefined ->
+    IO.puts(Colors.yellow("  No ETS table found (nothing was stored)"))
+
+  _tid ->
+    entries = :ets.tab2list(:jido_ai_memory)
+
+    if entries == [] do
+      IO.puts(Colors.yellow("  Table exists but is empty"))
+    else
+      for {{agent_id, key}, entry} <- Enum.sort(entries) do
+        IO.puts(
+          "  #{Colors.dim(agent_id)} │ " <>
+            Colors.bold(key) <>
+            " = #{inspect(entry.value)}" <>
+            if(entry.tags != [], do: "  #{Colors.dim("tags: #{inspect(entry.tags)}")}", else: "")
+        )
+      end
+    end
+end
+
+# Cleanup
+IO.puts("")
+GenServer.stop(pid)
+IO.puts(Colors.green("✓ Agent stopped"))
+IO.puts(Colors.bold("=" |> String.duplicate(60)) <> "\n")

--- a/test/jido_ai/memory_test.exs
+++ b/test/jido_ai/memory_test.exs
@@ -1,0 +1,139 @@
+defmodule Jido.AI.MemoryTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.AI.Memory
+  alias Jido.AI.Memory.Entry
+
+  @table :jido_ai_memory_test
+
+  setup do
+    if :ets.whereis(@table) != :undefined do
+      :ets.delete_all_objects(@table)
+    end
+
+    {:ok, opts: [table: @table]}
+  end
+
+  describe "store/4" do
+    test "stores a new entry", %{opts: opts} do
+      assert {:ok, %Entry{} = entry} = Memory.store("agent_1", "name", "Alice", opts)
+      assert entry.agent_id == "agent_1"
+      assert entry.key == "name"
+      assert entry.value == "Alice"
+      assert entry.tags == []
+      assert entry.metadata == %{}
+      assert %DateTime{} = entry.inserted_at
+    end
+
+    test "stores with tags and metadata", %{opts: opts} do
+      opts = Keyword.merge(opts, tags: ["profile", "personal"], metadata: %{source: "user"})
+      assert {:ok, %Entry{} = entry} = Memory.store("agent_1", "name", "Alice", opts)
+      assert entry.tags == ["profile", "personal"]
+      assert entry.metadata == %{source: "user"}
+    end
+
+    test "updates existing entry preserving inserted_at", %{opts: opts} do
+      {:ok, original} = Memory.store("agent_1", "name", "Alice", opts)
+      {:ok, updated} = Memory.store("agent_1", "name", "Bob", opts)
+
+      assert updated.value == "Bob"
+      assert updated.inserted_at == original.inserted_at
+      assert DateTime.compare(updated.updated_at, original.inserted_at) in [:gt, :eq]
+    end
+
+    test "scopes entries per agent", %{opts: opts} do
+      {:ok, _} = Memory.store("agent_1", "name", "Alice", opts)
+      {:ok, _} = Memory.store("agent_2", "name", "Bob", opts)
+
+      assert {:ok, %Entry{value: "Alice"}} = Memory.recall("agent_1", %{key: "name"}, opts)
+      assert {:ok, %Entry{value: "Bob"}} = Memory.recall("agent_2", %{key: "name"}, opts)
+    end
+  end
+
+  describe "recall/3 by key" do
+    test "returns entry when found", %{opts: opts} do
+      {:ok, _} = Memory.store("agent_1", "color", "blue", opts)
+      assert {:ok, %Entry{value: "blue"}} = Memory.recall("agent_1", %{key: "color"}, opts)
+    end
+
+    test "returns nil when not found", %{opts: opts} do
+      assert {:ok, nil} = Memory.recall("agent_1", %{key: "missing"}, opts)
+    end
+
+    test "does not cross agent boundaries", %{opts: opts} do
+      {:ok, _} = Memory.store("agent_1", "secret", "hidden", opts)
+      assert {:ok, nil} = Memory.recall("agent_2", %{key: "secret"}, opts)
+    end
+  end
+
+  describe "recall/3 by tags" do
+    test "returns entries matching all tags", %{opts: opts} do
+      {:ok, _} = Memory.store("agent_1", "k1", "v1", Keyword.put(opts, :tags, ["a", "b"]))
+      {:ok, _} = Memory.store("agent_1", "k2", "v2", Keyword.put(opts, :tags, ["a"]))
+      {:ok, _} = Memory.store("agent_1", "k3", "v3", Keyword.put(opts, :tags, ["b", "c"]))
+
+      assert {:ok, entries} = Memory.recall("agent_1", %{tags: ["a", "b"]}, opts)
+      assert length(entries) == 1
+      assert hd(entries).key == "k1"
+    end
+
+    test "returns empty list when no tags match", %{opts: opts} do
+      {:ok, _} = Memory.store("agent_1", "k1", "v1", Keyword.put(opts, :tags, ["x"]))
+      assert {:ok, []} = Memory.recall("agent_1", %{tags: ["z"]}, opts)
+    end
+
+    test "scopes tag recall per agent", %{opts: opts} do
+      {:ok, _} = Memory.store("agent_1", "k1", "v1", Keyword.put(opts, :tags, ["shared"]))
+      {:ok, _} = Memory.store("agent_2", "k2", "v2", Keyword.put(opts, :tags, ["shared"]))
+
+      assert {:ok, entries} = Memory.recall("agent_1", %{tags: ["shared"]}, opts)
+      assert length(entries) == 1
+      assert hd(entries).agent_id == "agent_1"
+    end
+  end
+
+  describe "forget/3 by key" do
+    test "deletes an existing entry", %{opts: opts} do
+      {:ok, _} = Memory.store("agent_1", "temp", "data", opts)
+      assert {:ok, 1} = Memory.forget("agent_1", %{key: "temp"}, opts)
+      assert {:ok, nil} = Memory.recall("agent_1", %{key: "temp"}, opts)
+    end
+
+    test "returns 0 when key not found", %{opts: opts} do
+      assert {:ok, 0} = Memory.forget("agent_1", %{key: "nope"}, opts)
+    end
+
+    test "does not delete across agents", %{opts: opts} do
+      {:ok, _} = Memory.store("agent_1", "keep", "me", opts)
+      assert {:ok, 0} = Memory.forget("agent_2", %{key: "keep"}, opts)
+      assert {:ok, %Entry{value: "me"}} = Memory.recall("agent_1", %{key: "keep"}, opts)
+    end
+  end
+
+  describe "forget/3 by tags" do
+    test "deletes all entries matching tags", %{opts: opts} do
+      {:ok, _} = Memory.store("agent_1", "k1", "v1", Keyword.put(opts, :tags, ["temp"]))
+      {:ok, _} = Memory.store("agent_1", "k2", "v2", Keyword.put(opts, :tags, ["temp"]))
+      {:ok, _} = Memory.store("agent_1", "k3", "v3", Keyword.put(opts, :tags, ["keep"]))
+
+      assert {:ok, 2} = Memory.forget("agent_1", %{tags: ["temp"]}, opts)
+      assert {:ok, nil} = Memory.recall("agent_1", %{key: "k1"}, opts)
+      assert {:ok, %Entry{}} = Memory.recall("agent_1", %{key: "k3"}, opts)
+    end
+  end
+
+  describe "Entry.new/1" do
+    test "creates entry with required fields" do
+      entry = Entry.new(%{agent_id: "a1", key: "k1"})
+      assert entry.agent_id == "a1"
+      assert entry.key == "k1"
+      assert entry.value == nil
+      assert entry.tags == []
+      assert entry.metadata == %{}
+    end
+
+    test "raises on missing required fields" do
+      assert_raise KeyError, fn -> Entry.new(%{}) end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Introduces `Jido.AI.Memory` — a simple, extensible memory system that lets agents store, recall, and forget facts across conversations.

## What's Included

| Layer | Module | Purpose |
|-------|--------|---------|
| Core | `Jido.AI.Memory` | Behaviour + facade, delegates to configured backend |
| Core | `Jido.AI.Memory.Entry` | Struct: agent_id, key, value, tags, metadata, timestamps |
| Backend | `Jido.AI.Memory.Backends.ETS` | Default ETS implementation with long-lived table owner |
| Signals | `Jido.AI.Memory.Signal` | `memory.stored`, `memory.recalled`, `memory.forgotten` |
| Actions | `Jido.AI.Actions.Memory.{Store,Recall,Forget}` | ReAct-compatible tools with Zoi schemas |
| Plugin | `Jido.AI.Skills.MemorySkill` | Bundles the three actions as a plugin |
| Example | `Jido.AI.Examples.MemoryAgent` | Demo agent with memory tools |
| Script | `scripts/test_memory_agent.exs` | End-to-end cross-conversation demo |

## Key Design Decisions

- **Behaviour-based**: `Jido.AI.Memory` defines callbacks so backends are swappable (ETS now, Postgres/Redis/vector later)
- **Per-agent scoping**: Memory is keyed by `{agent_id, key}` — agents can't see each other's memory
- **Auto-scoped via tool_context**: `ReActAgent.on_before_cmd` injects `agent_id` so the LLM never needs to pass it
- **Exact-match retrieval**: By key or by tags (AND semantics) — intentionally simple for the intro scaffold
- **ETS table ownership**: Spawns a long-lived process to own the named table, preventing premature cleanup when tool tasks exit

## Integration

```elixir
use Jido.AI.ReActAgent,
  name: "my_agent",
  tools: [
    Jido.AI.Actions.Memory.Store,
    Jido.AI.Actions.Memory.Recall,
    Jido.AI.Actions.Memory.Forget
  ],
  plugins: [Jido.AI.Skills.MemorySkill]
```

## Testing

- 16 unit tests covering store/recall/forget with agent isolation
- Live demo script verified: `mix run scripts/test_memory_agent.exs`

## Extension Points

- Implement `@behaviour Jido.AI.Memory` for Postgres/Redis/vector backends
- Signals defined but not yet emitted from actions — ready for directive wiring
- Add similarity search, TTL, or versioning on top of the same behaviour