### PR TITLE
docs(request): align await options with implementation

### DIFF
--- a/lib/jido_ai/request.ex
+++ b/lib/jido_ai/request.ex
@@ -235,8 +235,9 @@ defmodule Jido.AI.Request do
   ## Options
 
   - `:timeout` - How long to wait (default: 30_000ms)
-  - `:status_path` - Path to status in agent state (default: `[:requests, request_id, :status]`)
-  - `:result_path` - Path to result in agent state (default: `[:requests, request_id, :result]`)
+
+  `Request.await/2` always uses the internal request paths under
+  `state.requests[request_id]` for status, result, and error tracking.
 
   ## Returns
 


### PR DESCRIPTION
## Summary
- update `Jido.AI.Request.await/2` docs to remove unsupported `:status_path` and `:result_path` options
- clarify that await always uses internal request tracking paths under `state.requests[request_id]`

## Testing
- `mix test test/jido_ai/request_test.exs`

Closes #144
