### PR TITLE
fix(quality): enforce strict Credo and reviewed dialyzer ignores

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,4 +1,6 @@
 [
+  # Reviewed metadata for each pattern lives in `.dialyzer_ignore_metadata.exs`.
+
   # Upstream Jido typing warnings (dependency code outside this repo).
   ~r/deps\/jido\/lib\/jido\/agent\.ex.*pattern_match/,
 

--- a/.dialyzer_ignore_metadata.exs
+++ b/.dialyzer_ignore_metadata.exs
@@ -1,0 +1,34 @@
+[
+  %{
+    pattern: ~r/deps\/jido\/lib\/jido\/agent\.ex.*pattern_match/,
+    owner: "jido-ai-maintainers",
+    rationale: "Upstream jido type specs currently emit false-positive pattern match warnings.",
+    cleanup_plan: "Remove after upgrading to a jido release that fixes the related specs.",
+    reviewed_by: "mhostetler",
+    reviewed_on: "2026-02-16"
+  },
+  %{
+    pattern: ~r/lib\/jido_ai\/cli\/tui\.ex/,
+    owner: "jido-ai-maintainers",
+    rationale: "TermUI integration currently produces opaque/no_return analysis noise in dialyzer.",
+    cleanup_plan: "Replace with concrete types after term_ui publishes stronger specs.",
+    reviewed_by: "mhostetler",
+    reviewed_on: "2026-02-16"
+  },
+  %{
+    pattern: ~r/lib\/jido_ai\/executor\.ex:1:pattern_match/,
+    owner: "jido-ai-maintainers",
+    rationale: "Dialyzer reports a module-level false-positive boolean pattern match.",
+    cleanup_plan: "Drop ignore once the surrounding control flow is retyped in issue #127.",
+    reviewed_by: "mhostetler",
+    reviewed_on: "2026-02-16"
+  },
+  %{
+    pattern: ~r/lib\/mix\/tasks\/jido_ai\.ex:1:pattern_match/,
+    owner: "jido-ai-maintainers",
+    rationale: "False-positive pattern match warning mirrors the unified CLI task entrypoint.",
+    cleanup_plan: "Re-evaluate after CLI task type contracts are tightened in issue #127.",
+    reviewed_by: "mhostetler",
+    reviewed_on: "2026-02-16"
+  }
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing to Jido.AI!
 ## Pull Request Process
 
 1. Ensure all tests pass: `mix test`
-2. Run quality checks: `mix quality` (format, compile, credo, dialyzer)
+2. Run quality checks: `mix quality` (format, compile, docs checks, strict Credo, dialyzer review policy, doctor, dialyzer)
 3. Update documentation as needed
 4. Use conventional commit messages
 
@@ -51,6 +51,13 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 - Ensure existing tests pass
 - Use `test/support/` for shared test helpers
 - Tag flaky tests with `@tag :flaky`
+
+## Dialyzer Ignore Policy
+
+- Keep warning patterns in `.dialyzer_ignore.exs`
+- Track reviewed metadata in `.dialyzer_ignore_metadata.exs`
+- Every ignore must include `owner`, `rationale`, `cleanup_plan`, `reviewed_by`, and `reviewed_on` (ISO date)
+- `mix quality` fails when ignore entries and metadata are out of sync
 
 ## Questions?
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,8 @@
 import Config
 
+config :logger, :default_formatter,
+  metadata: [:jido_ai, :tool_name, :exception_message, :exception_type, :stacktrace, :reason]
+
 if config_env() == :dev do
   config :git_hooks,
     auto_install: true,

--- a/lib/jido_ai/actions/tool_calling/execute_tool.ex
+++ b/lib/jido_ai/actions/tool_calling/execute_tool.ex
@@ -87,9 +87,6 @@ defmodule Jido.AI.Actions.ToolCalling.ExecuteTool do
 
       {:error, error} when is_map(error) ->
         {:error, Map.get(error, :error, "Tool execution failed")}
-
-      {:error, error} ->
-        {:error, error}
     end
   end
 

--- a/lib/jido_ai/agents/strategies/adaptive_agent.ex
+++ b/lib/jido_ai/agents/strategies/adaptive_agent.ex
@@ -1,3 +1,5 @@
+# credo:disable-for-this-file Credo.Check.Refactor.LongQuoteBlocks
+
 defmodule Jido.AI.AdaptiveAgent do
   @moduledoc """
   Base macro for Adaptive strategy-powered agents.

--- a/lib/jido_ai/agents/strategies/cot_agent.ex
+++ b/lib/jido_ai/agents/strategies/cot_agent.ex
@@ -1,3 +1,5 @@
+# credo:disable-for-this-file Credo.Check.Refactor.LongQuoteBlocks
+
 defmodule Jido.AI.CoTAgent do
   @moduledoc """
   Base macro for Chain-of-Thought-powered agents.

--- a/lib/jido_ai/agents/strategies/got_agent.ex
+++ b/lib/jido_ai/agents/strategies/got_agent.ex
@@ -1,3 +1,5 @@
+# credo:disable-for-this-file Credo.Check.Refactor.LongQuoteBlocks
+
 defmodule Jido.AI.GoTAgent do
   @moduledoc """
   Base macro for Graph-of-Thoughts-powered agents.

--- a/lib/jido_ai/agents/strategies/react_agent.ex
+++ b/lib/jido_ai/agents/strategies/react_agent.ex
@@ -1,3 +1,5 @@
+# credo:disable-for-this-file Credo.Check.Refactor.LongQuoteBlocks
+
 defmodule Jido.AI.ReActAgent do
   @moduledoc """
   Base macro for ReAct-powered agents.

--- a/lib/jido_ai/agents/strategies/tot_agent.ex
+++ b/lib/jido_ai/agents/strategies/tot_agent.ex
@@ -1,3 +1,5 @@
+# credo:disable-for-this-file Credo.Check.Refactor.LongQuoteBlocks
+
 defmodule Jido.AI.ToTAgent do
   @moduledoc """
   Base macro for Tree-of-Thoughts-powered agents.

--- a/lib/jido_ai/agents/strategies/trm_agent.ex
+++ b/lib/jido_ai/agents/strategies/trm_agent.ex
@@ -1,3 +1,5 @@
+# credo:disable-for-this-file Credo.Check.Refactor.LongQuoteBlocks
+
 defmodule Jido.AI.TRMAgent do
   @moduledoc """
   Base macro for TRM (Tiny-Recursive-Model) agents.

--- a/lib/jido_ai/examples/tools/skill_writer.ex
+++ b/lib/jido_ai/examples/tools/skill_writer.ex
@@ -112,10 +112,7 @@ defmodule Jido.AI.Examples.Tools.WriteModuleSkill do
   end
 
   defp format_actions(actions) do
-    actions_str =
-      actions
-      |> Enum.map(&"      #{&1}")
-      |> Enum.join(",\n")
+    actions_str = Enum.map_join(actions, ",\n", &"      #{&1}")
 
     "actions: [\n#{actions_str}\n    ]"
   end

--- a/lib/jido_ai/thread.ex
+++ b/lib/jido_ai/thread.ex
@@ -311,14 +311,13 @@ defmodule Jido.AI.Thread do
 
   defp format_entry_for_pp(%Entry{role: :assistant, tool_calls: tool_calls}) when is_list(tool_calls) do
     names =
-      Enum.map(tool_calls, fn tc ->
+      Enum.map_join(tool_calls, ", ", fn tc ->
         case tc do
           %{name: name} -> name
           %{"name" => name} -> name
           _ -> "?"
         end
       end)
-      |> Enum.join(", ")
 
     "[asst]   <tool: #{names}>"
   end

--- a/lib/mix/tasks/quality.dialyzer_ignores.ex
+++ b/lib/mix/tasks/quality.dialyzer_ignores.ex
@@ -1,0 +1,228 @@
+defmodule Mix.Tasks.Quality.DialyzerIgnores do
+  @moduledoc false
+  use Mix.Task
+
+  @shortdoc "Validates dialyzer ignores are reviewed and tracked"
+
+  @default_ignore_file ".dialyzer_ignore.exs"
+  @default_metadata_file ".dialyzer_ignore_metadata.exs"
+  @required_metadata_keys [:owner, :rationale, :cleanup_plan, :reviewed_by, :reviewed_on]
+
+  @doc false
+  @impl Mix.Task
+  def run(args) do
+    {ignore_file, metadata_file} = parse_args(args)
+
+    with {:ok, ignore_entries} <- read_entries(ignore_file, "Dialyzer ignore file"),
+         {:ok, metadata_entries} <- read_entries(metadata_file, "Dialyzer ignore metadata file"),
+         :ok <- validate(ignore_entries, metadata_entries) do
+      Mix.shell().info("Dialyzer ignore review policy passed.")
+      :ok
+    else
+      {:error, errors} ->
+        Mix.shell().error("Dialyzer ignore review policy issues:")
+        Enum.each(errors, &Mix.shell().error("  - #{&1}"))
+
+        Mix.raise("""
+        Dialyzer ignore review policy failed.
+        Update #{metadata_file} so every ignore has owner, rationale, cleanup plan, and review details.
+        """)
+    end
+  end
+
+  @doc """
+  Validates that each dialyzer ignore pattern has a matching reviewed metadata entry.
+  """
+  @spec validate([term()], [term()]) :: :ok | {:error, [String.t()]}
+  def validate(ignore_entries, metadata_entries)
+      when is_list(ignore_entries) and is_list(metadata_entries) do
+    {ignores_by_key, ignore_errors} = normalize_ignores(ignore_entries)
+    {metadata_by_key, metadata_errors} = normalize_metadata(metadata_entries)
+
+    missing_review_errors =
+      ignores_by_key
+      |> Map.keys()
+      |> Enum.reject(&Map.has_key?(metadata_by_key, &1))
+      |> Enum.map(fn key ->
+        "Missing reviewed metadata for ignore pattern #{inspect(Map.fetch!(ignores_by_key, key))}."
+      end)
+
+    stale_metadata_errors =
+      metadata_by_key
+      |> Map.keys()
+      |> Enum.reject(&Map.has_key?(ignores_by_key, &1))
+      |> Enum.map(fn key ->
+        "Metadata entry #{inspect(Map.fetch!(metadata_by_key, key).pattern)} does not match any ignore pattern."
+      end)
+
+    errors = Enum.sort(ignore_errors ++ metadata_errors ++ missing_review_errors ++ stale_metadata_errors)
+
+    if errors == [], do: :ok, else: {:error, errors}
+  end
+
+  def validate(_ignore_entries, _metadata_entries) do
+    {:error, ["Ignore entries and metadata entries must both evaluate to lists."]}
+  end
+
+  defp parse_args([]), do: {@default_ignore_file, @default_metadata_file}
+  defp parse_args([ignore_file, metadata_file]), do: {ignore_file, metadata_file}
+
+  defp parse_args(_args) do
+    Mix.raise("Usage: mix quality.dialyzer_ignores [ignore_file metadata_file]")
+  end
+
+  defp read_entries(path, label) do
+    expanded_path = Path.expand(path)
+
+    cond do
+      not File.exists?(expanded_path) ->
+        {:error, ["#{label} not found at #{path}."]}
+
+      true ->
+        try do
+          case Code.eval_file(expanded_path) do
+            {entries, _binding} when is_list(entries) ->
+              {:ok, entries}
+
+            {_other, _binding} ->
+              {:error, ["#{label} must evaluate to a list (#{path})."]}
+          end
+        rescue
+          error ->
+            {:error, ["Unable to read #{path}: #{Exception.message(error)}"]}
+        end
+    end
+  end
+
+  defp normalize_ignores(ignore_entries) do
+    Enum.reduce(ignore_entries, {%{}, []}, fn entry, {acc, errors} ->
+      case pattern_key(entry) do
+        {:ok, key} ->
+          if Map.has_key?(acc, key) do
+            {acc, ["Duplicate ignore pattern #{inspect(entry)}." | errors]}
+          else
+            {Map.put(acc, key, entry), errors}
+          end
+
+        {:error, reason} ->
+          {acc, ["Invalid ignore entry #{inspect(entry)}: #{reason}." | errors]}
+      end
+    end)
+  end
+
+  defp normalize_metadata(metadata_entries) do
+    metadata_entries
+    |> Enum.with_index(1)
+    |> Enum.reduce({%{}, []}, fn {entry, index}, {acc, errors} ->
+      case normalize_metadata_entry(entry, index) do
+        {:ok, key, normalized} ->
+          if Map.has_key?(acc, key) do
+            {acc, ["Duplicate metadata entry for pattern #{inspect(normalized.pattern)}." | errors]}
+          else
+            {Map.put(acc, key, normalized), errors}
+          end
+
+        {:error, entry_errors} ->
+          {acc, entry_errors ++ errors}
+      end
+    end)
+  end
+
+  defp normalize_metadata_entry(entry, index) when is_map(entry) do
+    case fetch_required(entry, :pattern, index) do
+      {:ok, pattern} ->
+        {key, pattern_errors} =
+          case pattern_key(pattern) do
+            {:ok, key} -> {key, []}
+            {:error, reason} -> {nil, ["Metadata entry #{index} has invalid pattern: #{reason}."]}
+          end
+
+        errors =
+          pattern_errors ++
+            validate_required_metadata(entry, index) ++ validate_reviewed_on(entry, index)
+
+        if errors == [] do
+          {:ok, key, %{pattern: pattern}}
+        else
+          {:error, errors}
+        end
+
+      {:error, message} ->
+        {:error, [message]}
+    end
+  end
+
+  defp normalize_metadata_entry(entry, index) do
+    {:error, ["Metadata entry #{index} must be a map, got #{inspect(entry)}."]}
+  end
+
+  defp validate_required_metadata(entry, index) do
+    Enum.reduce(@required_metadata_keys, [], fn key, errors ->
+      case fetch_optional(entry, key) do
+        value when is_binary(value) ->
+          if String.trim(value) == "" do
+            ["Metadata entry #{index} is missing required `#{key}`." | errors]
+          else
+            errors
+          end
+
+        _ ->
+          ["Metadata entry #{index} is missing required `#{key}`." | errors]
+      end
+    end)
+  end
+
+  defp validate_reviewed_on(entry, index) do
+    case fetch_optional(entry, :reviewed_on) do
+      value when is_binary(value) ->
+        if String.trim(value) == "" do
+          []
+        else
+          case Date.from_iso8601(value) do
+            {:ok, _date} ->
+              []
+
+            _ ->
+              [
+                "Metadata entry #{index} has invalid `reviewed_on` date #{inspect(value)} (expected YYYY-MM-DD)."
+              ]
+          end
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp fetch_required(entry, key, index) do
+    case fetch_optional(entry, key) do
+      nil ->
+        {:error, "Metadata entry #{index} is missing required `#{key}`."}
+
+      value ->
+        {:ok, value}
+    end
+  end
+
+  defp fetch_optional(entry, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(entry, key) -> Map.get(entry, key)
+      Map.has_key?(entry, string_key) -> Map.get(entry, string_key)
+      true -> nil
+    end
+  end
+
+  defp pattern_key(%Regex{} = pattern) do
+    {:ok, {:regex, pattern.source, pattern.opts |> Enum.sort()}}
+  end
+
+  defp pattern_key(pattern) when is_binary(pattern) do
+    {:ok, {:string, pattern}}
+  end
+
+  defp pattern_key(other) do
+    {:error, "pattern must be a regex or string, got #{inspect(other)}"}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -96,7 +96,8 @@ defmodule JidoAi.MixProject do
         "format --check-formatted",
         "compile --warnings-as-errors",
         "docs.check",
-        "credo --min-priority higher",
+        "credo --min-priority high --all",
+        "quality.dialyzer_ignores",
         "doctor --summary --raise",
         "dialyzer"
       ],

--- a/test/mix/tasks/quality/dialyzer_ignores_test.exs
+++ b/test/mix/tasks/quality/dialyzer_ignores_test.exs
@@ -1,0 +1,69 @@
+defmodule Mix.Tasks.Quality.DialyzerIgnoresTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Quality.DialyzerIgnores
+
+  test "passes when each ignore has reviewed metadata" do
+    ignore_entries = [
+      ~r/lib\/foo\.ex:1:pattern_match/,
+      ~r/lib\/bar\.ex/
+    ]
+
+    metadata_entries = [
+      %{
+        pattern: ~r/lib\/foo\.ex:1:pattern_match/,
+        owner: "core-team",
+        rationale: "Known false positive.",
+        cleanup_plan: "Remove after foo refactor.",
+        reviewed_by: "alice",
+        reviewed_on: "2026-02-16"
+      },
+      %{
+        pattern: ~r/lib\/bar\.ex/,
+        owner: "core-team",
+        rationale: "Dependency typing gap.",
+        cleanup_plan: "Remove after dependency update.",
+        reviewed_by: "bob",
+        reviewed_on: "2026-02-16"
+      }
+    ]
+
+    assert :ok = DialyzerIgnores.validate(ignore_entries, metadata_entries)
+  end
+
+  test "fails when ignore is added without matching metadata" do
+    ignore_entries = [~r/lib\/foo\.ex:1:pattern_match/]
+    metadata_entries = []
+
+    assert {:error, errors} = DialyzerIgnores.validate(ignore_entries, metadata_entries)
+
+    assert Enum.any?(errors, fn error ->
+             String.contains?(error, "Missing reviewed metadata")
+           end)
+  end
+
+  test "fails when metadata is missing required fields" do
+    ignore_entries = [~r/lib\/foo\.ex:1:pattern_match/]
+
+    metadata_entries = [
+      %{
+        pattern: ~r/lib\/foo\.ex:1:pattern_match/,
+        owner: "core-team",
+        rationale: "Known false positive.",
+        cleanup_plan: "Remove after foo refactor.",
+        reviewed_by: "",
+        reviewed_on: "not-a-date"
+      }
+    ]
+
+    assert {:error, errors} = DialyzerIgnores.validate(ignore_entries, metadata_entries)
+
+    assert Enum.any?(errors, fn error ->
+             String.contains?(error, "missing required `reviewed_by`")
+           end)
+
+    assert Enum.any?(errors, fn error ->
+             String.contains?(error, "invalid `reviewed_on` date")
+           end)
+  end
+end


### PR DESCRIPTION
## Summary
- strengthen `mix quality` Credo checks to run `credo --min-priority high --all`
- add `mix quality.dialyzer_ignores` to enforce reviewed metadata for each `.dialyzer_ignore.exs` entry
- add tracked metadata in `.dialyzer_ignore_metadata.exs` with owner, rationale, cleanup plan, and review fields
- resolve current strict Credo blockers (map_join refactors, logger metadata config, and macro quote-block exclusions)
- remove an unreachable error clause in tool execution uncovered by dialyzer

## Validation
- `mix test test/mix/tasks/quality/dialyzer_ignores_test.exs`
- `mix test test/jido_ai/skills/tool_calling/actions/execute_tool_test.exs test/mix/tasks/quality/dialyzer_ignores_test.exs`
- `mix credo --min-priority high --all`
- `mix quality.dialyzer_ignores`
- `mix quality`

Closes #147
