### PR TITLE
fix(tool_adapter): ensure modules are loaded before validating

### DIFF
--- a/lib/jido_ai/tool_adapter.ex
+++ b/lib/jido_ai/tool_adapter.ex
@@ -247,6 +247,7 @@ defmodule Jido.AI.ToolAdapter do
 
   defp validate_action_module(module) do
     cond do
+      not Code.ensure_loaded?(module) -> {:error, :not_loaded}
       not function_exported?(module, :name, 0) -> {:error, :missing_name}
       not function_exported?(module, :description, 0) -> {:error, :missing_description}
       not function_exported?(module, :schema, 0) -> {:error, :missing_schema}

--- a/test/jido_ai/tool_adapter_test.exs
+++ b/test/jido_ai/tool_adapter_test.exs
@@ -178,6 +178,14 @@ defmodule Jido.AI.ToolAdapterTest do
       assert {:error, {:invalid_action, NotAnAction, _reason}} =
                ToolAdapter.validate_actions([ParamAction, NotAnAction])
     end
+
+    test "returns :not_loaded for a module that cannot be loaded" do
+      # Before the fix, a non-existent module would return :missing_name
+      # because function_exported?/3 returns false for unloaded modules.
+      # After the fix, it correctly returns :not_loaded.
+      assert {:error, {:invalid_action, This.Module.Does.Not.Exist, :not_loaded}} =
+               ToolAdapter.validate_actions([This.Module.Does.Not.Exist])
+    end
   end
 
   describe "to_action_map/1" do


### PR DESCRIPTION
`validate_action_module/1` calls `function_exported?/3` without first
calling `Code.ensure_loaded?/1`. This causes compile-time generated
modules (e.g. from AshJido) to fail validation with `:missing_name`
errors when they have not been loaded into the calling process yet.

The sibling function `valid_action_module?/1` in the same file already
handles this correctly by calling `Code.ensure_loaded?/1` first.
