### PR TITLE
refactor(cli): codify non-interactive mix task contract

### DIFF
--- a/lib/mix/tasks/jido_ai.ex
+++ b/lib/mix/tasks/jido_ai.ex
@@ -60,6 +60,10 @@ defmodule Mix.Tasks.JidoAi do
 
   @supported_types ~w(react aot cod cot tot got trm adaptive)
   @supported_formats ~w(text json)
+  @no_query_error """
+                  No query provided. Pass a prompt (mix jido_ai "<prompt>") or use --stdin for batch mode.
+                  """
+                  |> String.trim()
 
   @option_strict [
     type: :string,
@@ -110,20 +114,13 @@ defmodule Mix.Tasks.JidoAi do
       attach_trace_handlers()
     end
 
-    cond do
-      config.stdin ->
+    case validate_invocation(args, config) do
+      :ok ->
         start_jido_instance(JidoAi.CliJido)
         run_non_interactive(args, config)
 
-      Enum.empty?(args) ->
-        output_fatal_error(
-          config,
-          "No query provided. Pass a prompt (mix jido_ai \"<prompt>\") or use --stdin for batch mode."
-        )
-
-      true ->
-        start_jido_instance(JidoAi.CliJido)
-        run_non_interactive(args, config)
+      {:error, reason} ->
+        output_fatal_error(config, reason)
     end
   end
 
@@ -162,6 +159,14 @@ defmodule Mix.Tasks.JidoAi do
   def validate_format(format) do
     {:error, "Unsupported --format #{inspect(format)}. Supported formats: text, json"}
   end
+
+  @doc false
+  @spec validate_invocation([String.t()], map()) :: :ok | {:error, String.t()}
+  def validate_invocation(_args, %{stdin: true}), do: :ok
+
+  def validate_invocation([], _config), do: {:error, @no_query_error}
+
+  def validate_invocation(_args, _config), do: :ok
 
   defp run_non_interactive(args, config) do
     case resolve_adapter_and_agent(config) do

--- a/test/jido_ai/cli/adapters/mix_task_contract_test.exs
+++ b/test/jido_ai/cli/adapters/mix_task_contract_test.exs
@@ -118,4 +118,15 @@ defmodule Mix.Tasks.JidoAi.ContractTest do
       assert message =~ "text, json"
     end
   end
+
+  describe "validate_invocation/2" do
+    test "rejects empty invocations unless stdin mode is enabled" do
+      assert {:error, message} = JidoAiTask.validate_invocation([], %{stdin: false})
+      assert message =~ "No query provided"
+      assert message =~ "use --stdin"
+
+      assert :ok = JidoAiTask.validate_invocation([], %{stdin: true})
+      assert :ok = JidoAiTask.validate_invocation(["hello"], %{stdin: false})
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- make the `mix jido_ai` invocation contract explicit and non-interactive
- extract invocation validation so empty calls fail fast instead of drifting toward old TUI behavior
- add regression coverage for the no-query path

## Rationale
PR #122 is trying to restore a legacy `mix jido_ai.agent --tui` surface. `main` no longer exposes that API, and this repo does not need backwards compatibility for it. This change keeps the CLI intentionally trimmed to one-shot and `--stdin` modes and makes that decision testable.

## Testing
- `mix test test/jido_ai/cli`

Replaces #122 as the correct direction for the current CLI surface.
