### PR TITLE
fix(skill): prevent registry crashes when not started

### DIFF
--- a/test/jido_ai/skill/registry_not_started_test.exs
+++ b/test/jido_ai/skill/registry_not_started_test.exs
@@ -1,0 +1,61 @@
+defmodule Jido.AI.Skill.RegistryNotStartedTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.AI.Skill
+  alias Jido.AI.Skill.{Error, Registry}
+
+  setup do
+    stop_registry()
+
+    on_exit(fn ->
+      stop_registry()
+    end)
+
+    :ok
+  end
+
+  describe "when registry is not started" do
+    test "lookup/1 does not raise and returns not_found" do
+      assert Process.whereis(Registry) == nil
+
+      assert {:error, %Error.NotFound{name: "missing-skill"}} = Registry.lookup("missing-skill")
+      assert is_pid(Process.whereis(Registry))
+    end
+
+    test "list/0 returns an empty list" do
+      assert Process.whereis(Registry) == nil
+
+      assert Registry.list() == []
+      assert is_pid(Process.whereis(Registry))
+    end
+
+    test "all/0 returns an empty list" do
+      assert Process.whereis(Registry) == nil
+
+      assert Registry.all() == []
+      assert is_pid(Process.whereis(Registry))
+    end
+
+    test "Skill.resolve/1 returns a structured error" do
+      assert Process.whereis(Registry) == nil
+
+      assert {:error, %Error.NotFound{name: "missing-skill"}} = Skill.resolve("missing-skill")
+      assert is_pid(Process.whereis(Registry))
+    end
+  end
+
+  defp stop_registry do
+    case Process.whereis(Registry) do
+      nil ->
+        :ok
+
+      _pid ->
+        try do
+          GenServer.stop(Registry, :normal, 5_000)
+        catch
+          :exit, {:noproc, _} -> :ok
+          :exit, {:normal, _} -> :ok
+        end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- make `Jido.AI.Skill.Registry` lazily start itself before public API calls
- prevent ETS lookup/select crashes when registry has not been started yet
- add regression tests for not-started `lookup/1`, `list/0`, `all/0`, and `Skill.resolve/1`

## Testing
- `mix test test/jido_ai/skill/registry_test.exs test/jido_ai/skill/registry_not_started_test.exs`

Closes #140
