### PR TITLE
fix(agent): evaluate module attribute AST for system_prompt option

### DIFF
--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -224,6 +224,28 @@ defmodule Jido.AI.Agent do
     end
   end
 
+  @doc false
+  def normalize_system_prompt_value(value, file, line) do
+    case value do
+      nil -> :absent
+      false -> :absent
+      "" -> :absent
+      value when is_binary(value) -> {:resolved, value}
+      other -> raise_invalid_system_prompt!(other, file, line)
+    end
+  end
+
+  defp raise_invalid_system_prompt!(value, file, line) do
+    raise CompileError,
+      description:
+        "system_prompt must be a binary, nil, false, or a compile-time literal/module attribute resolving to one, got: #{inspect(value)}",
+      file: file,
+      line: line
+  end
+
+  defp system_prompt_line({_, meta, _}, default), do: Keyword.get(meta, :line, default)
+  defp system_prompt_line(_, default), do: default
+
   defmacro __using__(opts) do
     # Extract all values at compile time (in the calling module's context)
     name = Keyword.fetch!(opts, :name)
@@ -239,17 +261,27 @@ defmodule Jido.AI.Agent do
 
     description = Keyword.get(opts, :description, "AI agent #{name}")
     tags = Keyword.get(opts, :tags, [])
-    # system_prompt may arrive as a string literal or as AST (e.g. @attr).
-    # AST forms like module attributes can only be resolved in the calling
-    # module's compile context, so we defer them to the quote block via
-    # strategy_opts_ast below. For strings and nil we resolve eagerly.
     system_prompt_raw = Keyword.get(opts, :system_prompt)
+    system_prompt_line = system_prompt_line(system_prompt_raw, __CALLER__.line)
 
     system_prompt =
       case system_prompt_raw do
-        nil -> nil
-        val when is_binary(val) -> val
-        _ast -> :deferred
+        {:@, _, [{_name, _, _}]} = attr_ast ->
+          {:deferred, attr_ast}
+
+        other ->
+          expanded = Macro.expand(other, __CALLER__)
+
+          if Macro.quoted_literal?(expanded) do
+            {resolved, _binding} = Code.eval_quoted(expanded, [], __CALLER__)
+            __MODULE__.normalize_system_prompt_value(resolved, __CALLER__.file, system_prompt_line)
+          else
+            raise CompileError,
+              description:
+                "system_prompt only supports binaries, nil, false, compile-time literal expressions, or bare module attributes",
+              file: __CALLER__.file,
+              line: system_prompt_line
+          end
       end
 
     model =
@@ -350,20 +382,27 @@ defmodule Jido.AI.Agent do
       ]
       |> then(fn o ->
         case system_prompt do
-          :deferred -> o  # Will be added in the quote block
-          nil -> o
-          val -> Keyword.put(o, :system_prompt, val)
+          :absent -> o
+          {:resolved, value} -> Keyword.put(o, :system_prompt, value)
+          {:deferred, _attr_ast} -> o
         end
       end)
 
-    # For deferred system_prompt (AST like @attr), build an AST expression
-    # that merges it into strategy_opts at compile time in the calling module's
-    # context, where the attribute is actually accessible.
     strategy_opts_ast =
       case system_prompt do
-        :deferred ->
+        {:deferred, attr_ast} ->
           quote do
-            unquote(Macro.escape(strategy_opts)) ++ [system_prompt: unquote(system_prompt_raw)]
+            case unquote(__MODULE__).normalize_system_prompt_value(
+                   unquote(attr_ast),
+                   __ENV__.file,
+                   unquote(system_prompt_line)
+                 ) do
+              :absent ->
+                unquote(Macro.escape(strategy_opts))
+
+              {:resolved, value} ->
+                Keyword.put(unquote(Macro.escape(strategy_opts)), :system_prompt, value)
+            end
           end
 
         _ ->

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -1877,7 +1877,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       reqllm_tools: reqllm_tools,
       actions_by_name: actions_by_name,
       request_transformer: validate_request_transformer_opt!(Keyword.get(opts, :request_transformer)),
-      system_prompt: Keyword.get(opts, :system_prompt, @default_system_prompt),
+      system_prompt: normalize_system_prompt_opt(opts),
       model: resolved_model,
       max_iterations: Keyword.get(opts, :max_iterations, @default_max_iterations),
       max_tokens: Keyword.get(opts, :max_tokens, @default_max_tokens),
@@ -1910,6 +1910,22 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       base_llm_opts: opts |> Keyword.get(:llm_opts, []) |> normalize_llm_opts(provider_opt_keys_by_string),
       provider_opt_keys_by_string: provider_opt_keys_by_string
     }
