### PR TITLE
fix(agent): accept full ReqLLM model inputs

### DIFF
--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -145,13 +145,17 @@ defmodule Jido.AI.Agent do
       {:%, meta, args} ->
         {:%, meta, args}
 
+      # Allow tuple syntax: {...}
+      {:{}, meta, elements} ->
+        {:{}, meta, elements}
+
       # Allow 2-tuples (key-value pairs in maps)
-      {key, value} when not is_atom(key) or key not in [:__aliases__, :%, :%{}] ->
+      {key, value} when not is_atom(key) or key not in [:__aliases__, :%, :%{}, :{}] ->
         {key, value}
 
       # Reject function calls and other unsafe constructs
       {func, meta, args} = node when is_atom(func) and is_list(args) ->
-        if func in [:__aliases__, :%, :%{}] do
+        if func in [:__aliases__, :%, :%{}, :{}] do
           node
         else
           raise CompileError,
@@ -187,6 +191,12 @@ defmodule Jido.AI.Agent do
     case value do
       nil ->
         nil
+
+      value when is_tuple(value) ->
+        value
+        |> expand_aliases_in_ast(caller_env)
+        |> Code.eval_quoted([], caller_env)
+        |> elem(0)
 
       value when is_map(value) ->
         value
@@ -230,7 +240,12 @@ defmodule Jido.AI.Agent do
     description = Keyword.get(opts, :description, "AI agent #{name}")
     tags = Keyword.get(opts, :tags, [])
     system_prompt = Keyword.get(opts, :system_prompt)
-    model = Keyword.get(opts, :model, @default_model)
+
+    model =
+      opts
+      |> Keyword.get(:model, @default_model)
+      |> __MODULE__.expand_and_eval_literal_option(__CALLER__)
+
     max_iterations = Keyword.get(opts, :max_iterations, @default_max_iterations)
     max_tokens = Keyword.get(opts, :max_tokens, @default_max_tokens)
     streaming = Keyword.get(opts, :streaming, true)
