### PR TITLE
docs: align API/config guides and enforce doc drift checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,19 @@ def deps do
 end
 ```
 
-Configure your LLM provider (see [Configuration Guide](guides/developer/08_configuration.md)):
+Configure model aliases and LLM provider credentials (see [Configuration Guide](guides/developer/08_configuration.md)):
 
 ```elixir
 # config/config.exs
-config :jido_ai, :models,
-  anthropic: [
-    api_key: System.get_env("ANTHROPIC_API_KEY")
-  ],
-  openai: [
-    api_key: System.get_env("OPENAI_API_KEY")
-  ]
+config :jido_ai,
+  model_aliases: %{
+    fast: "anthropic:claude-haiku-4-5",
+    capable: "anthropic:claude-sonnet-4-20250514"
+  }
+
+config :req_llm,
+  anthropic_api_key: System.get_env("ANTHROPIC_API_KEY"),
+  openai_api_key: System.get_env("OPENAI_API_KEY")
 ```
 
 ## Reasoning Strategies

--- a/guides/developer/01_architecture_overview.md
+++ b/guides/developer/01_architecture_overview.md
@@ -184,25 +184,23 @@ directive = Directive.LLMStream.new!(%{
 })
 ```
 
-### 5. Tool System (`Jido.AI.Tools.*`)
+### 5. Tool System (`Jido.AI.*`)
 
-The tool system bridges Jido.Actions and LLM tool calling.
+The tool system bridges Jido.Actions and LLM tool calling without a global registry.
 
 | Module | Purpose |
 |--------|---------|
-| `Registry` | Unified registry for Actions and Tools |
-| `Executor` | Consistent tool execution with normalization |
-| `ToolAdapter` | Converts Actions to ReqLLM.Tool format |
-| `Tool` | Behavior for custom tool implementations |
+| `Jido.AI.Actions.ToolCalling.*` | Tool-calling actions (`CallWithTools`, `ExecuteTool`, `ListTools`) |
+| `Jido.AI.Executor` | Consistent tool execution with normalization and timeout handling |
+| `Jido.AI.ToolAdapter` | Converts Action modules to ReqLLM tool definitions |
 
 ```elixir
-# Register tools
-Registry.register(MyApp.Actions.Calculator)
-Registry.register(MyApp.Tools.Search)
+tools = Jido.AI.Executor.build_tools_map([MyApp.Actions.Calculator, MyApp.Actions.Search])
 
-# Lookup and execute
-{:ok, {:action, module}} = Registry.get("calculator")
-{:ok, result} = Executor.execute("calculator", %{a: 1, b: 2, operation: "add"})
+{:ok, result} =
+  Jido.AI.Executor.execute("calculator", %{"a" => 1, "b" => 2, "operation" => "add"}, %{},
+    tools: tools
+  )
 ```
 
 ### 6. Signal Layer (`Jido.AI.Signal.*`)
@@ -218,7 +216,7 @@ Typed signals for event-driven communication.
 | `EmbedResult` | `ai.embed.result` | Embedding generated |
 | `Usage` | `ai.usage` | Token usage tracking |
 
-### 7. Skill Framework (`Jido.AI.Skills.*`)
+### 7. Plugin/Skill Framework (`Jido.AI.Plugins.*`, `Jido.AI.Skill.*`)
 
 Skills provide modular capabilities. Each skill:
 

--- a/guides/developer/04_directives.md
+++ b/guides/developer/04_directives.md
@@ -159,7 +159,7 @@ The directive implementation:
 
 ## ToolExec Directive
 
-Executes a Jido.Action or Jido.AI.Tools.Tool as a tool.
+Executes a `Jido.Action` module as a tool.
 
 ### Schema
 

--- a/guides/developer/06_tool_system.md
+++ b/guides/developer/06_tool_system.md
@@ -1,288 +1,132 @@
 # Tool System Guide
 
