### PR TITLE
feat(react): add llm_opts passthrough for provider-specific options

### DIFF
--- a/lib/jido_ai/reasoning/react/config.ex
+++ b/lib/jido_ai/reasoning/react/config.ex
@@ -17,7 +17,8 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
                 temperature: Zoi.number() |> Zoi.default(0.2),
                 timeout_ms: Zoi.integer() |> Zoi.nullish(),
                 tool_choice: Zoi.any() |> Zoi.default(:auto),
-                req_http_options: Zoi.list(Zoi.any()) |> Zoi.default([])
+                req_http_options: Zoi.list(Zoi.any()) |> Zoi.default([]),
+                llm_opts: Zoi.list(Zoi.any()) |> Zoi.default([])
               })
 
   @tool_exec_schema Zoi.object(%{
@@ -90,7 +91,8 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
       temperature: normalize_float(get_opt(opts_map, :temperature, 0.2), 0.2),
       timeout_ms: normalize_optional_pos_integer(llm_timeout),
       tool_choice: get_opt(opts_map, :tool_choice, :auto),
-      req_http_options: normalize_req_http_options(get_opt(opts_map, :req_http_options, []))
+      req_http_options: normalize_req_http_options(get_opt(opts_map, :req_http_options, [])),
+      llm_opts: normalize_llm_opts(get_opt(opts_map, :llm_opts, []))
     }
 
     tool_exec = %{
@@ -194,6 +196,7 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
       tools: reqllm_tools(config)
     ]
 
+    opts = maybe_merge_llm_opts(opts, config.llm.llm_opts)
     opts = maybe_put_req_http_options(opts, config.llm.req_http_options)
 
     if is_integer(config.llm.timeout_ms) do
@@ -270,6 +273,15 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
 
   defp normalize_req_http_options(value) when is_list(value), do: value
   defp normalize_req_http_options(_), do: []
+
+  defp normalize_llm_opts(value) when is_list(value), do: value
+  defp normalize_llm_opts(_), do: []
+
+  defp maybe_merge_llm_opts(opts, llm_opts) when is_list(llm_opts) and llm_opts != [] do
+    Keyword.merge(opts, llm_opts)
+  end
+
+  defp maybe_merge_llm_opts(opts, _), do: opts
 
   defp maybe_put_req_http_options(opts, req_http_options) when is_list(req_http_options) do
     if req_http_options == [] do

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -407,10 +407,12 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       @start ->
         run_context = Map.get(params, :tool_context) || %{}
         run_req_http_options = params |> Map.get(:req_http_options, []) |> normalize_req_http_options()
+        run_llm_opts = Map.get(params, :llm_opts, [])
 
         agent
         |> set_run_tool_context(run_context)
         |> set_run_req_http_options(run_req_http_options)
+        |> set_run_llm_opts(run_llm_opts)
         |> process_start(params)
 
       @cancel ->
@@ -470,7 +472,10 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       run_req_http_options = Map.get(state, :run_req_http_options, [])
       base_req_http_options = normalize_req_http_options(config[:base_req_http_options])
       effective_req_http_options = base_req_http_options ++ run_req_http_options
-      runtime_config = runtime_config_from_strategy(config, req_http_options: effective_req_http_options)
+      run_llm_opts = Map.get(state, :run_llm_opts, [])
+      base_llm_opts = config[:base_llm_opts] || []
+      effective_llm_opts = Keyword.merge(base_llm_opts, run_llm_opts)
+      runtime_config = runtime_config_from_strategy(config, req_http_options: effective_req_http_options, llm_opts: effective_llm_opts)
       base_thread = strategy_thread(state, config)
       run_thread = Thread.append_user(base_thread, query)
       runtime_state = runtime_state_from_thread(run_thread, query, request_id, run_id)
@@ -985,6 +990,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       max_iterations: config[:max_iterations],
       streaming: config[:streaming],
       req_http_options: req_http_options,
+      llm_opts: Keyword.get(opts, :llm_opts, config[:base_llm_opts] || []),
       tool_timeout_ms: config[:tool_timeout_ms],
       tool_max_retries: config[:tool_max_retries],
       tool_retry_backoff_ms: config[:tool_retry_backoff_ms],
@@ -1006,6 +1012,13 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     state = StratState.get(agent, %{})
     put_strategy_state(agent, Map.put(state, :run_req_http_options, req_http_options))
   end
+
+  defp set_run_llm_opts(agent, llm_opts) when is_list(llm_opts) do
+    state = StratState.get(agent, %{})
+    put_strategy_state(agent, Map.put(state, :run_llm_opts, llm_opts))
+  end
+
+  defp set_run_llm_opts(agent, _), do: agent
 
   defp normalize_action({inner, _meta}), do: normalize_action(inner)
   defp normalize_action(action), do: action
@@ -1198,7 +1211,8 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
         ),
       agent_id: agent.id,
       base_tool_context: Map.get(agent.state, :tool_context) || tool_context_opt,
