### PR TITLE
feat: pass req_http_options through LLM directives to ReqLLM

### DIFF
--- a/lib/jido_ai/helpers.ex
+++ b/lib/jido_ai/helpers.ex
@@ -254,6 +254,15 @@ defmodule Jido.AI.Helpers do
   end
 
   @doc """
+  Adds req_http_options to a keyword list if any are specified.
+  """
+  @spec add_req_http_options(keyword(), list()) :: keyword()
+  def add_req_http_options(opts, []), do: opts
+
+  def add_req_http_options(opts, req_http_options) when is_list(req_http_options),
+    do: Keyword.put(opts, :req_http_options, req_http_options)
+
+  @doc """
   Adds tools option to a keyword list if tools are specified.
   """
   @spec add_tools_opt(keyword(), list()) :: keyword()


### PR DESCRIPTION
## Summary

- Add `req_http_options` field to `LLMStream` and `LLMGenerate` directive schemas (defaults to `[]`)
- Wire through both `DirectiveExec` implementations to the ReqLLM opts pipeline via new `Helpers.add_req_http_options/2`
- Support in ReAct strategy as base config (`req_http_options:` strategy opt) and ephemeral per-request option (via `react.start` params), with same lifecycle as `tool_context`

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] Full test suite passes (1574 tests, 0 failures)
- [ ] Verify directive construction: `Directive.LLMStream.new!(%{id: "t", context: [], req_http_options: [plug: {P, []}]}).req_http_options`

Closes #133