-This guide covers the tool system in Jido.AI, which bridges Jido.Actions and LLM tool calling.
-
-## Table of Contents
-
-- [Overview](#overview)
-- [Architecture](#architecture)
-- [Registry](#registry)
-- [Executor](#executor)
-- [ToolAdapter](#tooladapter)
-- [Creating Tools](#creating-tools)
+This guide describes how Jido.AI handles tool calling with `Jido.Action` modules.
 
 ## Overview
 
-The tool system enables LLMs to execute Jido.Actions as tools. It provides:
+Jido.AI does **not** use a global tools registry module.
+Tools are provided as action modules and passed through runtime context (usually `context[:tools]`).
 
-1. **Unified Registry**: Single source of truth for action discovery
-2. **Validated Execution**: All actions run via `Jido.Exec.run/3`
-3. **Argument Normalization**: Converts JSON arguments to atom keys
-4. **Consistent Execution**: Standardized error handling and telemetry
-
-### Tool Flow
-
-```mermaid
-sequenceDiagram
-    participant LLM as LLM
-    participant Strategy as ReAct Strategy
-    participant Runtime as AgentServer
-    participant Registry as Tools.Registry
-    participant Executor as Tools.Executor
-    participant Action as Jido.Action
-
-    LLM->>Strategy: Tool call request
-    Strategy->>Runtime: Directive.ToolExec
-    Runtime->>Registry: get(tool_name)
-    Registry-->>Runtime: {:ok, module}
-    Runtime->>Executor: execute(tool_name, arguments)
-    Executor->>Action: normalize + Jido.Exec.run
-    Action-->>Executor: {:ok, result}
-    Executor-->>Runtime: Signal.ToolResult
-    Runtime->>Strategy: signal_routes()
-```
-
-## Architecture
-
-### Components
+## Core Components
 
 | Module | Purpose |
 |--------|---------|
-| `Jido.AI.Tools.Registry` | Action storage and lookup |
-| `Jido.AI.Executor` | Execution with timeout, telemetry, formatting |
-| `Jido.AI.ToolAdapter` | Converts Actions to ReqLLM format |
+| `Jido.AI.Actions.ToolCalling.CallWithTools` | LLM call with tool definitions and optional auto-execution |
+| `Jido.AI.Actions.ToolCalling.ExecuteTool` | Directly execute one tool by name |
+| `Jido.AI.Actions.ToolCalling.ListTools` | Discover available tools from context |
+| `Jido.AI.Executor` | Name lookup, argument normalization, execution, timeout, telemetry |
+| `Jido.AI.ToolAdapter` | Convert action modules into ReqLLM tool definitions |
 
-### Storage
+## Tool Map Pattern
 
-```
-┌─────────────────────────────────────────┐
-│         Tools.Registry                  │
-├─────────────────────────────────────────┤
-│  "calculator" → Calculator              │
-│  "search"     → Search                  │
-│  "weather"    → Weather                 │
-└─────────────────────────────────────────┘
-```
-
-## Registry
-
-The `Jido.AI.Tools.Registry` provides storage for Action modules used as tools.
-
-### Starting the Registry
-
-The registry auto-starts on first access. You can also start it explicitly:
+Tools are represented as `%{"tool_name" => MyActionModule}` maps.
 
 ```elixir
-{:ok, _pid} = Jido.AI.Tools.Registry.start_link()
-```
-
-### Registration
-
-```elixir
-alias Jido.AI.Tools.Registry
-
-# Register an action
-:ok = Registry.register(MyApp.Actions.Calculator)
-
-# Also available as register_action
-:ok = Registry.register_action(MyApp.Actions.Calculator)
-
-# Batch registration
-:ok = Registry.register_actions([
+tools = Jido.AI.Executor.build_tools_map([
   MyApp.Actions.Calculator,
   MyApp.Actions.Search
 ])
+# => %{"calculator" => MyApp.Actions.Calculator, "search" => MyApp.Actions.Search}
 ```
 
-### Lookup
+You can pass this map into tool-calling actions via context:
 
 ```elixir
-# Safe lookup
-{:ok, module} = Registry.get("calculator")
-{:error, :not_found} = Registry.get("unknown")
+context = %{tools: tools}
 
-# Bang version (raises on not found)
-module = Registry.get!("calculator")
+{:ok, result} =
+  Jido.Exec.run(Jido.AI.Actions.ToolCalling.ExecuteTool, %{
+    tool_name: "calculator",
+    params: %{a: 5, b: 3, operation: "add"}
+  }, context)
 ```
 
-### Listing
+## Execution Flow
+
+`Jido.AI.Executor.execute/4` performs:
+
+1. Tool name lookup in the provided `tools:` map
+2. Parameter normalization from JSON-style string keys
+3. Action execution (`Jido.Exec.run/3`)
+4. Result formatting
+5. Structured error handling
+
+Example:
 
 ```elixir
-# List all registered actions
-Registry.list_all()
-# => [{"calculator", Calculator}, {"search", Search}]
+tools = Jido.AI.Executor.build_tools_map([MyApp.Actions.Calculator])
 
-# Also available as list_actions
-Registry.list_actions()
-# => [{"calculator", Calculator}, {"search", Search}]
+{:ok, result} =
+  Jido.AI.Executor.execute(
+    "calculator",
+    %{"a" => "5", "b" => "3", "operation" => "add"},
+    %{},
+    tools: tools,
+    timeout: 5_000
+  )
 ```
 
-### ReqLLM Conversion
+## ReqLLM Tool Conversion
+
+Convert action modules into ReqLLM tool definitions:
 
 ```elixir
-# Convert all to ReqLLM.Tool structs
-tools = Registry.to_reqllm_tools()
-ReqLLM.stream_text(model, messages, tools: tools)
-```
-
-### Management
-
-```elixir
-# Unregister by name
-:ok = Registry.unregister("calculator")
-
-# Clear all (useful for testing)
-:ok = Registry.clear()
-```
-
-## Executor
-
-The `Jido.AI.Executor` provides consistent action execution with timeout handling.
-
-### Execution Flow
-
-```elixir
-def execute(tool_name, arguments, context \\ %{})
-```
-
-1. Lookup action in Registry
-2. Normalize arguments (string keys → atom keys)
-3. Execute via `Jido.Exec.run/3` (validates with schema)
-4. Format and return result
-
-### Argument Normalization
-
-LLMs return tool call arguments with string keys (JSON format). The executor normalizes them:
-
-```elixir
-# Before (from LLM)
-%{"a" => "1", "b" => "2", "operation" => "add"}
-
-# After normalization (based on schema)
-%{a: 1, b: 2, operation: "add"}
-```
-
-### Usage
-
-```elixir
-alias Jido.AI.Executor
-
-# Execute by name (uses registry)
-{:ok, result} = Executor.execute("calculator", %{
-  "a" => 5,
-  "b" => 3,
-  "operation" => "add"
-})
-
-# Execute directly with module (bypasses registry)
-{:ok, result} = Executor.execute_module(MyApp.Actions.Calculator, %{
-  "a" => 5,
-  "b" => 3
-}, %{})
-
-# With timeout
-{:ok, result} = Executor.execute("search", %{"query" => "Elixir"}, %{}, timeout: 5000)
-```
-
-### Error Handling
-
-The executor returns structured errors:
-
-```elixir
-{:error, %{error: "Tool not found: unknown", type: :not_found}}
-{:error, %{error: "...", type: :execution_error, details: %{...}}}
-{:error, %{error: "Tool execution timed out after 30000ms", type: :timeout}}
-```
-
-## ToolAdapter
-
-The `Jido.AI.ToolAdapter` converts Jido.Actions to ReqLLM.Tool format.
-
-### From Actions
-
-```elixir
-alias Jido.AI.ToolAdapter
-
-# Single action
-tool = ToolAdapter.from_action(MyApp.Actions.Calculator)
-# => %ReqLLM.Tool{name: "calculator", description: "...", parameter_schema: %{...}}
-
-# Multiple actions
-tools = ToolAdapter.from_actions([
+tools = Jido.AI.ToolAdapter.from_actions([
   MyApp.Actions.Calculator,
   MyApp.Actions.Search
 ])
 
-# With prefix
-tools = ToolAdapter.from_actions(actions, prefix: "myapp_")
+{:ok, response} =
+  Jido.AI.LLMClient.generate_text(%{}, "anthropic:claude-sonnet-4-20250514", messages,
+    tools: tools
+  )
 ```
 
-### Lookup
+## ToolCalling Plugin
+
+`Jido.AI.Plugins.ToolCalling` accepts tools through plugin config:
 
 ```elixir
-# Find action by tool name
-{:ok, action} = ToolAdapter.lookup_action("calculator", action_modules)
+plugins: [
+  {Jido.AI.Plugins.ToolCalling,
+   tools: [MyApp.Actions.Calculator, MyApp.Actions.Search],
+   auto_execute: true,
+   max_turns: 10}
+]
 ```
+
+The plugin stores tools in its state and supplies them to actions via context.
 
 ## Creating Tools
 
-All tools are `Jido.Action` modules. Use the standard Action pattern:
+Tools are normal `Jido.Action` modules:
 
 ```elixir
-defmodule MyApp.Tools.Calculator do
+defmodule MyApp.Actions.Calculator do
   use Jido.Action,
     name: "calculator",
-    description: "Performs basic arithmetic operations",
-    schema: [
-      a: [type: :number, required: true, doc: "First number"],
-      b: [type: :number, required: true, doc: "Second number"],
-      operation: [type: :string, default: "add", doc: "Operation: add, subtract, multiply, divide"]
-    ]
+    description: "Performs arithmetic",
+    schema:
+      Zoi.object(%{
+        a: Zoi.number(),
+        b: Zoi.number(),
+        operation: Zoi.string() |> Zoi.default("add")
+      })
 
   @impl true
-  def run(%{a: a, b: b, operation: op}, _context) do
-    result = case op do
-      "add" -> a + b
-      "subtract" -> a - b
-      "multiply" -> a * b
-      "divide" when b != 0 -> a / b
-      "divide" -> {:error, "Division by zero"}
-      _ -> {:error, "Unknown operation: #{op}"}
-    end
-
-    case result do
-      {:error, reason} -> {:error, reason}
-      value -> {:ok, %{result: value}}
-    end
-  end
+  def run(%{a: a, b: b, operation: "add"}, _context), do: {:ok, %{result: a + b}}
+  def run(%{a: a, b: b, operation: "subtract"}, _context), do: {:ok, %{result: a - b}}
+  def run(%{a: a, b: b, operation: "multiply"}, _context), do: {:ok, %{result: a * b}}
+  def run(%{a: _a, b: 0, operation: "divide"}, _context), do: {:error, "division by zero"}
+  def run(%{a: a, b: b, operation: "divide"}, _context), do: {:ok, %{result: a / b}}
+  def run(_params, _context), do: {:error, "unsupported operation"}
 end
 ```
 
-### Registering Tools
+## Best Practices
 
-```elixir
-# In application startup
-defmodule MyApp.Application do
-  def start(_type, _args) do
-    # Register tools
-    Jido.AI.Tools.Registry.register(MyApp.Tools.Calculator)
-    Jido.AI.Tools.Registry.register(MyApp.Tools.Search)
-
-    # ...
-  end
-end
-```
-
-## Tool Best Practices
-
-1. **Use descriptive names**: Clear, action-oriented tool names
-2. **Provide detailed descriptions**: Help LLMs understand when to use tools
-3. **Validate input**: Use schemas for parameter validation
-4. **Handle errors**: Return `{:error, reason}` for failures
-5. **Return structured results**: Use maps with clear field names
-
-## Next Steps
-
-- [Strategies Guide](02_strategies.md) - Using tools in strategies
-- [Directives Guide](04_directives.md) - ToolExec directive
-- [Skills Guide](07_skills.md) - ToolCalling skill
+1. Pass tools explicitly through context instead of relying on global mutable state.
+2. Keep schemas strict so argument normalization is predictable.
+3. Return structured results (`%{...}`) and explicit `{:error, reason}` tuples.
+4. Use `ListTools` with `allowed_tools` and `include_sensitive` in user-facing flows.
+5. Set execution timeouts on `Executor.execute/4` for external/network-bound tools.

--- a/guides/developer/08_configuration.md
+++ b/guides/developer/08_configuration.md
@@ -1,313 +1,87 @@
 # Configuration Guide
 
-This guide covers configuration in Jido.AI, including model aliases, provider setup, and environment variables.
-
-## Table of Contents
-
-- [Overview](#overview)
-- [Model Aliases](#model-aliases)
-- [Provider Configuration](#provider-configuration)
-- [Environment Variables](#environment-variables)
-- [Config Module](#config-module)
-- [Resolution](#resolution)
+This guide covers runtime configuration used by Jido.AI.
 
 ## Overview
 
-Jido.AI uses a configuration system based on ReqLLM for managing:
+There is no dedicated `Config` helper module in this project.
+Configuration is handled through:
 
-- **Model aliases**: Short names for specific models
-- **Provider settings**: API keys, base URLs, timeouts
-- **Environment-specific configs**: Development, test, production
+- `Jido.AI` functions (model alias resolution)
+- application config (`config :jido_ai, ...`)
+- ReqLLM provider config (`config :req_llm, ...`)
 
-### Configuration Architecture
+## Model Aliases (`:jido_ai`)
 
-```mermaid
-graph TB
-    Application[Application Config]
-    Environment[Environment Variables]
-    Config[Jido.AI.Config]
-
-    Application --> Config
-    Environment --> Config
-
-    Config --> Resolve[resolve_model/1]
-    Resolve --> Model[Model Spec]
-
-    Config --> Provider[get_provider/1]
-    Provider --> Settings[API Keys, URLs]
-```
-
-## Model Aliases
-
-Model aliases provide convenient shorthand for commonly used models.
-
-### Available Aliases
-
-| Alias | Default Model | Purpose |
-|-------|---------------|---------|
-| `:fast` | `anthropic:claude-haiku-4-5` | Fast, cost-effective operations |
-| `:capable` | `anthropic:claude-3-5-sonnet-20241022` | Capable general-purpose model |
-| `:reasoning` | `anthropic:claude-3-5-sonnet-20241022` | Complex reasoning tasks |
-| `:planning` | `anthropic:claude-3-5-sonnet-20241022` | Planning and decomposition |
-
-### Using Aliases
+Jido.AI resolves model aliases through `Jido.AI.resolve_model/1`.
 
 ```elixir
-# In strategies
-use Jido.Agent,
-  name: "my_agent",
-  strategy: {
-    Jido.AI.Strategies.ReAct,
-    model: :fast,  # Use alias instead of full model spec
-    tools: [Calculator]
-  }
-
-# In directives
-directive = Directive.LLMStream.new!(%{
-  id: "call_123",
-  model_alias: :fast,
-  context: context
-})
-
-# Programmatic resolution
-{:ok, model} = Jido.AI.Config.resolve_model(:fast)
-# => {:ok, "anthropic:claude-haiku-4-5"}
+Jido.AI.resolve_model(:fast)
+# => "anthropic:claude-haiku-4-5"
 ```
 
-## Provider Configuration
-
-### Supported Providers
-
-| Provider | Prefix | Models |
-|----------|--------|--------|
-| **Anthropic** | `anthropic:` | Claude 3.5, Haiku, Opus |
-| **OpenAI** | `openai:` | GPT-4, GPT-3.5 |
-| **Google** | `google:` | Gemini Pro |
-| **Mistral** | `mistral:` | Mistral Large, Mixtral |
-
-### Configuration Structure
-
-```elixir
-# config/dev.exs
-config :jido_ai, :providers,
-  anthropic: [
-    api_key: System.get_env("ANTHROPIC_API_KEY"),
-    base_url: "https://api.anthropic.com",
-    organization_id: nil
-  ],
-  openai: [
-    api_key: System.get_env("OPENAI_API_KEY"),
-    base_url: "https://api.openai.com/v1",
-    organization_id: nil
-  ]
-```
-
-### Provider Functions
-
-```elixir
-alias Jido.AI.Config
-
-# Get provider configuration
-{:ok, provider_config} = Config.get_provider(:anthropic)
-# => {:ok, %{api_key: "...", base_url: "...", ...}}
-
-# Get with defaults
-config = Config.get_provider!(:anthropic)
-```
-
-## Environment Variables
-
-### Required Variables
-
-```bash
-# Anthropic API Key (for Claude models)
-export ANTHROPIC_API_KEY="sk-ant-..."
-
-# OpenAI API Key (for GPT models)
-export OPENAI_API_KEY="sk-..."
-
-# Google API Key (for Gemini models)
-export GOOGLE_API_KEY="..."
-
-# Mistral API Key (for Mistral models)
-export MISTRAL_API_KEY="..."
-```
-
-### Optional Variables
-
-```bash
-# Custom base URLs (for proxy/testing)
-export ANTHROPIC_BASE_URL="https://api.anthropic.com"
-export OPENAI_BASE_URL="https://api.openai.com/v1"
-
-# Default model aliases (override defaults)
-export JIDO_FAST_MODEL="anthropic:claude-haiku-4-5"
-export JIDO_CAPABLE_MODEL="anthropic:claude-3-5-sonnet-20241022"
-```
-
-## Config Module
-
-The `Jido.AI.Config` module provides configuration utilities.
-
-### Model Resolution
-
-```elixir
-# Resolve model alias to full spec
-Config.resolve_model(:fast)
-# => {:ok, "anthropic:claude-haiku-4-5"}
-
-# Direct model spec passes through
-Config.resolve_model("anthropic:claude-3-5-sonnet-20241022")
-# => {:ok, "anthropic:claude-3-5-sonnet-20241022"}
-
-# Unknown alias falls back to default
-Config.resolve_model(:unknown)
-# => {:ok, "anthropic:claude-haiku-4-5"}
-```
-
-### Provider Configuration
-
-```elixir
-# Get provider config
-Config.get_provider(:anthropic)
-# => {:ok, %{api_key: "...", base_url: "...", organization_id: nil}}
-
-# Bang version (raises on error)
-config = Config.get_provider!(:anthropic)
-
-# Validate provider has required fields
-Config.validate_provider!(:anthropic)
-# => :ok | {:error, :missing_api_key}
-```
-
-### Model Aliases Configuration
-
-```elixir
-# In your config files
-config :jido_ai, :model_aliases,
-  fast: "anthropic:claude-haiku-4-5",
-  capable: "anthropic:claude-3-5-sonnet-20241022",
-  reasoning: "anthropic:claude-3-5-sonnet-20241022",
-  planning: "anthropic:claude-3-5-sonnet-20241022"
-```
-
-## Resolution
-
-### Resolution Order
-
-Model aliases are resolved in the following order:
-
-1. **Application config**: `config :jido_ai, :model_aliases`
-2. **Environment variables**: `JIDO_<ALIAS>_MODEL`
-3. **Default values**: Built-in defaults
-
-```mermaid
-graph TD
-    A[resolve_model/1] --> B{App Config?}
-    B -->|Yes| C[Use App Config]
-    B -->|No| D{Env Var?}
-    D -->|Yes| E[Use Env Var]
-    D -->|No| F[Use Default]
-```
-
-### In Directives
-
-```elixir
-# Directives support both model and model_alias
-directive = Directive.LLMStream.new!(%{
-  id: "call_123",
-  model_alias: :fast,  # Resolved at execution time
-  context: context
-})
-
-# Or use direct model
-directive = Directive.LLMStream.new!(%{
-  id: "call_123",
-  model: "anthropic:claude-haiku-4-5",  # Used directly
-  context: context
-})
-```
-
-### In Strategies
-
-```elixir
-# Strategies accept aliases
-use Jido.Agent,
-  name: "my_agent",
-  strategy: {
-    Jido.AI.Strategies.ReAct,
-    model: :fast,  # Alias
-    tools: [Calculator]
-  }
-
-# Or full model specs
-use Jido.Agent,
-  name: "my_agent",
-  strategy: {
-    Jido.AI.Strategies.ReAct,
-    model: "anthropic:claude-haiku-4-5",
-    tools: [Calculator]
-  }
-```
-
-## Full Configuration Example
+Set aliases in app config:
 
 ```elixir
 # config/config.exs
-import Config
-
-# Provider configuration
-config :jido_ai, :providers,
-  anthropic: [
-    api_key: System.get_env("ANTHROPIC_API_KEY"),
-    base_url: System.get_env("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
-  ],
-  openai: [
-    api_key: System.get_env("OPENAI_API_KEY"),
-    base_url: System.get_env("OPENAI_BASE_URL", "https://api.openai.com/v1")
-  ]
-
-# Custom model aliases
-config :jido_ai, :model_aliases,
-  fast: System.get_env("JIDO_FAST_MODEL", "anthropic:claude-haiku-4-5"),
-  capable: System.get_env("JIDO_CAPABLE_MODEL", "anthropic:claude-3-5-sonnet-20241022"),
-  reasoning: "anthropic:claude-3-5-sonnet-20241022",
-  planning: "anthropic:claude-3-5-sonnet-20241022",
-  # Custom aliases
-  embed: "openai:text-embedding-3-small"
+config :jido_ai,
+  model_aliases: %{
+    fast: "anthropic:claude-haiku-4-5",
+    capable: "anthropic:claude-sonnet-4-20250514",
+    reasoning: "anthropic:claude-sonnet-4-20250514",
+    planning: "anthropic:claude-sonnet-4-20250514"
+  }
 ```
 
-## Configuration Best Practices
+Resolution behavior:
 
-1. **Use aliases**: Prefer `:fast` over hardcoding model names
-2. **Environment variables**: Store API keys in environment, not code
-3. **Provider validation**: Validate provider config at startup
-4. **Fallback models**: Always have a fallback for missing config
-5. **Per-environment configs**: Different models for dev/test/prod
+1. Built-in defaults are defined in `Jido.AI`.
+2. `config :jido_ai, model_aliases: %{...}` overrides/extends defaults.
+3. Unknown aliases raise `ArgumentError`.
+
+## Provider Credentials (`:req_llm`)
+
+Provider keys are consumed by ReqLLM.
 
 ```elixir
-# Good: Use alias
-model: :fast
-
-# Avoid: Hardcode model
-model: "anthropic:claude-haiku-4-5-20250119"
+# config/runtime.exs (or config/config.exs)
+config :req_llm,
+  anthropic_api_key: System.get_env("ANTHROPIC_API_KEY"),
+  openai_api_key: System.get_env("OPENAI_API_KEY"),
+  google_api_key: System.get_env("GOOGLE_API_KEY"),
+  mistral_api_key: System.get_env("MISTRAL_API_KEY")
 ```
 
-## Testing Configuration
+You can also rely on environment variables directly (ReqLLM supports both).
 
-For tests, you can mock configurations:
+## Optional Jido.AI Runtime Keys
 
 ```elixir
-# config/test.exs
-config :jido_ai, :model_aliases,
-  fast: "mock:model",
-  capable: "mock:model"
-
-# Or use environment variables in test helper
-System.put_env("ANTHROPIC_API_KEY", "test-key")
+config :jido_ai,
+  llm_client: MyApp.CustomLLMClient
 ```
 
-## Next Steps
+- `:llm_client` lets you swap the client module used by `Jido.AI.LLMClient`.
+- The module should implement the callbacks expected by `Jido.AI.LLMClient`.
 
-- [Strategies Guide](./02_strategies.md) - Using model configuration in strategies
-- [Directives Guide](./04_directives.md) - Model resolution in directives
+## Usage in Strategies and Actions
+
+```elixir
+use Jido.AI.ReActAgent,
+  name: "my_agent",
+  model: :fast,
+  tools: [MyApp.Actions.Calculator]
+```
+
+Aliases can also be used in directives/actions that accept `model_alias` or `model`.
+
+## Validation Tip
+
+Run a quick sanity check in `iex -S mix`:
+
+```elixir
+Jido.AI.model_aliases()
+Jido.AI.resolve_model(:fast)
+```
+
+If alias resolution works and ReqLLM keys are present, LLM actions are ready to run.

--- a/lib/jido_ai/actions/tool_calling/list_tools.ex
+++ b/lib/jido_ai/actions/tool_calling/list_tools.ex
@@ -2,8 +2,8 @@ defmodule Jido.AI.Actions.ToolCalling.ListTools do
   @moduledoc """
   A Jido.Action for listing all available tools with their schemas.
 
-  This action queries the `Jido.AI.Tools.Registry` and returns information
-  about all registered Action modules, including their names and schemas.
+  This action reads tools from action context (`context[:tools]`) and returns
+  information about available Action modules, including their names and schemas.
 
   ## Parameters
 

--- a/lib/jido_ai/directive.ex
+++ b/lib/jido_ai/directive.ex
@@ -105,10 +105,10 @@ defmodule Jido.AI.Directive do
 
     1. **Direct module execution** (preferred): When `action_module` is provided,
        the module is executed directly via `Executor.execute_module/4`, bypassing
-       Registry lookup. This is used by strategies that maintain their own tool lists.
+       name-based lookup. This is used by strategies that maintain their own tool lists.
 
-    2. **Registry lookup**: When `action_module` is nil, looks up the action in
-       `Jido.AI.Tools.Registry` by name and executes via `Jido.AI.Executor`.
+    2. **Name lookup**: When `action_module` is nil, runtime resolves the tool name
+       against the current strategy/plugin tool map and executes via `Jido.AI.Executor`.
 
     ## Argument Normalization
 
@@ -126,9 +126,11 @@ defmodule Jido.AI.Directive do
               %{
                 id: Zoi.string(description: "Tool call ID from LLM (ReqLLM.ToolCall.id)"),
                 tool_name:
-                  Zoi.string(description: "Name of the tool (used for Registry lookup if action_module not provided)"),
+                  Zoi.string(
+                    description: "Name of the tool (resolved from runtime tool map if action_module not provided)"
+                  ),
                 action_module:
-                  Zoi.atom(description: "Module to execute directly (bypasses Registry lookup)")
+                  Zoi.atom(description: "Module to execute directly (bypasses name lookup)")
                   |> Zoi.optional(),
                 arguments:
                   Zoi.map(description: "Arguments from LLM (string keys, normalized before exec)")

--- a/lib/jido_ai/plugins/tool_calling.ex
+++ b/lib/jido_ai/plugins/tool_calling.ex
@@ -46,12 +46,10 @@ defmodule Jido.AI.Plugins.ToolCalling do
       # List available tools
       {:ok, result} = Jido.Exec.run(Jido.AI.Actions.ToolCalling.ListTools, %{})
 
-  ## Tool Registry
+  ## Tool Source
 
-  Tools are managed through `Jido.AI.Tools.Registry`:
-
-  - **Actions** - Jido.Action modules registered as tools
-  - All actions are executed via `Jido.Exec.run/3` for consistent validation
+  Tools are supplied through plugin configuration (`tools:`) and stored in plugin state.
+  The plugin passes these tool modules through action context for discovery/execution.
 
   ## Auto-Execution
 
@@ -74,7 +72,7 @@ defmodule Jido.AI.Plugins.ToolCalling do
   **Direct ReqLLM Calls**: Calls `ReqLLM.Generation.generate_text/3` with
   `tools:` option directly, following the core design principle of Jido.AI.
 
-  **Registry Integration**: Uses `Jido.AI.Tools.Registry` for tool discovery
+  **Tool Integration**: Uses context-provided tool maps for discovery
   and `Jido.AI.Executor` for execution.
 
   **Tool Format**: Tools are converted to ReqLLM format via

--- a/lib/mix/tasks/docs.check.ex
+++ b/lib/mix/tasks/docs.check.ex
@@ -1,0 +1,127 @@
+defmodule Mix.Tasks.Docs.Check do
+  @moduledoc false
+  use Mix.Task
+
+  @shortdoc "Checks markdown docs for stale Jido.AI module references and deprecated config keys"
+
+  @module_ref_regex ~r/\bJido\.AI(?:\.[A-Z][A-Za-z0-9_]*)+\b/
+  @deprecated_config_regex ~r/config\s+:jido_ai,\s*:models\b/
+
+  @doc_globs [
+    "README.md",
+    "usage-rules.md",
+    "guides/**/*.md",
+    "examples/**/*.md"
+  ]
+
+  @impl Mix.Task
+  def run(_args) do
+    files = docs_files()
+    invalid_refs = invalid_module_refs(files)
+    deprecated_configs = deprecated_config_refs(files)
+
+    if invalid_refs == [] and deprecated_configs == [] do
+      Mix.shell().info("Documentation reference check passed.")
+      :ok
+    else
+      print_invalid_refs(invalid_refs)
+      print_deprecated_configs(deprecated_configs)
+
+      Mix.raise("""
+      Documentation reference check failed.
+      Fix stale module references and deprecated config keys in markdown docs.
+      """)
+    end
+  end
+
+  defp docs_files do
+    @doc_globs
+    |> Enum.flat_map(&Path.wildcard/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp invalid_module_refs(files) do
+    Enum.flat_map(files, &invalid_module_refs_in_file/1)
+  end
+
+  defp invalid_module_refs_in_file(file) do
+    file
+    |> File.stream!()
+    |> Stream.with_index(1)
+    |> Enum.flat_map(fn {line, line_number} ->
+      line
+      |> extract_module_refs()
+      |> Enum.reject(&module_ref_valid?/1)
+      |> Enum.map(fn module_ref ->
+        %{file: file, line: line_number, module_ref: module_ref}
+      end)
+    end)
+  end
+
+  defp extract_module_refs(line) do
+    @module_ref_regex
+    |> Regex.scan(line)
+    |> List.flatten()
+    |> Enum.uniq()
+  end
+
+  defp module_exists?(module_ref) when is_binary(module_ref) do
+    module_ref
+    |> String.split(".")
+    |> Module.concat()
+    |> Code.ensure_loaded?()
+  end
+
+  defp module_ref_valid?(module_ref) do
+    module_exists?(module_ref) or namespace_ref?(module_ref)
+  end
+
+  defp namespace_ref?(module_ref) do
+    prefix = "Elixir." <> module_ref <> "."
+
+    (Application.spec(:jido_ai, :modules) || [])
+    |> Enum.any?(fn module ->
+      module
+      |> Atom.to_string()
+      |> String.starts_with?(prefix)
+    end)
+  end
+
+  defp deprecated_config_refs(files) do
+    Enum.flat_map(files, &deprecated_config_refs_in_file/1)
+  end
+
+  defp deprecated_config_refs_in_file(file) do
+    file
+    |> File.stream!()
+    |> Stream.with_index(1)
+    |> Enum.flat_map(fn {line, line_number} ->
+      if Regex.match?(@deprecated_config_regex, line) do
+        [%{file: file, line: line_number, snippet: String.trim(line)}]
+      else
+        []
+      end
+    end)
+  end
+
+  defp print_invalid_refs([]), do: :ok
+
+  defp print_invalid_refs(refs) do
+    Mix.shell().error("Invalid Jido.AI module references found:")
+
+    Enum.each(refs, fn %{file: file, line: line, module_ref: module_ref} ->
+      Mix.shell().error("  #{file}:#{line} -> #{module_ref}")
+    end)
+  end
+
+  defp print_deprecated_configs([]), do: :ok
+
+  defp print_deprecated_configs(refs) do
+    Mix.shell().error("Deprecated config key `config :jido_ai, :models` found:")
+
+    Enum.each(refs, fn %{file: file, line: line, snippet: snippet} ->
+      Mix.shell().error("  #{file}:#{line} -> #{snippet}")
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -94,6 +94,7 @@ defmodule JidoAi.MixProject do
       quality: [
         "format --check-formatted",
         "compile --warnings-as-errors",
+        "docs.check",
         "credo --min-priority higher",
         "dialyzer"
       ],


### PR DESCRIPTION
## Summary
- update README and developer guides to reflect current public APIs (`Jido.AI`, `Executor`, tool-calling actions/plugins)
- remove stale references to non-existent modules and deprecated config key usage (`config :jido_ai, :models`)
- add `mix docs.check` and wire it into `mix quality` to fail on doc/API drift

## Testing
- `mix docs.check`
- `mix test test/jido_ai/skills/tool_calling/tool_calling_skill_test.exs`

Closes #141
