### PR TITLE
 docs: add action description to AddNumbers examples in README and first_react_agent guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Build tool-using Elixir agents with explicit reasoning strategies and production
 defmodule MyApp.Actions.AddNumbers do
   use Jido.Action,
     name: "add_numbers",
-    schema: Zoi.object(%{a: Zoi.integer(), b: Zoi.integer()})
+    schema: Zoi.object(%{a: Zoi.integer(), b: Zoi.integer()}),
+    description: "Add two numbers."
 
   @impl true
   def run(%{a: a, b: b}, _context), do: {:ok, %{sum: a + b}}
@@ -42,7 +43,7 @@ end
 - [jido_action](https://hex.pm/packages/jido_action): typed tool/action contract used by `jido_ai`
 - [req_llm](https://hex.pm/packages/req_llm): provider abstraction for Anthropic, OpenAI, Google, and others
 
-Use `jido_ai` when you need long-lived agents, tool-calling loops, or explicit reasoning strategies. You can also use it without a running agent process via `Jido.AI.generate_text/2`, `Jido.AI.ask/2`, or `Jido.Exec.run/3` with any action module.  
+Use `jido_ai` when you need long-lived agents, tool-calling loops, or explicit reasoning strategies. You can also use it without a running agent process via `Jido.AI.generate_text/2`, `Jido.AI.ask/2`, or `Jido.Exec.run/3` with any action module.
 For cross-package tutorials (for example `jido` + `jido_ai` + app packages), see [agentjido.xyz](https://agentjido.xyz).
 
 ## Installation

--- a/guides/user/first_react_agent.md
+++ b/guides/user/first_react_agent.md
@@ -10,7 +10,8 @@ After this guide, you will run a custom tool, submit async requests, and await s
 defmodule MyApp.Actions.AddNumbers do
   use Jido.Action,
     name: "add_numbers",
-    schema: Zoi.object(%{a: Zoi.integer(), b: Zoi.integer()})
+    schema: Zoi.object(%{a: Zoi.integer(), b: Zoi.integer()}),
+    description: "Add two numbers."
 
   @impl true
   def run(%{a: a, b: b}, _context), do: {:ok, %{sum: a + b}}


### PR DESCRIPTION
## Summary
This PR updates documentation examples to include `description` in `Jido.Action` definitions.

## Changes
- Added `description: "Add two numbers."` to `AddNumbers` example in `README.md`
- Added `description: "Add two numbers."` to `AddNumbers` example in `guides/user/first_react_agent.md`
- Removed trailing whitespace in `README.md`

## Why
Keeps docs aligned with current recommended action definitions and improves clarity for users following the examples.

## Testing
- Docs-only change
- No runtime behavior changes