### PR TITLE
feat(context): carry refs through context entries and projection

### DIFF
--- a/lib/jido_ai/context.ex
+++ b/lib/jido_ai/context.ex
@@ -124,9 +124,10 @@ defmodule Jido.AI.Context do
   @doc """
   Append a tool result to the thread.
   """
-  @spec append_tool_result(t(), String.t(), String.t(), String.t() | [ContentPart.t()]) :: t()
-  def append_tool_result(thread, tool_call_id, name, content) do
-    append(thread, %Entry{role: :tool, tool_call_id: tool_call_id, name: name, content: content})
+  @spec append_tool_result(t(), String.t(), String.t(), String.t() | [ContentPart.t()], keyword()) :: t()
+  def append_tool_result(thread, tool_call_id, name, content, opts \\ []) do
+    refs = Keyword.get(opts, :refs)
+    append(thread, %Entry{role: :tool, tool_call_id: tool_call_id, name: name, content: content, refs: refs})
   end
 
   @doc """
@@ -459,7 +460,8 @@ defmodule Jido.AI.Context do
       reasoning_details: get_field(msg, :reasoning_details, "reasoning_details"),
       tool_calls: get_field(msg, :tool_calls, "tool_calls"),
       tool_call_id: get_field(msg, :tool_call_id, "tool_call_id"),
-      name: get_field(msg, :name, "name")
+      name: get_field(msg, :name, "name"),
+      refs: normalize_entry_refs(get_field(msg, :refs, "refs"))
     }
   end
 
@@ -611,9 +613,13 @@ defmodule Jido.AI.Context do
       tool_calls: get_field(entry, :tool_calls),
       tool_call_id: get_field(entry, :tool_call_id),
       name: get_field(entry, :name),
-      timestamp: get_field(entry, :timestamp)
+      timestamp: get_field(entry, :timestamp),
+      refs: normalize_entry_refs(get_field(entry, :refs))
     }
   end
+
+  defp normalize_entry_refs(refs) when is_map(refs) and map_size(refs) > 0, do: refs
+  defp normalize_entry_refs(_refs), do: nil
 
   defp generate_id do
     :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -1146,7 +1146,8 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
               context,
               tool_call_id,
               name,
-              normalize_content(fetch_map_value(payload, :content))
+              normalize_content(fetch_map_value(payload, :content)),
+              refs: normalize_refs(refs)
             )
 
           _ ->
@@ -1403,11 +1404,13 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
             }
           end)
 
+        refs = runtime_event_refs(event, request_id)
+
         updated =
           base_state
           |> Map.put(:status, if(turn_type == :tool_calls, do: :awaiting_tool, else: :completed))
           |> Map.put(:pending_tool_calls, pending_tool_calls)
-          |> append_assistant_to_run_context(turn_type, text, tool_calls, thinking_content, reasoning_details)
+          |> append_assistant_to_run_context(turn_type, text, tool_calls, thinking_content, reasoning_details, refs)
           |> Map.update(:usage, usage || %{}, fn existing -> merge_usage(existing, usage || %{}) end)
           |> maybe_append_thinking_trace(thinking_content)
           |> maybe_put_result(turn_type, text)
@@ -1438,12 +1441,14 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
         tool_name = event_field(data, :tool_name, event_field(event, :tool_name, ""))
         tool_result = normalize_tool_result(event_field(data, :result, {:error, :unknown, []}))
 
+        refs = runtime_event_refs(event, request_id)
+
         updated =
           base_state
           |> Map.update(:pending_tool_calls, [], fn pending ->
             Enum.map(pending, fn tc -> if tc.id == tool_call_id, do: %{tc | result: tool_result}, else: tc end)
           end)
-          |> append_tool_result_to_run_context(tool_call_id, tool_name, tool_result)
+          |> append_tool_result_to_run_context(tool_call_id, tool_name, tool_result, refs)
 
         signal = Signal.ToolResult.new!(%{call_id: tool_call_id, tool_name: tool_name, result: tool_result})
         {updated, [signal]}
@@ -1746,7 +1751,15 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     end
   end
 
-  defp append_assistant_to_run_context(state, turn_type, text, tool_calls, thinking_content, reasoning_details) do
+  defp append_assistant_to_run_context(
+         state,
+         turn_type,
+         text,
+         tool_calls,
+         thinking_content,
+         reasoning_details,
+         refs
+       ) do
     context = Map.get(state, :run_context) || Map.get(state, :context)
 
     case context do
@@ -1757,6 +1770,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           []
           |> maybe_put_assistant_context_opt(:thinking, thinking_content)
           |> maybe_put_assistant_context_opt(:reasoning_details, reasoning_details)
+          |> maybe_put_assistant_context_opt(:refs, normalize_refs(refs))
 
         Map.put(state, :run_context, AIContext.append_assistant(context, text, assistant_tool_calls, assistant_opts))
 
@@ -1765,13 +1779,18 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     end
   end
 
-  defp append_tool_result_to_run_context(state, tool_call_id, tool_name, tool_result) do
+  defp append_tool_result_to_run_context(state, tool_call_id, tool_name, tool_result, refs) do
     context = Map.get(state, :run_context) || Map.get(state, :context)
 
     case context do
       %AIContext{} = context when is_binary(tool_call_id) and is_binary(tool_name) ->
         content = Turn.format_tool_result_content(tool_result)
-        Map.put(state, :run_context, AIContext.append_tool_result(context, tool_call_id, tool_name, content))
+
+        Map.put(
+          state,
+          :run_context,
+          AIContext.append_tool_result(context, tool_call_id, tool_name, content, refs: normalize_refs(refs))
+        )
 
       _ ->
         state
@@ -1781,6 +1800,14 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   defp maybe_put_assistant_context_opt(opts, _key, nil), do: opts
   defp maybe_put_assistant_context_opt(opts, _key, ""), do: opts
   defp maybe_put_assistant_context_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp runtime_event_refs(event, fallback_request_id) do
+    %{}
+    |> maybe_put_ref(:request_id, event_field(event, :request_id, fallback_request_id))
+    |> maybe_put_ref(:run_id, event_field(event, :run_id, fallback_request_id))
+    |> maybe_put_ref(:signal_id, event_field(event, :id))
+    |> normalize_refs()
+  end
 
   defp commit_run_context(state) do
     case Map.get(state, :run_context) do

--- a/test/jido_ai/context_refs_test.exs
+++ b/test/jido_ai/context_refs_test.exs
@@ -30,6 +30,18 @@ defmodule JidoAI.ContextRefsTest do
       assert msg.refs == %{slack_ts: "1234.001"}
     end
 
+    test "to_messages preserves refs on tool messages" do
+      ctx =
+        Context.new()
+        |> Context.append_tool_result("tc_1", "calculator", ~s({"result": 3}), refs: %{signal_id: "evt_3"})
+
+      [msg] = Context.to_messages(ctx)
+
+      assert msg.role == :tool
+      assert msg.tool_call_id == "tc_1"
+      assert msg.refs == %{signal_id: "evt_3"}
+    end
+
     test "to_messages omits refs key when nil" do
       ctx =
         Context.new()
@@ -66,6 +78,59 @@ defmodule JidoAI.ContextRefsTest do
       msgs = Context.to_messages(ctx)
       refs = Enum.map(msgs, &Map.get(&1, :refs, :none))
       assert refs == [%{slack_ts: "1.0"}, :none, %{slack_ts: "3.0"}]
+    end
+
+    test "append_messages preserves refs from imported histories" do
+      msgs = [
+        %{role: :user, content: "hello", refs: %{slack_ts: "1.0"}},
+        %{role: :assistant, content: "hi", refs: %{slack_ts: "2.0"}},
+        %{
+          role: :tool,
+          tool_call_id: "tc_1",
+          name: "calculator",
+          content: ~s({"result": 3}),
+          refs: %{signal_id: "evt_3"}
+        }
+      ]
+
+      ctx = Context.new() |> Context.append_messages(msgs)
+
+      assert Enum.map(Context.to_messages(ctx), &Map.get(&1, :refs)) == [
+               %{slack_ts: "1.0"},
+               %{slack_ts: "2.0"},
+               %{signal_id: "evt_3"}
+             ]
+    end
+
+    test "coerce preserves refs from serialized context entries" do
+      raw = %{
+        id: "ctx_1",
+        entries: [
+          %{
+            role: :tool,
+            tool_call_id: "tc_1",
+            name: "calculator",
+            content: ~s({"result": 3}),
+            refs: %{signal_id: "evt_3"}
+          },
+          %{role: :user, content: "hello", refs: %{slack_ts: "1.0"}}
+        ],
+        system_prompt: "You are helpful."
+      }
+
+      assert {:ok, ctx} = Context.coerce(raw)
+
+      assert Context.to_messages(ctx) == [
+               %{role: :system, content: "You are helpful."},
+               %{role: :user, content: "hello", refs: %{slack_ts: "1.0"}},
+               %{
+                 role: :tool,
+                 tool_call_id: "tc_1",
+                 name: "calculator",
+                 content: ~s({"result": 3}),
+                 refs: %{signal_id: "evt_3"}
+               }
+             ]
     end
   end
 end

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -539,7 +539,12 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
 
       assert history == [
                %{role: :user, content: "Who am I?"},
-               %{role: :assistant, content: "You asked who you are.", reasoning_details: reasoning_details},
+               %{
+                 role: :assistant,
+                 content: "You asked who you are.",
+                 reasoning_details: reasoning_details,
+                 refs: %{request_id: "req_turn_1", run_id: "req_turn_1", signal_id: "evt_2"}
+               },
                %{role: :user, content: "What did I just ask?"}
              ]
     end
@@ -576,7 +581,11 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
 
       assert conversation == [
                %{role: :user, content: "Track this"},
-               %{role: :assistant, content: "Tracked"}
+               %{
+                 role: :assistant,
+                 content: "Tracked",
+                 refs: %{request_id: "req_snap", run_id: "req_snap", signal_id: "evt_2"}
+               }
              ]
     end
 
@@ -1269,6 +1278,51 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
       user_msg = Enum.find(messages, &(&1.role == :user))
       assert user_msg != nil
       assert user_msg.refs == %{slack_ts: "1234.001"}
+    end
+
+    test "runtime assistant and tool messages retain refs in run context" do
+      agent = create_agent(tools: [TestCalculator])
+
+      start_instruction =
+        Jido.Agent.Strategy.normalize_instruction(
+          ReAct,
+          instruction(ReAct.start_action(), %{
+            query: "hello",
+            request_id: "req_runtime_refs"
+          }),
+          %{}
+        )
+
+      {agent, [_spawn]} = ReAct.cmd(agent, [start_instruction], %{})
+
+      events = [
+        runtime_event(:llm_completed, "req_runtime_refs", 2, %{
+          turn_type: :tool_calls,
+          text: "",
+          thinking_content: nil,
+          reasoning_details: nil,
+          tool_calls: [%{id: "tc_1", name: "calculator", arguments: %{operation: "add", a: 1, b: 2}}],
+          usage: %{}
+        }),
+        runtime_event(:tool_completed, "req_runtime_refs", 3, %{
+          tool_call_id: "tc_1",
+          tool_name: "calculator",
+          result: {:ok, %{result: 3}, []}
+        })
+      ]
+
+      {agent, []} =
+        Enum.reduce(events, {agent, []}, fn event, {acc, _} ->
+          ReAct.cmd(acc, [instruction(:ai_react_worker_event, %{request_id: "req_runtime_refs", event: event})], %{})
+        end)
+
+      messages = Jido.AI.Context.to_messages(agent.state.__strategy__.run_context)
+
+      assistant_msg = Enum.find(messages, &(&1.role == :assistant))
+      tool_msg = Enum.find(messages, &(&1.role == :tool))
+
+      assert assistant_msg.refs == %{request_id: "req_runtime_refs", run_id: "req_runtime_refs", signal_id: "evt_2"}
+      assert tool_msg.refs == %{request_id: "req_runtime_refs", run_id: "req_runtime_refs", signal_id: "evt_3"}
     end
 
     test "extra_refs cannot override reserved thread entry refs" do


### PR DESCRIPTION
Add refs field to `Context.Entry` so metadata (like external message identifiers) can travel from thread entries through the context projection into LLM messages. Strategy projection now passes refs from thread entries when building context. Run context includes `extra_refs` on user message entries.

Follow-up to #211