+  end
+
+  defp normalize_system_prompt_opt(opts) do
+    case Keyword.fetch(opts, :system_prompt) do
+      :error ->
+        @default_system_prompt
+
+      {:ok, prompt} when is_binary(prompt) and prompt != "" ->
+        prompt
+
+      {:ok, prompt} when prompt in [nil, false, ""] ->
+        nil
+
+      {:ok, other} ->
+        raise ArgumentError, "invalid system_prompt: expected binary, nil, or false, got #{inspect(other)}"
+    end
   end
 
   defp resolve_model_spec(model), do: Jido.AI.ModelInput.normalize!(model)

--- a/test/jido_ai/agent_test.exs
+++ b/test/jido_ai/agent_test.exs
@@ -140,6 +140,20 @@ defmodule Jido.AI.AgentTest do
       system_prompt: @my_prompt
   end
 
+  defmodule AgentWithFalseSystemPrompt do
+    use Jido.AI.Agent,
+      name: "agent_with_false_prompt",
+      tools: [TestCalculator],
+      system_prompt: false
+  end
+
+  defmodule AgentWithNilSystemPrompt do
+    use Jido.AI.Agent,
+      name: "agent_with_nil_prompt",
+      tools: [TestCalculator],
+      system_prompt: nil
+  end
+
   # ============================================================================
   # expand_aliases_in_ast/2 Tests
   # ============================================================================
@@ -316,6 +330,39 @@ defmodule Jido.AI.AgentTest do
       config = state[:config]
 
       assert config.system_prompt == "You are a helpful testing assistant."
+    end
+
+    test "false system_prompt is treated as omitted" do
+      default_config = StratState.get(BasicAgent.new(), %{})[:config]
+      config = StratState.get(AgentWithFalseSystemPrompt.new(), %{})[:config]
+
+      assert config.system_prompt == default_config.system_prompt
+    end
+
+    test "nil system_prompt is treated as omitted" do
+      default_config = StratState.get(BasicAgent.new(), %{})[:config]
+      config = StratState.get(AgentWithNilSystemPrompt.new(), %{})[:config]
+
+      assert config.system_prompt == default_config.system_prompt
+    end
+
+    test "raises when module attribute system_prompt does not resolve to a binary" do
+      module_name = Module.concat(__MODULE__, :"InvalidPromptAgent#{System.unique_integer([:positive, :monotonic])}")
+
+      source = """
+      defmodule #{inspect(module_name)} do
+        @prompt 123
+
+        use Jido.AI.Agent,
+          name: "invalid_prompt_agent",
+          tools: [#{inspect(TestCalculator)}],
+          system_prompt: @prompt
+      end
+      """
+
+      assert_raise CompileError, ~r/system_prompt must be a binary, nil, false/, fn ->
+        Code.compile_string(source)
+      end
     end
 
     test "tools list resolves module aliases" do

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -89,6 +89,20 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
         create_agent(tools: [TestCalculator], request_transformer: :not_a_module)
       end
     end
+
+    test "treats false system_prompt as no prompt for direct strategy callers" do
+      agent = create_agent(tools: [TestCalculator], system_prompt: false)
+      state = StratState.get(agent, %{})
+
+      assert state.config.system_prompt == nil
+      assert state.context.system_prompt == nil
+    end
+
+    test "raises for non-binary system_prompt values" do
+      assert_raise ArgumentError, ~r/invalid system_prompt/, fn ->
+        create_agent(tools: [TestCalculator], system_prompt: 123)
+      end
+    end
   end
 
   describe "signal_routes/1" do


### PR DESCRIPTION
The `__using__` macro extracts `system_prompt` from opts as raw AST at macro expansion time. String literals are self-quoting so they work, but module attribute references like `@base_system_prompt` produce `{:@, _, [{:attr_name, _, nil}]}` AST that gets passed through `Macro.escape` as a literal tuple.

This causes a `CaseClauseError` in `Context.to_messages/2` when `build_snapshot_details` serializes the thread — the case clause only handles `nil` and binary `system_prompt` values:

```
** (CaseClauseError) no case clause matching:
    {:@, [line: 41, column: 20], [{:base_system_prompt, [line: 41, column: 21], nil}]}

    (jido_ai) lib/jido_ai/context.ex:153: Jido.AI.Context.to_messages/2
    (jido_ai) lib/jido_ai/reasoning/react/strategy.ex:336: ...build_snapshot_details/2
```

## Fix

Resolve module attribute references via `Module.get_attribute` at macro expansion time, with a `Code.eval_quoted` fallback for other expressions. This matches how other options (`tools`, `req_http_options`, `tool_context`) already handle AST evaluation.

## Reproduction

```elixir
@my_prompt "You are a helpful assistant."

use Jido.AI.Agent,
  name: "my_agent",
  tools: [],
  system_prompt: @my_prompt  # crashes without this fix
```

Closes #216