### PR TITLE
chore: add CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@main
+
+  test:
+    name: Test
+    uses: agentjido/github-actions/.github/workflows/elixir-test.yml@main
+    with:
+      otp_versions: '["27", "28"]'
+      elixir_versions: '["1.18", "1.19"]'
+      test_command: mix test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (no git push, no tag, no GitHub release, no Hex publish)"
+        required: false
+        type: boolean
+        default: false
+      hex_dry_run:
+        description: "Hex dry run only (run all git/release steps, but skip actual Hex publish)"
+        required: false
+        type: boolean
+        default: false
+      skip_tests:
+        description: "Skip tests before release"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    uses: agentjido/github-actions/.github/workflows/elixir-release.yml@main
+    with:
+      dry_run: ${{ inputs.dry_run }}
+      hex_dry_run: ${{ inputs.hex_dry_run }}
+      skip_tests: ${{ inputs.skip_tests }}
+    secrets: inherit


### PR DESCRIPTION
## What changed

- **CI workflow**: Added canonical CI workflow using shared reusable workflows from `agentjido/github-actions`. Runs lint and test jobs against OTP 27+28 and Elixir 1.18+1.19.
- **Release workflow**: Added `workflow_dispatch`-based release workflow using the shared `elixir-release` workflow with dry-run options.

## Why

This repo had no CI or release workflows. Adding the standardized shared workflows ensures consistent CI/release infrastructure across all Jido repos.