-      base_req_http_options: opts |> Keyword.get(:req_http_options, []) |> normalize_req_http_options()
+      base_req_http_options: opts |> Keyword.get(:req_http_options, []) |> normalize_req_http_options(),
+      base_llm_opts: opts |> Keyword.get(:llm_opts, [])
     }
   end
 

--- a/test/jido_ai/react/llm_opts_passthrough_test.exs
+++ b/test/jido_ai/react/llm_opts_passthrough_test.exs
@@ -1,0 +1,89 @@
+defmodule Jido.AI.Reasoning.ReAct.LlmOptsPassthroughTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.AI.Reasoning.ReAct.Config
+
+  describe "Config.llm_opts/1 with llm_opts passthrough" do
+    test "merges extra llm_opts into output" do
+      config =
+        Config.new(%{
+          model: "anthropic:claude-sonnet-4-5",
+          max_tokens: 1024,
+          llm_opts: [web_search: %{max_uses: 5}]
+        })
+
+      opts = Config.llm_opts(config)
+
+      assert Keyword.get(opts, :web_search) == %{max_uses: 5}
+      assert Keyword.get(opts, :max_tokens) == 1024
+    end
+
+    test "empty llm_opts does not affect output" do
+      config =
+        Config.new(%{
+          model: "anthropic:claude-sonnet-4-5",
+          max_tokens: 2048,
+          llm_opts: []
+        })
+
+      opts = Config.llm_opts(config)
+
+      assert Keyword.get(opts, :max_tokens) == 2048
+      refute Keyword.has_key?(opts, :web_search)
+    end
+
+    test "llm_opts defaults to empty list" do
+      config =
+        Config.new(%{
+          model: "anthropic:claude-sonnet-4-5"
+        })
+
+      opts = Config.llm_opts(config)
+
+      assert Keyword.get(opts, :max_tokens) == 1024
+      refute Keyword.has_key?(opts, :web_search)
+    end
+
+    test "llm_opts supports provider-specific options like thinking" do
+      config =
+        Config.new(%{
+          model: "anthropic:claude-sonnet-4-5",
+          llm_opts: [thinking: %{type: "enabled", budget_tokens: 4096}]
+        })
+
+      opts = Config.llm_opts(config)
+
+      assert Keyword.get(opts, :thinking) == %{type: "enabled", budget_tokens: 4096}
+    end
+
+    test "llm_opts can override base options" do
+      config =
+        Config.new(%{
+          model: "anthropic:claude-sonnet-4-5",
+          temperature: 0.2,
+          llm_opts: [temperature: 0.8]
+        })
+
+      opts = Config.llm_opts(config)
+
+      # llm_opts merges after base, so it overrides
+      assert Keyword.get(opts, :temperature) == 0.8
+    end
+
+    test "multiple provider options can be passed" do
+      config =
+        Config.new(%{
+          model: "anthropic:claude-sonnet-4-5",
+          llm_opts: [
+            web_search: %{max_uses: 3},
+            anthropic_prompt_cache: true
+          ]
+        })
+
+      opts = Config.llm_opts(config)
+
+      assert Keyword.get(opts, :web_search) == %{max_uses: 3}
+      assert Keyword.get(opts, :anthropic_prompt_cache) == true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `llm_opts` passthrough in the ReAct strategy/config so agents can pass provider-specific LLM options (like Anthropic's `web_search`, `thinking`, `anthropic_prompt_cache`) through to ReqLLM
- Without this, there's no way for agents using the ReAct strategy to leverage provider-specific features since `Config.llm_opts/1` only emits `max_tokens`, `temperature`, `tool_choice`, `tools`, and `req_http_options`

## Changes
- **config.ex**: Add `llm_opts` field to LLM schema, merge into `Config.llm_opts/1` output, add to `Config.new/1`
- **strategy.ex**: Read `llm_opts` from `ai_react_start` params, store as `run_llm_opts` in state, merge with `base_llm_opts` from agent config, pass through to runtime config

## Usage

In an agent's `on_before_cmd`:

```elixir
def on_before_cmd(agent, {:ai_react_start, params} = _action) do
  params = Map.put(params, :llm_opts, [web_search: %{max_uses: 5}])
  {:ok, agent, {:ai_react_start, params}}
end
```

## Notes
- This is a backport-style PR based on `v2.0.0-rc.0` — I noticed that `main` (v2.0.0) already has this feature, but the transitive dependency changes (`jido ~> 2.1`, `jido_action ~> 2.1`, `multigraph`) make upgrading from `2.0.0-rc.0` difficult for projects using `ash_jido`
- This PR provides the feature for users still on the rc release train

## Test plan
- [x] 6 new tests covering: basic passthrough, empty defaults, provider-specific options (thinking, web_search), option override, multiple options