@@ -330,7 +345,7 @@ defmodule Jido.AI.Agent do
       quote do
         Zoi.object(%{
           __strategy__: Zoi.map() |> Zoi.default(%{}),
-          model: Zoi.any() |> Zoi.default(unquote(model)),
+          model: Zoi.any() |> Zoi.default(unquote(Macro.escape(model))),
           # Request tracking for concurrent request isolation
           requests: Zoi.map() |> Zoi.default(%{}),
           last_request_id: Zoi.string() |> Zoi.optional(),

--- a/lib/jido_ai/agents/strategies/adaptive_agent.ex
+++ b/lib/jido_ai/agents/strategies/adaptive_agent.ex
@@ -102,7 +102,12 @@ defmodule Jido.AI.AdaptiveAgent do
   defmacro __using__(opts) do
     name = Keyword.fetch!(opts, :name)
     description = Keyword.get(opts, :description, "Adaptive agent #{name}")
-    model = Keyword.get(opts, :model, @default_model)
+
+    model =
+      opts
+      |> Keyword.get(:model, @default_model)
+      |> Jido.AI.Agent.expand_and_eval_literal_option(__CALLER__)
+
     has_tools_opt? = Keyword.has_key?(opts, :tools)
     tools_ast = Keyword.get(opts, :tools, [])
 
@@ -139,7 +144,7 @@ defmodule Jido.AI.AdaptiveAgent do
       quote do
         Zoi.object(%{
           __strategy__: Zoi.map() |> Zoi.default(%{}),
-          model: Zoi.any() |> Zoi.default(unquote(model)),
+          model: Zoi.any() |> Zoi.default(unquote(Macro.escape(model))),
           # Request tracking for concurrent request isolation
           requests: Zoi.map() |> Zoi.default(%{}),
           last_request_id: Zoi.string() |> Zoi.optional(),

--- a/lib/jido_ai/agents/strategies/aot_agent.ex
+++ b/lib/jido_ai/agents/strategies/aot_agent.ex
@@ -17,7 +17,12 @@ defmodule Jido.AI.AoTAgent do
   defmacro __using__(opts) do
     name = Keyword.fetch!(opts, :name)
     description = Keyword.get(opts, :description, "AoT agent #{name}")
-    model = Keyword.get(opts, :model, @default_model)
+
+    model =
+      opts
+      |> Keyword.get(:model, @default_model)
+      |> Jido.AI.Agent.expand_and_eval_literal_option(__CALLER__)
+
     profile = Keyword.get(opts, :profile, @default_profile)
     search_style = Keyword.get(opts, :search_style, @default_search_style)
     temperature = Keyword.get(opts, :temperature, @default_temperature)
@@ -42,7 +47,7 @@ defmodule Jido.AI.AoTAgent do
       quote do
         Zoi.object(%{
           __strategy__: Zoi.map() |> Zoi.default(%{}),
-          model: Zoi.any() |> Zoi.default(unquote(model)),
+          model: Zoi.any() |> Zoi.default(unquote(Macro.escape(model))),
           requests: Zoi.map() |> Zoi.default(%{}),
           last_request_id: Zoi.string() |> Zoi.optional(),
           last_prompt: Zoi.string() |> Zoi.default(""),

--- a/lib/jido_ai/agents/strategies/cod_agent.ex
+++ b/lib/jido_ai/agents/strategies/cod_agent.ex
@@ -13,7 +13,12 @@ defmodule Jido.AI.CoDAgent do
   defmacro __using__(opts) do
     name = Keyword.fetch!(opts, :name)
     description = Keyword.get(opts, :description, "CoD agent #{name}")
-    model = Keyword.get(opts, :model, @default_model)
+
+    model =
+      opts
+      |> Keyword.get(:model, @default_model)
+      |> Jido.AI.Agent.expand_and_eval_literal_option(__CALLER__)
+
     system_prompt = Keyword.get(opts, :system_prompt, Jido.AI.Reasoning.ChainOfDraft.default_system_prompt())
     plugins = Keyword.get(opts, :plugins, [])
 
@@ -25,7 +30,7 @@ defmodule Jido.AI.CoDAgent do
       quote do
         Zoi.object(%{
           __strategy__: Zoi.map() |> Zoi.default(%{}),
-          model: Zoi.any() |> Zoi.default(unquote(model)),
+          model: Zoi.any() |> Zoi.default(unquote(Macro.escape(model))),
           requests: Zoi.map() |> Zoi.default(%{}),
           last_request_id: Zoi.string() |> Zoi.optional(),
           last_prompt: Zoi.string() |> Zoi.default(""),

--- a/lib/jido_ai/agents/strategies/cot_agent.ex
+++ b/lib/jido_ai/agents/strategies/cot_agent.ex
@@ -89,7 +89,12 @@ defmodule Jido.AI.CoTAgent do
   defmacro __using__(opts) do
     name = Keyword.fetch!(opts, :name)
     description = Keyword.get(opts, :description, "CoT agent #{name}")
-    model = Keyword.get(opts, :model, @default_model)
+
+    model =
+      opts
+      |> Keyword.get(:model, @default_model)
+      |> Jido.AI.Agent.expand_and_eval_literal_option(__CALLER__)
+
     system_prompt = Keyword.get(opts, :system_prompt)
     plugins = Keyword.get(opts, :plugins, [])
 
@@ -106,7 +111,7 @@ defmodule Jido.AI.CoTAgent do
       quote do
         Zoi.object(%{
           __strategy__: Zoi.map() |> Zoi.default(%{}),
-          model: Zoi.any() |> Zoi.default(unquote(model)),
+          model: Zoi.any() |> Zoi.default(unquote(Macro.escape(model))),
           # Request tracking for concurrent request isolation
           requests: Zoi.map() |> Zoi.default(%{}),
           last_request_id: Zoi.string() |> Zoi.optional(),

--- a/lib/jido_ai/agents/strategies/got_agent.ex
+++ b/lib/jido_ai/agents/strategies/got_agent.ex
@@ -95,7 +95,12 @@ defmodule Jido.AI.GoTAgent do
   defmacro __using__(opts) do
     name = Keyword.fetch!(opts, :name)
     description = Keyword.get(opts, :description, "GoT agent #{name}")
-    model = Keyword.get(opts, :model, @default_model)
+
+    model =
+      opts
+      |> Keyword.get(:model, @default_model)
+      |> Jido.AI.Agent.expand_and_eval_literal_option(__CALLER__)
+
     max_nodes = Keyword.get(opts, :max_nodes, @default_max_nodes)
     max_depth = Keyword.get(opts, :max_depth, @default_max_depth)
     aggregation_strategy = Keyword.get(opts, :aggregation_strategy, @default_aggregation_strategy)
@@ -127,7 +132,7 @@ defmodule Jido.AI.GoTAgent do
       quote do
         Zoi.object(%{
           __strategy__: Zoi.map() |> Zoi.default(%{}),
-          model: Zoi.any() |> Zoi.default(unquote(model)),
+          model: Zoi.any() |> Zoi.default(unquote(Macro.escape(model))),
           requests: Zoi.map() |> Zoi.default(%{}),
           last_request_id: Zoi.string() |> Zoi.optional(),
           last_prompt: Zoi.string() |> Zoi.default(""),

--- a/lib/jido_ai/agents/strategies/tot_agent.ex
+++ b/lib/jido_ai/agents/strategies/tot_agent.ex
@@ -115,7 +115,12 @@ defmodule Jido.AI.ToTAgent do
   defmacro __using__(opts) do
     name = Keyword.fetch!(opts, :name)
     description = Keyword.get(opts, :description, "ToT agent #{name}")
-    model = Keyword.get(opts, :model, @default_model)
+
+    model =
+      opts
+      |> Keyword.get(:model, @default_model)
+      |> Jido.AI.Agent.expand_and_eval_literal_option(__CALLER__)
+
     branching_factor = Keyword.get(opts, :branching_factor, @default_branching_factor)
     max_depth = Keyword.get(opts, :max_depth, @default_max_depth)
     traversal_strategy = Keyword.get(opts, :traversal_strategy, @default_traversal_strategy)
@@ -187,7 +192,7 @@ defmodule Jido.AI.ToTAgent do
       quote do
         Zoi.object(%{
           __strategy__: Zoi.map() |> Zoi.default(%{}),
-          model: Zoi.any() |> Zoi.default(unquote(model)),
+          model: Zoi.any() |> Zoi.default(unquote(Macro.escape(model))),
           # Request tracking for concurrent request isolation
           requests: Zoi.map() |> Zoi.default(%{}),
           last_request_id: Zoi.string() |> Zoi.optional(),

--- a/lib/jido_ai/agents/strategies/trm_agent.ex
+++ b/lib/jido_ai/agents/strategies/trm_agent.ex
@@ -91,7 +91,12 @@ defmodule Jido.AI.TRMAgent do
   defmacro __using__(opts) do
     name = Keyword.fetch!(opts, :name)
     description = Keyword.get(opts, :description, "TRM agent #{name}")
-    model = Keyword.get(opts, :model, @default_model)
+
+    model =
+      opts
+      |> Keyword.get(:model, @default_model)
+      |> Jido.AI.Agent.expand_and_eval_literal_option(__CALLER__)
+
     max_supervision_steps = Keyword.get(opts, :max_supervision_steps, @default_max_supervision_steps)
     act_threshold = Keyword.get(opts, :act_threshold, @default_act_threshold)
     plugins = Keyword.get(opts, :plugins, [])
@@ -109,7 +114,7 @@ defmodule Jido.AI.TRMAgent do
       quote do
         Zoi.object(%{
           __strategy__: Zoi.map() |> Zoi.default(%{}),
-          model: Zoi.any() |> Zoi.default(unquote(model)),
+          model: Zoi.any() |> Zoi.default(unquote(Macro.escape(model))),
           # Request tracking for concurrent request isolation
           requests: Zoi.map() |> Zoi.default(%{}),
           last_request_id: Zoi.string() |> Zoi.optional(),

--- a/lib/jido_ai/model_input.ex
+++ b/lib/jido_ai/model_input.ex
@@ -1,0 +1,76 @@
+defmodule Jido.AI.ModelInput do
+  @moduledoc false
+
+  @type t :: Jido.AI.model_alias() | ReqLLM.model_input()
+
+  @doc false
+  @spec normalize!(t()) :: ReqLLM.model_input()
+  def normalize!(model) when is_atom(model), do: Jido.AI.resolve_model(model)
+  def normalize!(model) when is_binary(model), do: model
+  def normalize!(%LLMDB.Model{} = model), do: model
+  def normalize!(model) when is_map(model) and not is_struct(model), do: model
+
+  def normalize!({provider, model_id, provider_opts} = model)
+      when is_atom(provider) and is_binary(model_id) and is_list(provider_opts),
+      do: model
+
+  def normalize!({provider, provider_opts} = model) when is_atom(provider) and is_list(provider_opts), do: model
+
+  def normalize!(model) do
+    raise ArgumentError,
+          "invalid model input #{inspect(model)}. " <>
+            "Expected a model alias, string spec, ReqLLM tuple spec, inline model map, or %LLMDB.Model{}."
+  end
+
+  @doc false
+  @spec label(t()) :: String.t()
+  def label(model) when is_atom(model), do: Jido.AI.resolve_model(model)
+  def label(model) when is_binary(model), do: model
+
+  def label(model) do
+    case ReqLLM.model(model) do
+      {:ok, %LLMDB.Model{} = normalized} -> LLMDB.Model.spec(normalized)
+      _ -> inspect(model)
+    end
+  end
+
+  @doc false
+  @spec fingerprint_segment(t()) :: String.t()
+  def fingerprint_segment(model) when is_atom(model), do: Jido.AI.resolve_model(model)
+  def fingerprint_segment(model) when is_binary(model), do: model
+
+  def fingerprint_segment(model) do
+    model
+    |> fingerprint_term()
+    |> :erlang.term_to_binary([:deterministic])
+    |> Base.url_encode64(padding: false)
+  end
+
+  @doc false
+  @spec provider_opt_keys(t()) :: %{optional(String.t()) => atom()}
+  def provider_opt_keys(model) do
+    with {:ok, %LLMDB.Model{} = normalized} <- ReqLLM.model(normalize!(model)),
+         {:ok, provider_mod} <- ReqLLM.provider(normalized.provider),
+         true <- function_exported?(provider_mod, :provider_schema, 0) do
+      provider_mod.provider_schema().schema
+      |> Keyword.keys()
+      |> Enum.map(&{Atom.to_string(&1), &1})
+      |> Map.new()
+    else
+      _ -> %{}
+    end
+  end
+
+  defp fingerprint_term(model) do
+    case ReqLLM.model(model) do
+      {:ok, %LLMDB.Model{} = normalized} ->
+        normalized
+        |> Map.from_struct()
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+        |> Map.new()
+
+      _ ->
+        model
+    end
+  end
+end

--- a/lib/jido_ai/reasoning/adaptive/strategy.ex
+++ b/lib/jido_ai/reasoning/adaptive/strategy.ex
@@ -391,13 +391,7 @@ defmodule Jido.AI.Reasoning.Adaptive.Strategy do
     }
   end
 
-  defp resolve_model_spec(model) when is_atom(model) do
-    Jido.AI.resolve_model(model)
-  end
-
-  defp resolve_model_spec(model) when is_binary(model) do
-    model
-  end
+  defp resolve_model_spec(model), do: Jido.AI.ModelInput.normalize!(model)
 
   defp handle_initial_instruction(agent, instructions, ctx, state) do
     # Find the start instruction

--- a/lib/jido_ai/reasoning/algorithm_of_thoughts/strategy.ex
+++ b/lib/jido_ai/reasoning/algorithm_of_thoughts/strategy.ex
@@ -329,9 +329,7 @@ defmodule Jido.AI.Reasoning.AlgorithmOfThoughts.Strategy do
     }
   end
 
-  defp resolve_model_spec(model) when is_atom(model), do: Jido.AI.resolve_model(model)
-  defp resolve_model_spec(model) when is_binary(model), do: model
-  defp resolve_model_spec(_), do: Jido.AI.resolve_model(@default_model)
+  defp resolve_model_spec(model), do: Jido.AI.ModelInput.normalize!(model)
 
   defp normalize_temperature(temp) when is_number(temp), do: temp * 1.0
   defp normalize_temperature(_), do: 0.0

--- a/lib/jido_ai/reasoning/chain_of_thought/strategy.ex
+++ b/lib/jido_ai/reasoning/chain_of_thought/strategy.ex
@@ -565,7 +565,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Strategy do
 
     Signal.Usage.new!(%{
       call_id: call_id,
-      model: model || "",
+      model: Jido.AI.ModelInput.label(model),
       input_tokens: input_tokens,
       output_tokens: output_tokens,
       total_tokens: input_tokens + output_tokens,
@@ -724,8 +724,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Strategy do
   defp normalize_map_opt({:%{}, _meta, pairs}) when is_list(pairs), do: Map.new(pairs)
   defp normalize_map_opt(_), do: %{}
 
-  defp resolve_model_spec(model) when is_atom(model), do: Jido.AI.resolve_model(model)
-  defp resolve_model_spec(model) when is_binary(model), do: model
+  defp resolve_model_spec(model), do: Jido.AI.ModelInput.normalize!(model)
 
   defp generate_call_id, do: Machine.generate_call_id()
 

--- a/lib/jido_ai/reasoning/chain_of_thought/worker/strategy.ex
+++ b/lib/jido_ai/reasoning/chain_of_thought/worker/strategy.ex
@@ -540,9 +540,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Worker.Strategy do
     Map.get(map, key, Map.get(map, Atom.to_string(key), default))
   end
 
-  defp resolve_model_spec(model) when is_atom(model), do: Jido.AI.resolve_model(model)
-  defp resolve_model_spec(model) when is_binary(model), do: model
-  defp resolve_model_spec(_), do: Jido.AI.resolve_model(@default_model)
+  defp resolve_model_spec(model), do: Jido.AI.ModelInput.normalize!(model)
 
   defp normalize_blank(""), do: nil
   defp normalize_blank(value), do: value

--- a/lib/jido_ai/reasoning/graph_of_thoughts/strategy.ex
+++ b/lib/jido_ai/reasoning/graph_of_thoughts/strategy.ex
@@ -319,13 +319,7 @@ defmodule Jido.AI.Reasoning.GraphOfThoughts.Strategy do
     }
   end
 
-  defp resolve_model_spec(model) when is_atom(model) do
-    Jido.AI.resolve_model(model)
-  end
-
-  defp resolve_model_spec(model) when is_binary(model) do
-    model
-  end
+  defp resolve_model_spec(model), do: Jido.AI.ModelInput.normalize!(model)
 
   defp process_instruction(agent, %{action: @start, params: params}, _ctx) do
     state = StratState.get(agent, %{})

--- a/lib/jido_ai/reasoning/react/config.ex
+++ b/lib/jido_ai/reasoning/react/config.ex
@@ -3,7 +3,7 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
   Canonical configuration for the Task-based ReAct runtime.
   """
 
-  alias Jido.AI.ModelAliases
+  alias Jido.AI.ModelInput
   alias Jido.AI.Reasoning.ReAct.RequestTransformer
   alias Jido.AI.ToolAdapter
   require Logger
@@ -56,7 +56,7 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
             __MODULE__,
             %{
               version: Zoi.integer() |> Zoi.default(1),
-              model: Zoi.string(description: "Resolved model spec"),
+              model: Zoi.any(description: "Resolved ReqLLM model input"),
               system_prompt: Zoi.string() |> Zoi.nullish(),
               tools: Zoi.map() |> Zoi.default(%{}),
               request_transformer: Zoi.atom() |> Zoi.nullish(),
@@ -87,7 +87,7 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
   @spec new(map() | keyword()) :: t()
   def new(opts \\ %{}) do
     opts_map = normalize_opts(opts)
-    resolved_model = opts_map |> get_opt(:model, @default_model) |> resolve_model()
+    resolved_model = opts_map |> get_opt(:model, @default_model) |> ModelInput.normalize!()
     provider_opt_keys_by_string = provider_opt_keys_by_string(resolved_model)
 
     tools =
@@ -169,7 +169,7 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
 
     parts = [
       "v#{config.version}",
-      config.model,
+      ModelInput.fingerprint_segment(config.model),
       config.system_prompt || "",
       Integer.to_string(config.max_iterations),
       to_string(config.streaming),
@@ -244,10 +244,6 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
     normalized_overrides = normalize_llm_opts(overrides, provider_opt_keys_by_string)
     maybe_merge_llm_opts(base_opts, normalized_overrides)
   end
-
-  defp resolve_model(model) when is_binary(model), do: model
-  defp resolve_model(model) when is_atom(model), do: ModelAliases.resolve_model(model)
-  defp resolve_model(_), do: ModelAliases.resolve_model(@default_model)
 
   defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
   defp normalize_opts(opts) when is_map(opts), do: opts
@@ -419,18 +415,7 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
     end
   end
 
-  defp provider_opt_keys_by_string(model_spec) when is_binary(model_spec) do
-    with {:ok, model} <- ReqLLM.model(model_spec),
-         {:ok, provider_mod} <- ReqLLM.provider(model.provider),
-         true <- function_exported?(provider_mod, :provider_schema, 0) do
-      provider_mod.provider_schema().schema
-      |> Keyword.keys()
-      |> Enum.map(&{Atom.to_string(&1), &1})
-      |> Map.new()
-    else
-      _ -> %{}
-    end
-  end
+  defp provider_opt_keys_by_string(model_spec), do: ModelInput.provider_opt_keys(model_spec)
 
   defp maybe_merge_llm_opts(opts, llm_opts) when is_list(llm_opts) do
     if llm_opts == [] do

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -9,6 +9,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   alias Jido.AI.Reasoning.ReAct.{Config, Event, PendingToolCall, State, Token, ToolSelection}
   alias Jido.AI.Effects
   alias Jido.AI.Context, as: AIContext
+  alias Jido.AI.ModelInput
   alias Jido.AI.Turn
   alias Jido.Agent.State, as: AgentState
 
@@ -429,8 +430,8 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
            stream_process_opts(owner, ref, trace_cfg, state_key, heartbeat_interval_ms)
          ) do
       {:ok, response} ->
-        {:ok, current_stream_state(state_key, state), Turn.from_response(response, model: config.model),
-         extract_response_id(response)}
+        {:ok, current_stream_state(state_key, state),
+         Turn.from_response(response, model: ModelInput.label(config.model)), extract_response_id(response)}
 
       {:error, reason} ->
         {:error, current_stream_state(state_key, state), reason}
@@ -444,7 +445,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   end
 
   defp consume_generate(%State{} = state, %Config{} = config, response) do
-    turn = Turn.from_response(response, model: config.model)
+    turn = Turn.from_response(response, model: ModelInput.label(config.model))
     {:ok, state, turn, extract_response_id(response)}
   rescue
     e ->

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -38,7 +38,6 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   alias Jido.Agent.Strategy.State, as: StratState
   alias Jido.AI.Directive
   alias Jido.AI.Effects
-  alias Jido.AI.ModelAliases
   alias Jido.AI.Reasoning.ReAct.RequestTransformer
   alias Jido.AI.Reasoning.ReAct.State, as: ReActState
   alias Jido.AI.Reasoning.ReAct.Config, as: ReActRuntimeConfig
@@ -1529,7 +1528,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
 
     Signal.Usage.new!(%{
       call_id: call_id,
-      model: model || "",
+      model: Jido.AI.ModelInput.label(model),
       input_tokens: input_tokens,
       output_tokens: output_tokens,
       total_tokens: input_tokens + output_tokens
@@ -1865,8 +1864,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     }
   end
 
-  defp resolve_model_spec(model) when is_atom(model), do: ModelAliases.resolve_model(model)
-  defp resolve_model_spec(model) when is_binary(model), do: model
+  defp resolve_model_spec(model), do: Jido.AI.ModelInput.normalize!(model)
 
   defp validate_request_policy!(:reject), do: :reject
 
@@ -2060,18 +2058,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     end
   end
 
-  defp provider_opt_keys_by_string(model_spec) when is_binary(model_spec) do
-    with {:ok, model} <- ReqLLM.model(model_spec),
-         {:ok, provider_mod} <- ReqLLM.provider(model.provider),
-         true <- function_exported?(provider_mod, :provider_schema, 0) do
-      provider_mod.provider_schema().schema
-      |> Keyword.keys()
-      |> Enum.map(&{Atom.to_string(&1), &1})
-      |> Map.new()
-    else
-      _ -> %{}
-    end
-  end
+  defp provider_opt_keys_by_string(model_spec), do: Jido.AI.ModelInput.provider_opt_keys(model_spec)
 
   defp generate_call_id, do: "req_#{Jido.Util.generate_id()}"
 

--- a/lib/jido_ai/reasoning/tree_of_thoughts/strategy.ex
+++ b/lib/jido_ai/reasoning/tree_of_thoughts/strategy.ex
@@ -888,13 +888,7 @@ defmodule Jido.AI.Reasoning.TreeOfThoughts.Strategy do
     }
   end
 
-  defp resolve_model_spec(model) when is_atom(model) do
-    Jido.AI.resolve_model(model)
-  end
-
-  defp resolve_model_spec(model) when is_binary(model) do
-    model
-  end
+  defp resolve_model_spec(model), do: Jido.AI.ModelInput.normalize!(model)
 
   defp normalize_tools_modules(modules) when is_list(modules) do
     modules

--- a/lib/jido_ai/reasoning/trm/strategy.ex
+++ b/lib/jido_ai/reasoning/trm/strategy.ex
@@ -311,13 +311,7 @@ defmodule Jido.AI.Reasoning.TRM.Strategy do
     }
   end
 
-  defp resolve_model_spec(model) when is_atom(model) do
-    Jido.AI.resolve_model(model)
-  end
-
-  defp resolve_model_spec(model) when is_binary(model) do
-    model
-  end
+  defp resolve_model_spec(model), do: Jido.AI.ModelInput.normalize!(model)
 
   defp process_instruction(agent, %Jido.Instruction{action: action, params: params} = instruction, ctx) do
     normalized_action = normalize_action(action)

--- a/test/jido_ai/agent_test.exs
+++ b/test/jido_ai/agent_test.exs
@@ -110,6 +110,20 @@ defmodule Jido.AI.AgentTest do
       request_transformer: TestRequestTransformer
   end
 
+  defmodule AgentWithInlineModelMap do
+    use Jido.AI.Agent,
+      name: "agent_with_inline_model_map",
+      tools: [TestCalculator],
+      model: %{provider: :openai, id: "gpt-4o-mini", base_url: "http://localhost:4000/v1"}
+  end
+
+  defmodule AgentWithTupleModelSpec do
+    use Jido.AI.Agent,
+      name: "agent_with_tuple_model_spec",
+      tools: [TestCalculator],
+      model: {:openai, "gpt-4o-mini", []}
+  end
+
   defmodule AgentWithStreamTimeoutAlias do
     use Jido.AI.Agent,
       name: "agent_with_stream_timeout_alias",
@@ -260,6 +274,22 @@ defmodule Jido.AI.AgentTest do
       config = state[:config]
 
       assert config.request_transformer == TestRequestTransformer
+    end
+
+    test "inline map model specs are evaluated and forwarded into strategy config" do
+      agent = AgentWithInlineModelMap.new()
+      state = StratState.get(agent, %{})
+      config = state[:config]
+
+      assert config.model == %{provider: :openai, id: "gpt-4o-mini", base_url: "http://localhost:4000/v1"}
+    end
+
+    test "tuple model specs are evaluated and forwarded into strategy config" do
+      agent = AgentWithTupleModelSpec.new()
+      state = StratState.get(agent, %{})
+      config = state[:config]
+
+      assert config.model == {:openai, "gpt-4o-mini", []}
     end
 
     test "stream_timeout_ms alias is forwarded into strategy config" do

--- a/test/jido_ai/react/public_api_test.exs
+++ b/test/jido_ai/react/public_api_test.exs
@@ -23,6 +23,16 @@ defmodule Jido.AI.Reasoning.ReAct.PublicApiTest do
       passthrough = ReAct.build_config(built)
       assert passthrough == built
     end
+
+    test "accepts ReqLLM inline, tuple, and struct model specs" do
+      inline_model = %{provider: :openai, id: "gpt-4o-mini", base_url: "http://localhost:4000/v1"}
+      tuple_model = {:openai, "gpt-4o-mini", []}
+      struct_model = ReqLLM.model!(inline_model)
+
+      assert ReAct.build_config(%{model: inline_model, tools: %{}}).model == inline_model
+      assert ReAct.build_config(%{model: tuple_model, tools: %{}}).model == tuple_model
+      assert ReAct.build_config(%{model: struct_model, tools: %{}}).model == struct_model
+    end
   end
 
   describe "stream APIs" do

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -201,6 +201,29 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     assert Enum.any?(events, &(&1.kind == :checkpoint and &1.data.reason == :terminal))
   end
 
+  test "passes inline model specs through to ReqLLM requests" do
+    inline_model = %{provider: :openai, id: "gpt-4o-mini", base_url: "http://localhost:4000/v1"}
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      assert model == inline_model
+
+      {:ok,
+       responses_stream_response(
+         [ReqLLM.StreamChunk.text("Hello from inline model")],
+         %{finish_reason: :stop, usage: %{input_tokens: 3, output_tokens: 2}},
+         model
+       )}
+    end)
+
+    config = Config.new(%{model: inline_model, tools: %{}})
+
+    events =
+      ReAct.stream("Say hello", config, request_id: "req_inline_model", run_id: "run_inline_model")
+      |> Enum.to_list()
+
+    assert Enum.any?(events, &(&1.kind == :request_completed))
+  end
+
   test "uses non-streaming generation when streaming is disabled" do
     Mimic.stub(ReqLLM.Generation, :stream_text, fn _model, _messages, _opts ->
       flunk("stream_text should not be called when ReAct streaming is disabled")

--- a/test/jido_ai/react/token_test.exs
+++ b/test/jido_ai/react/token_test.exs
@@ -81,6 +81,17 @@ defmodule Jido.AI.Reasoning.ReAct.TokenTest do
     assert {:error, :token_config_mismatch} = Token.decode(token, config_b)
   end
 
+  test "fingerprint supports inline model specs" do
+    config =
+      Config.new(%{
+        model: %{provider: :openai, id: "gpt-4o-mini", base_url: "http://localhost:4000/v1"},
+        tools: %{},
+        token_secret: "secret-a"
+      })
+
+    assert is_binary(Config.fingerprint(config))
+  end
+
   test "rejects expired tokens" do
     config = Config.new(%{model: :capable, tools: %{}, token_secret: "secret-a", token_ttl_ms: 1})
     state = State.new("hello", nil, request_id: "req_4", run_id: "run_4")


### PR DESCRIPTION
## Summary
- allow agent macros to evaluate and preserve ReqLLM map and tuple model specs at compile time
- normalize ReAct and related reasoning strategies through a shared model-input helper instead of string-only handling
- add regressions covering inline maps, tuple specs, structs, runtime forwarding, and checkpoint fingerprints

## Testing
- mix precommit
- mix test test/jido_ai/agent_test.exs test/jido_ai/react/public_api_test.exs test/jido_ai/react/token_test.exs test/jido_ai/react/runtime_runner_test.exs
- mix test test/jido_ai/aot_agent_test.exs test/jido_ai/cot_agent_test.exs test/jido_ai/got_agent_test.exs test/jido_ai/tot_agent_test.exs test/jido_ai/adaptive_agent_test.exs test/jido_ai/trm_agent_test.exs test/jido_ai/react_agent_test.exs test/jido_ai/strategy/algorithm_of_thoughts_test.exs test/jido_ai/strategy/adaptive_test.exs test/jido_ai/strategy/chain_of_thought_test.exs test/jido_ai/strategy/graph_of_thoughts_test.exs test/jido_ai/strategy/tree_of_thoughts_test.exs test/jido_ai/strategy/trm_test.exs

Closes #202