### PR TITLE
fix(context): avoid Bedrock 400 on blank assistant content

### DIFF
--- a/lib/jido_ai/context.ex
+++ b/lib/jido_ai/context.ex
@@ -107,18 +107,25 @@ defmodule Jido.AI.Context do
   """
   @spec append_assistant(t(), String.t() | nil, list() | nil, keyword()) :: t()
   def append_assistant(thread, content, tool_calls \\ nil, opts \\ []) do
-    thinking = Keyword.get(opts, :thinking)
-    reasoning_details = Keyword.get(opts, :reasoning_details)
-    refs = Keyword.get(opts, :refs)
+    has_text = is_binary(content) and content != ""
+    has_tools = is_list(tool_calls) and tool_calls != []
 
-    append(thread, %Entry{
-      role: :assistant,
-      content: content,
-      tool_calls: tool_calls,
-      thinking: thinking,
-      reasoning_details: reasoning_details,
-      refs: refs
-    })
+    if not has_text and not has_tools do
+      thread
+    else
+      thinking = Keyword.get(opts, :thinking)
+      reasoning_details = Keyword.get(opts, :reasoning_details)
+      refs = Keyword.get(opts, :refs)
+
+      append(thread, %Entry{
+        role: :assistant,
+        content: if(has_text, do: content),
+        tool_calls: tool_calls,
+        thinking: thinking,
+        reasoning_details: reasoning_details,
+        refs: refs
+      })
+    end
   end
 
   @doc """

--- a/test/jido_ai/thread_test.exs
+++ b/test/jido_ai/thread_test.exs
@@ -86,7 +86,38 @@ defmodule Jido.AI.ContextTest do
       assert AIContext.length(thread) == 1
       [entry] = thread.entries
       assert entry.role == :assistant
-      assert entry.content == ""
+      assert entry.content == nil
+      assert entry.tool_calls == tool_calls
+    end
+  end
+
+  describe "append_assistant with blank content" do
+    test "skips append when content is empty and no tool calls" do
+      thread =
+        AIContext.new()
+        |> AIContext.append_assistant("")
+
+      assert AIContext.length(thread) == 0
+    end
+
+    test "skips append when content is nil and no tool calls" do
+      thread =
+        AIContext.new()
+        |> AIContext.append_assistant(nil)
+
+      assert AIContext.length(thread) == 0
+    end
+
+    test "keeps tool calls but drops blank text" do
+      tool_calls = [%{id: "tc_1", name: "acknowledge", arguments: %{}}]
+
+      thread =
+        AIContext.new()
+        |> AIContext.append_assistant("", tool_calls)
+
+      assert AIContext.length(thread) == 1
+      [entry] = thread.entries
+      assert entry.content == nil
       assert entry.tool_calls == tool_calls
     end
   end


### PR DESCRIPTION
Bedrock rejects `ContentBlock` with empty text field. Set content to nil (omitted from payload) instead of `""` when assistant entry has tool calls but no text. Skip appending entirely when both content and tool calls are absent.