### PR TITLE
fix(tool-calling): align ToolCalling mount state with schema

### DIFF
--- a/lib/jido_ai/plugins/tool_calling.ex
+++ b/lib/jido_ai/plugins/tool_calling.ex
@@ -137,7 +137,7 @@ defmodule Jido.AI.Plugins.ToolCalling do
         |> Zoi.default(10),
       available_tools:
         Zoi.list(
-          Zoi.map(description: "Tool information with :name and :type keys"),
+          Zoi.string(description: "Registered tool name"),
           description: "List of available tools from registry"
         )
         |> Zoi.default([])

--- a/test/jido_ai/skills/tool_calling/tool_calling_skill_test.exs
+++ b/test/jido_ai/skills/tool_calling/tool_calling_skill_test.exs
@@ -43,6 +43,13 @@ defmodule Jido.AI.Plugins.ToolCallingTest do
       assert state.max_turns == 5
       assert state.default_model == :capable
     end
+
+    test "mounted state validates against plugin schema" do
+      {:ok, state} =
+        ToolCalling.mount(%Jido.Agent{}, %{tools: [Jido.AI.Actions.ToolCalling.ExecuteTool]})
+
+      assert {:ok, _parsed_state} = Zoi.parse(ToolCalling.schema(), state)
+    end
   end
 
   describe "actions" do


### PR DESCRIPTION
## Summary
- align `ToolCalling.schema/0` with `mount/2` by defining `available_tools` as `list(string)`
- keep mount behavior as tool-name list while preserving existing plugin state shape
- add an integration test asserting mounted state successfully parses via `Zoi.parse/2`

## Testing
- `mix test test/jido_ai/skills/tool_calling/tool_calling_skill_test.exs`

Closes #139
