### PR TITLE
Preserve assistant metadata and reasoning details in Jido.AI.Turn

### DIFF
--- a/lib/jido_ai/turn.ex
+++ b/lib/jido_ai/turn.ex
@@ -84,8 +84,7 @@ defmodule Jido.AI.Turn do
       usage: normalize_usage(ReqLLM.Response.usage(response)),
       model: Keyword.get(opts, :model, response.model),
       metadata: normalize_metadata(response.message && response.message.metadata),
-      reasoning_details:
-        normalize_reasoning_details(response.message && response.message.reasoning_details),
+      reasoning_details: normalize_reasoning_details(response.message && response.message.reasoning_details),
       tool_results: []
     }
   end
@@ -123,7 +122,7 @@ defmodule Jido.AI.Turn do
       tool_calls: map |> get_field(:tool_calls, []) |> normalize_tool_calls(),
       usage: normalize_usage(get_field(map, :usage)),
       model: normalize_optional_string(get_field(map, :model)),
-      metadata: normalize_metadata(get_field(map, :metadata, %{})),
+      metadata: normalize_metadata(get_field(map, :metadata, get_field(map, :message_metadata, %{}))),
       reasoning_details: normalize_reasoning_details(get_field(map, :reasoning_details)),
       tool_results: map |> get_field(:tool_results, []) |> normalize_tool_results()
     }
@@ -140,34 +139,23 @@ defmodule Jido.AI.Turn do
   @doc """
   Projects the turn into an assistant message compatible with ReqLLM context.
   """
-  @spec assistant_message(t()) :: map()
+  @spec assistant_message(t()) :: ReqLLM.Message.t()
   def assistant_message(%__MODULE__{type: :tool_calls} = turn) do
-    %{
-      role: :assistant,
-      content: turn.text,
-      tool_calls: turn.tool_calls,
-      metadata: turn.metadata,
-      reasoning_details: turn.reasoning_details
-    }
+    turn.text
+    |> Context.assistant(tool_calls: turn.tool_calls, metadata: turn.metadata)
+    |> put_reasoning_details(turn.reasoning_details)
   end
 
   def assistant_message(%__MODULE__{tool_calls: tool_calls} = turn) when is_list(tool_calls) and tool_calls != [] do
-    %{
-      role: :assistant,
-      content: turn.text,
-      tool_calls: tool_calls,
-      metadata: turn.metadata,
-      reasoning_details: turn.reasoning_details
-    }
+    turn.text
+    |> Context.assistant(tool_calls: tool_calls, metadata: turn.metadata)
+    |> put_reasoning_details(turn.reasoning_details)
   end
 
   def assistant_message(%__MODULE__{} = turn) do
-    %{
-      role: :assistant,
-      content: turn.text,
-      metadata: turn.metadata,
-      reasoning_details: turn.reasoning_details
-    }
+    turn.text
+    |> Context.assistant(metadata: turn.metadata)
+    |> put_reasoning_details(turn.reasoning_details)
   end
 
   @doc """
@@ -377,7 +365,9 @@ defmodule Jido.AI.Turn do
       thinking_content: turn.thinking_content,
       tool_calls: turn.tool_calls,
       usage: turn.usage,
-      model: turn.model
+      model: turn.model,
+      metadata: turn.metadata,
+      reasoning_details: turn.reasoning_details
     }
   end
 
@@ -472,6 +462,11 @@ defmodule Jido.AI.Turn do
   defp normalize_reasoning_details(nil), do: nil
   defp normalize_reasoning_details(details) when is_list(details), do: details
   defp normalize_reasoning_details(_), do: nil
+
+  defp put_reasoning_details(%ReqLLM.Message{} = message, nil), do: message
+
+  defp put_reasoning_details(%ReqLLM.Message{} = message, reasoning_details),
+    do: %{message | reasoning_details: reasoning_details}
 
   defp normalize_usage_key("input_tokens"), do: :input_tokens
   defp normalize_usage_key("output_tokens"), do: :output_tokens

--- a/test/jido_ai/turn_test.exs
+++ b/test/jido_ai/turn_test.exs
@@ -122,8 +122,27 @@ defmodule Jido.AI.TurnTest do
 
       assert turn.metadata == %{response_id: "resp_123"}
       assert turn.reasoning_details == [%{signature: "sig_abc"}]
+      assert %ReqLLM.Message{} = message
       assert message.metadata == %{response_id: "resp_123"}
       assert message.reasoning_details == [%{signature: "sig_abc"}]
+      assert [%ReqLLM.ToolCall{} = tool_call] = message.tool_calls
+      assert tool_call.id == "call_123"
+      assert ReqLLM.ToolCall.name(tool_call) == "list_directory"
+      assert ReqLLM.ToolCall.args_map(tool_call) == %{"path" => "."}
+    end
+  end
+
+  describe "from_result_map/1" do
+    test "accepts legacy message_metadata keys" do
+      turn =
+        Turn.from_result_map(%{
+          type: :tool_calls,
+          text: "Tool round",
+          tool_calls: [%{id: "tc_1", name: "calculator", arguments: %{a: 1, b: 2}}],
+          message_metadata: %{response_id: "resp_tool_round_1"}
+        })
+
+      assert turn.metadata == %{response_id: "resp_tool_round_1"}
     end
   end
 
@@ -143,10 +162,13 @@ defmodule Jido.AI.TurnTest do
       assistant_message = Turn.assistant_message(turn)
       [tool_message] = Turn.tool_messages(turn)
 
-      assert is_map(assistant_message)
+      assert %ReqLLM.Message{} = assistant_message
       assert assistant_message.role == :assistant
       assert assistant_message.metadata == %{response_id: "resp_tool_round_1"}
-      assert [%{id: "tc_1", name: "calculator", arguments: %{a: 5, b: 3}}] = assistant_message.tool_calls
+      assert [%ReqLLM.ToolCall{} = tool_call] = assistant_message.tool_calls
+      assert tool_call.id == "tc_1"
+      assert ReqLLM.ToolCall.name(tool_call) == "calculator"
+      assert ReqLLM.ToolCall.args_map(tool_call) == %{"a" => 5, "b" => 3}
 
       assert %ReqLLM.Message{} = tool_message
       assert tool_message.role == :tool


### PR DESCRIPTION
This patch preserves assistant-message `metadata` and `reasoning_details` in `Jido.AI.Turn`.

Why this matters:
- OpenAI Responses tool-calling resume flows rely on provider-specific assistant metadata such as `response_id`.
- If that metadata is dropped between turns, downstream context assembly cannot reconstruct the prior assistant turn faithfully.
- In practice this can surface later as tool-resume failures even when tool execution itself succeeded.

What changed:
- preserve `response.message.metadata` in `Turn.from_response/2`
- preserve `response.message.reasoning_details` in `Turn.from_response/2`
- preserve both in `from_result_map/1`
- include both in `assistant_message/1`

Added a regression test covering the round-trip projection.

## Notes

This patch works together with a companion `req_llm` fix that preserves the same fields when loose assistant maps are normalized into `ReqLLM.Context`.