### PR TITLE
feat: split out AI tool error contract

### DIFF
--- a/guides/developer/directives_runtime_contract.md
+++ b/guides/developer/directives_runtime_contract.md
@@ -46,6 +46,18 @@ Runtime-emitted failures for `ai.llm.response` and `ai.tool.result` normalize to
 Legacy error shapes may still enter at boundaries, but runtime helpers normalize
 them before the signal leaves the runtime layer.
 
+## Tool Result Content Contract
+
+For model follow-up turns, the canonical tool result semantics should be
+represented in the content body:
+
+- success: `%{ok: true, result: ...}`
+- failure: `%{ok: false, error: %{type: ..., message: ..., details: ..., retryable?: ...}}`
+
+Runtime may also preserve native outputs in metadata for adapters and local
+tooling, but metadata is supplementary and should not be the only place the
+result meaning exists.
+
 ## Contract Rules
 
 - Directives describe work; they do not own strategy state transitions.

--- a/lib/jido_ai/directive/emit_tool_error.ex
+++ b/lib/jido_ai/directive/emit_tool_error.ex
@@ -15,7 +15,8 @@ defmodule Jido.AI.Directive.EmitToolError do
             %{
               id: Zoi.string(description: "Tool call ID from LLM (ReqLLM.ToolCall.id)"),
               tool_name: Zoi.string(description: "Name of the tool that could not be resolved"),
-              error: Zoi.any(description: "Error tuple or map describing the failure")
+              error: Zoi.any(description: "Error tuple or map describing the failure"),
+              metadata: Zoi.map(description: "Optional correlation metadata") |> Zoi.default(%{})
             },
             coerce: true
           )
@@ -45,6 +46,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.EmitToolError do
   """
 
   alias Jido.AI.Signal
+  alias Jido.AI.Signal.Helpers, as: SignalHelpers
 
   def exec(directive, _input_signal, state) do
     %{
@@ -54,13 +56,17 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.EmitToolError do
     } = directive
 
     agent_pid = self()
+    metadata = Map.get(directive, :metadata, %{})
 
     # Emit the error result synchronously (no task needed)
     signal =
       Signal.ToolResult.new!(%{
         call_id: call_id,
         tool_name: tool_name,
-        result: {:error, error}
+        result:
+          {:error,
+           SignalHelpers.normalize_error(error, :execution_error, "Tool execution failed", %{tool_name: tool_name}), []},
+        metadata: metadata
       })
 
     Jido.AgentServer.cast(agent_pid, signal)

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -10,6 +10,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   alias Jido.AI.Effects
   alias Jido.AI.Context, as: AIContext
   alias Jido.AI.ModelInput
+  alias Jido.AI.Signal.Helpers, as: SignalHelpers
   alias Jido.AI.Turn
   alias Jido.Agent.State, as: AgentState
 
@@ -708,7 +709,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     max_retries = normalize_retry_count(config.tool_exec[:max_retries])
     backoff_ms = normalize_backoff(config.tool_exec[:retry_backoff_ms])
 
-    case retryable?(result) and attempt <= max_retries do
+    case SignalHelpers.retryable?(result) and attempt <= max_retries do
       true ->
         case backoff_ms > 0 do
           true -> Process.sleep(backoff_ms)
@@ -721,13 +722,6 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
         {pending_call, result, attempt, duration_ms}
     end
   end
-
-  defp retryable?({:ok, _, _}), do: false
-
-  defp retryable?({:error, %{type: :timeout}, _}), do: true
-  defp retryable?({:error, %{type: :exception}, _}), do: true
-  defp retryable?({:error, %{type: :execution_error}, _}), do: true
-  defp retryable?({:error, _, _}), do: false
 
   defp finalize(%State{} = state, owner, ref, %Config{} = config) do
     {state, _token} = emit_checkpoint(state, owner, ref, config, :terminal)

--- a/lib/jido_ai/reasoning/tree_of_thoughts/strategy.ex
+++ b/lib/jido_ai/reasoning/tree_of_thoughts/strategy.ex
@@ -73,6 +73,7 @@ defmodule Jido.AI.Reasoning.TreeOfThoughts.Strategy do
   alias Jido.AI.Directive
   alias Jido.AI.Effects
   alias Jido.AI.Reasoning.Helpers
+  alias Jido.AI.Signal.Helpers, as: SignalHelpers
   alias Jido.AI.Reasoning.TreeOfThoughts.Machine
   alias Jido.AI.ToolAdapter
   alias Jido.AI.Turn
@@ -528,7 +529,15 @@ defmodule Jido.AI.Reasoning.TreeOfThoughts.Strategy do
                 Directive.EmitToolError.new!(%{
                   id: call.call_id,
                   tool_name: call.tool_name,
-                  error: %{type: :not_found, message: "Tool not found: #{call.tool_name}"}
+                  error: %{type: :not_found, message: "Tool not found: #{call.tool_name}"},
+                  metadata: %{
+                    request_id: request_id,
+                    run_id: request_id,
+                    iteration: iteration,
+                    origin: :worker_runtime,
+                    operation: :tool_execute,
+                    strategy: :tot
+                  }
                 })
 
               module ->
@@ -549,7 +558,13 @@ defmodule Jido.AI.Reasoning.TreeOfThoughts.Strategy do
                   max_retries: config[:tool_max_retries],
                   retry_backoff_ms: config[:tool_retry_backoff_ms],
                   request_id: request_id,
-                  iteration: iteration
+                  iteration: iteration,
+                  metadata: %{
+                    request_id: request_id,
+                    run_id: request_id,
+                    iteration: iteration,
+                    strategy: :tot
+                  }
                 })
             end
           end)
@@ -903,7 +918,7 @@ defmodule Jido.AI.Reasoning.TreeOfThoughts.Strategy do
   defp normalize_map_opt({:%{}, _meta, pairs}) when is_list(pairs), do: Map.new(pairs)
   defp normalize_map_opt(_), do: %{}
 
-  defp normalize_tool_result(result), do: Effects.normalize_result(result)
+  defp normalize_tool_result(result), do: SignalHelpers.normalize_result(result, :tool_error, "Tool execution failed")
 
   defp generate_call_id, do: Machine.generate_call_id()
 

--- a/lib/jido_ai/turn.ex
+++ b/lib/jido_ai/turn.ex
@@ -13,6 +13,7 @@ defmodule Jido.AI.Turn do
   """
 
   alias Jido.AI.{Effects, Observe, ToolAdapter}
+  alias Jido.AI.Signal.Helpers, as: SignalHelpers
   alias Jido.Action.Error.TimeoutError
   alias Jido.Action.Tool, as: ActionTool
   alias ReqLLM.Context
@@ -185,7 +186,13 @@ defmodule Jido.AI.Turn do
           execute_internal(module, tool_name, params, context, timeout, exec_opts)
 
         :error ->
-          {:error, error_envelope(tool_name, :not_found, "Tool not found: #{tool_name}"), []}
+          {:error,
+           SignalHelpers.error_envelope(
+             :not_found,
+             "Tool not found: #{tool_name}",
+             %{tool_name: tool_name},
+             false
+           ), []}
       end
 
     finalize_execute_telemetry(tool_name, result, start_time, context)
@@ -336,30 +343,48 @@ defmodule Jido.AI.Turn do
   def format_tool_result_content({:ok, result, _effects}), do: format_tool_result_content({:ok, result})
   def format_tool_result_content({:error, error, _effects}), do: format_tool_result_content({:error, error})
 
-  def format_tool_result_content({:ok, %ToolResult{} = result}),
-    do: normalize_tool_result_output(result.content, result.output)
+  def format_tool_result_content({:ok, %ToolResult{} = result}) do
+    payload = build_tool_result_payload(result.output, result.content, result.metadata)
+    encode_tool_result_envelope(%{ok: true, result: payload}, normalize_content_parts(result.content))
+  end
 
-  def format_tool_result_content({:ok, result}) when is_binary(result), do: result
+  def format_tool_result_content({:ok, result}) when is_binary(result),
+    do: encode_tool_result_envelope(%{ok: true, result: result})
 
   def format_tool_result_content({:ok, result}) when is_list(result) do
-    if content_parts_list?(result), do: normalize_content_parts(result), else: encode_or_inspect(result)
+    if content_parts_list?(result) do
+      parts = normalize_content_parts(result)
+      encode_tool_result_envelope(%{ok: true, result: %{content: serialize_content_parts(parts)}}, parts)
+    else
+      encode_tool_result_envelope(%{ok: true, result: result})
+    end
   end
 
   def format_tool_result_content({:ok, result}) when is_map(result) do
     case extract_content_parts_result(result) do
-      {:ok, output, parts} -> normalize_tool_result_output(parts, output)
-      :error -> encode_or_inspect(result)
+      {:ok, output, parts} ->
+        encode_tool_result_envelope(%{ok: true, result: build_tool_result_payload(output, parts)}, parts)
+
+      :error ->
+        encode_tool_result_envelope(%{ok: true, result: result})
     end
   end
 
-  def format_tool_result_content({:ok, result}), do: inspect(result)
+  def format_tool_result_content({:ok, result}), do: encode_tool_result_envelope(%{ok: true, result: result})
 
-  def format_tool_result_content({:error, error}) when is_map(error) do
-    get_field(error, :message) || get_field(error, :error) || "Execution failed"
+  def format_tool_result_content({:error, error}) do
+    encode_tool_result_envelope(%{
+      ok: false,
+      error: SignalHelpers.normalize_error(error, :execution_error, "Tool execution failed")
+    })
   end
 
-  def format_tool_result_content({:error, error}), do: inspect(error)
-  def format_tool_result_content(other), do: inspect(other)
+  def format_tool_result_content(other) do
+    encode_tool_result_envelope(%{
+      ok: false,
+      error: SignalHelpers.error_envelope(:invalid_result, "Invalid tool result envelope", %{result: inspect(other)})
+    })
+  end
 
   @doc """
   Converts a turn to a plain result map for public action/plugin outputs.
@@ -536,19 +561,21 @@ defmodule Jido.AI.Turn do
     timeout_ms = reason.timeout || timeout_from_details(reason.details)
     message = Exception.message(reason)
 
-    error_envelope(tool_name, :timeout, message, reason.details || %{})
-    |> Map.put(:timeout_ms, timeout_ms)
+    SignalHelpers.error_envelope(
+      :timeout,
+      message,
+      %{tool_name: tool_name, timeout_ms: timeout_ms}
+      |> Map.merge(reason.details || %{}),
+      true
+    )
   end
 
   defp format_error(tool_name, reason) when is_exception(reason) do
-    message = Exception.message(reason)
-    error_envelope(tool_name, :execution_error, message, %{exception_type: reason.__struct__})
+    SignalHelpers.normalize_error(reason, :execution_error, Exception.message(reason), %{tool_name: tool_name})
   end
 
   defp format_error(tool_name, reason) do
-    message = inspect(reason)
-    details = reason
-    error_envelope(tool_name, :execution_error, message, details)
+    SignalHelpers.normalize_error(reason, :execution_error, "Tool execution failed", %{tool_name: tool_name})
   end
 
   defp format_exception(tool_name, exception, stacktrace) do
@@ -561,25 +588,23 @@ defmodule Jido.AI.Turn do
 
     message = Exception.message(exception)
 
-    error_envelope(tool_name, :exception, message, %{exception_type: exception.__struct__})
-    |> Map.put(:exception_type, exception.__struct__)
+    SignalHelpers.error_envelope(
+      :exception,
+      message,
+      %{tool_name: tool_name, exception_type: exception.__struct__},
+      false
+    )
   end
 
   defp format_catch(tool_name, kind, reason) do
     message = "Caught #{kind}: #{inspect(reason)}"
 
-    error_envelope(tool_name, :caught, message, %{kind: kind})
-    |> Map.put(:kind, kind)
-  end
-
-  defp error_envelope(tool_name, type, message, details \\ nil) do
-    %{
-      error: message,
-      message: message,
-      tool_name: tool_name,
-      type: type,
-      details: details
-    }
+    SignalHelpers.error_envelope(
+      :caught,
+      message,
+      %{tool_name: tool_name, kind: kind, reason: inspect(reason)},
+      false
+    )
   end
 
   defp timeout_from_details(%{} = details), do: get_field(details, :timeout)
@@ -691,7 +716,7 @@ defmodule Jido.AI.Turn do
     raw_result =
       case tool_name do
         "" ->
-          {:error, %{type: :validation, message: "Missing tool name"}, []}
+          {:error, SignalHelpers.error_envelope(:validation, "Missing tool name"), []}
 
         _ ->
           execute(tool_name, arguments, context, exec_opts)
@@ -759,10 +784,28 @@ defmodule Jido.AI.Turn do
     |> Exception.format_stacktrace()
   end
 
-  defp encode_or_inspect(value) do
-    Jason.encode!(value)
-  rescue
-    _ -> inspect(value)
+  defp encode_tool_result_envelope(payload, parts \\ []) when is_map(payload) and is_list(parts) do
+    encoded = Jason.encode!(payload)
+
+    case parts do
+      [] -> encoded
+      normalized_parts -> [ContentPart.text(encoded) | normalized_parts]
+    end
+  end
+
+  defp build_tool_result_payload(output, content, metadata \\ %{}) do
+    payload =
+      %{}
+      |> maybe_add(:output, empty_map_to_nil(output))
+      |> maybe_add(:content, normalize_tool_result_content_payload(content))
+      |> maybe_add(:metadata, empty_map_to_nil(metadata))
+
+    case payload do
+      %{output: result} when map_size(payload) == 1 -> result
+      %{content: result} when map_size(payload) == 1 -> result
+      %{} = map when map_size(map) > 0 -> map
+      _ -> nil
+    end
   end
 
   defp extract_content_parts_result(result) do
@@ -779,22 +822,6 @@ defmodule Jido.AI.Turn do
         :error
     end
   end
-
-  defp normalize_tool_result_output(content, output) do
-    parts = normalize_content_parts(content)
-    encoded_output = maybe_encode_tool_result_output(output)
-
-    cond do
-      parts == [] and is_nil(encoded_output) -> ""
-      parts == [] -> encoded_output
-      is_nil(encoded_output) -> parts
-      true -> [ContentPart.text(encoded_output) | parts]
-    end
-  end
-
-  defp maybe_encode_tool_result_output(nil), do: nil
-  defp maybe_encode_tool_result_output(%{} = map) when map_size(map) == 0, do: nil
-  defp maybe_encode_tool_result_output(output), do: encode_or_inspect(output)
 
   defp normalize_content_parts(parts) when is_list(parts) do
     Enum.flat_map(parts, fn
@@ -883,7 +910,36 @@ defmodule Jido.AI.Turn do
   defp empty_map_to_nil(%{} = map) when map_size(map) == 0, do: nil
   defp empty_map_to_nil(value), do: value
 
-  defp normalize_tool_result_content(content, _raw_result) when is_binary(content), do: content
+  defp normalize_tool_result_content_payload(content) when is_binary(content), do: content
+
+  defp normalize_tool_result_content_payload(content) when is_list(content) do
+    if content_parts_list?(content),
+      do: serialize_content_parts(normalize_content_parts(content)),
+      else: content
+  end
+
+  defp normalize_tool_result_content_payload(nil), do: nil
+  defp normalize_tool_result_content_payload(other), do: other
+
+  defp serialize_content_parts(parts) when is_list(parts) do
+    Enum.map(parts, fn
+      %ContentPart{} = part ->
+        part
+        |> Map.from_struct()
+        |> Enum.reject(fn
+          {:metadata, metadata} -> metadata in [nil, %{}]
+          {_key, value} -> is_nil(value)
+        end)
+        |> Map.new()
+
+      other ->
+        other
+    end)
+  end
+
+  defp normalize_tool_result_content(content, raw_result) when is_binary(content) do
+    if canonical_tool_payload?(content), do: content, else: format_tool_result_content(raw_result)
+  end
 
   defp normalize_tool_result_content(content, _raw_result) when is_list(content) do
     if content_parts_list?(content),
@@ -892,7 +948,18 @@ defmodule Jido.AI.Turn do
   end
 
   defp normalize_tool_result_content(nil, raw_result), do: format_tool_result_content(raw_result)
+
+  defp normalize_tool_result_content(content, _raw_result) when is_map(content),
+    do: encode_tool_result_envelope(%{ok: true, result: build_tool_result_payload(content, nil)})
+
   defp normalize_tool_result_content(_content, raw_result), do: format_tool_result_content(raw_result)
+
+  defp canonical_tool_payload?(content) when is_binary(content) do
+    case Jason.decode(content) do
+      {:ok, %{"ok" => _}} -> true
+      _ -> false
+    end
+  end
 
   defp normalize_raw_result(raw_result), do: Effects.normalize_result(raw_result)
 

--- a/test/jido_ai/directive/deadlock_prevention_test.exs
+++ b/test/jido_ai/directive/deadlock_prevention_test.exs
@@ -50,7 +50,15 @@ defmodule Jido.AI.Directive.DeadlockPreventionTest do
       assert signal.type == "ai.tool.result"
       assert signal.data.call_id == "tc_123"
       assert signal.data.tool_name == "unknown_tool"
-      assert signal.data.result == {:error, {:unknown_tool, "Tool 'unknown_tool' not found"}}
+
+      assert signal.data.result ==
+               {:error,
+                %{
+                  type: :unknown_tool,
+                  message: "Tool 'unknown_tool' not found",
+                  details: %{tool_name: "unknown_tool"},
+                  retryable?: false
+                }, []}
     end
   end
 
@@ -152,7 +160,7 @@ defmodule Jido.AI.Directive.DeadlockPreventionTest do
       assert signal.type == "ai.tool.result"
       assert signal.data.call_id == "tc_123"
       assert signal.data.tool_name == "unknown_tool"
-      assert {:error, {:unknown_tool, _}} = signal.data.result
+      assert {:error, {:unknown_tool, "Tool 'unknown_tool' not found"}} = signal.data.result
     end
 
     test "creates valid ToolResult signal with exception error" do
@@ -163,11 +171,11 @@ defmodule Jido.AI.Directive.DeadlockPreventionTest do
           result:
             {:error,
              %{
-               error: "something went wrong",
-               tool_name: "crashy_tool",
+               message: "something went wrong",
                type: :exception,
-               exception_type: RuntimeError
-             }}
+               details: %{tool_name: "crashy_tool", exception_type: RuntimeError},
+               retryable?: false
+             }, []}
         })
 
       assert signal.type == "ai.tool.result"
@@ -175,11 +183,11 @@ defmodule Jido.AI.Directive.DeadlockPreventionTest do
       assert signal.data.result ==
                {:error,
                 %{
-                  error: "something went wrong",
-                  tool_name: "crashy_tool",
+                  message: "something went wrong",
                   type: :exception,
-                  exception_type: RuntimeError
-                }}
+                  details: %{tool_name: "crashy_tool", exception_type: RuntimeError},
+                  retryable?: false
+                }, []}
     end
   end
 end

--- a/test/jido_ai/executor_test.exs
+++ b/test/jido_ai/executor_test.exs
@@ -4,6 +4,8 @@ defmodule Jido.AI.TurnExecutionTest do
   alias Jido.AI.Turn
   alias ReqLLM.Message.ContentPart
 
+  defp decode_tool_content(content) when is_binary(content), do: Jason.decode!(content)
+
   # Define test Action modules
   defmodule TestActions.Calculator do
     use Jido.Action,
@@ -172,8 +174,8 @@ defmodule Jido.AI.TurnExecutionTest do
         )
 
       assert {:error, error, []} = result
-      assert error.error == "Division by zero"
-      assert error.tool_name == "calculator"
+      assert error.message == "Division by zero"
+      assert error.details.tool_name == "calculator"
       assert error.type == :execution_error
     end
   end
@@ -197,8 +199,8 @@ defmodule Jido.AI.TurnExecutionTest do
       result = Turn.execute("unknown_tool", %{}, %{}, tools: %{})
 
       assert {:error, error, []} = result
-      assert error.error == "Tool not found: unknown_tool"
-      assert error.tool_name == "unknown_tool"
+      assert error.message == "Tool not found: unknown_tool"
+      assert error.details.tool_name == "unknown_tool"
       assert error.type == :not_found
     end
   end
@@ -215,8 +217,8 @@ defmodule Jido.AI.TurnExecutionTest do
 
       assert {:error, error, []} = result
       assert error.type == :timeout
-      assert error.tool_name == "slow_action"
-      assert String.contains?(error.error, "timed out")
+      assert error.details.tool_name == "slow_action"
+      assert String.contains?(error.message, "timed out")
     end
   end
 
@@ -226,8 +228,8 @@ defmodule Jido.AI.TurnExecutionTest do
 
       assert {:error, error, []} = result
       assert error.type == :execution_error
-      assert error.tool_name == "error_action"
-      assert error.error == "test error"
+      assert error.details.tool_name == "error_action"
+      assert error.message == "test error"
     end
 
     test "handles missing required parameters", %{tools: tools} do
@@ -235,9 +237,9 @@ defmodule Jido.AI.TurnExecutionTest do
 
       assert {:error, error, []} = result
       assert error.type == :execution_error
-      assert error.tool_name == "calculator"
+      assert error.details.tool_name == "calculator"
       # Error message should mention missing required option
-      assert String.contains?(error.error, "required")
+      assert String.contains?(error.message, "required")
     end
   end
 
@@ -309,16 +311,45 @@ defmodule Jido.AI.TurnExecutionTest do
 
   describe "format_tool_result_content/1" do
     test "formats common success and error payloads" do
-      assert Turn.format_tool_result_content({:ok, "hello"}) == "hello"
-      assert Turn.format_tool_result_content({:ok, %{value: 1}}) == "{\"value\":1}"
-      assert Turn.format_tool_result_content({:ok, 42}) == "42"
-      assert Turn.format_tool_result_content({:error, %{message: "boom"}}) == "boom"
-      assert Turn.format_tool_result_content({:error, :badarg}) == ":badarg"
+      assert decode_tool_content(Turn.format_tool_result_content({:ok, "hello"})) == %{
+               "ok" => true,
+               "result" => "hello"
+             }
+
+      assert decode_tool_content(Turn.format_tool_result_content({:ok, %{value: 1}})) == %{
+               "ok" => true,
+               "result" => %{"value" => 1}
+             }
+
+      assert decode_tool_content(Turn.format_tool_result_content({:ok, 42})) == %{
+               "ok" => true,
+               "result" => 42
+             }
+
+      assert decode_tool_content(Turn.format_tool_result_content({:error, %{message: "boom"}})) == %{
+               "ok" => false,
+               "error" => %{
+                 "message" => "boom",
+                 "type" => "execution_error",
+                 "retryable?" => false,
+                 "details" => %{}
+               }
+             }
+
+      assert decode_tool_content(Turn.format_tool_result_content({:error, :badarg})) == %{
+               "ok" => false,
+               "error" => %{
+                 "message" => "badarg",
+                 "type" => "execution_error",
+                 "retryable?" => false,
+                 "details" => %{"reason" => "badarg"}
+               }
+             }
     end
 
     test "normalizes map content parts into multimodal tool content" do
       assert [
-               %ContentPart{type: :text, text: "{\"value\":1}"},
+               %ContentPart{type: :text, text: encoded_payload},
                %ContentPart{type: :image_url, url: "https://example.com/chart.png"}
              ] =
                Turn.format_tool_result_content(
@@ -330,6 +361,14 @@ defmodule Jido.AI.TurnExecutionTest do
                     ]
                   }}
                )
+
+      assert Jason.decode!(encoded_payload) == %{
+               "ok" => true,
+               "result" => %{
+                 "output" => %{"value" => 1},
+                 "content" => [%{"type" => "image_url", "url" => "https://example.com/chart.png"}]
+               }
+             }
     end
   end
 
@@ -531,7 +570,7 @@ defmodule Jido.AI.TurnExecutionTest do
 
         assert {:error, error, []} = result
         assert error.type == :execution_error
-        assert error.tool_name == "exception_action2"
+        assert error.details.tool_name == "exception_action2"
 
         refute Map.has_key?(error, :stacktrace)
       end)

--- a/test/jido_ai/integration/tools_phase2_test.exs
+++ b/test/jido_ai/integration/tools_phase2_test.exs
@@ -312,8 +312,8 @@ defmodule Jido.AI.Integration.ToolsPhase2Test do
 
       assert {:error, error, []} = result
       assert error.type == :not_found
-      assert error.tool_name == "nonexistent_tool"
-      assert String.contains?(error.error, "not found")
+      assert error.details.tool_name == "nonexistent_tool"
+      assert String.contains?(error.message, "not found")
     end
 
     test "executor handles tool execution errors gracefully", %{tools: tools} do
@@ -322,8 +322,8 @@ defmodule Jido.AI.Integration.ToolsPhase2Test do
 
       assert {:error, error, []} = result
       assert error.type == :execution_error
-      assert error.tool_name == "failing_action"
-      assert error.error == "Something went wrong"
+      assert error.details.tool_name == "failing_action"
+      assert error.message == "Something went wrong"
     end
 
     test "executor handles validation errors for missing required params", %{tools: tools} do
@@ -332,7 +332,7 @@ defmodule Jido.AI.Integration.ToolsPhase2Test do
 
       assert {:error, error, []} = result
       assert error.type == :execution_error
-      assert String.contains?(error.error, "required")
+      assert String.contains?(error.message, "required")
     end
 
     test "executor normalizes string keys to atom keys", %{tools: tools} do
@@ -367,7 +367,7 @@ defmodule Jido.AI.Integration.ToolsPhase2Test do
 
       assert {:error, error, []} = result
       assert error.type == :timeout
-      assert error.tool_name == "slow_action"
+      assert error.details.tool_name == "slow_action"
     end
 
     test "complete simulated tool calling flow", %{tools: tools} do
@@ -399,7 +399,7 @@ defmodule Jido.AI.Integration.ToolsPhase2Test do
 
       # 4. Format result for tool message content (would be added back to conversation)
       formatted = Turn.format_tool_result_content(result)
-      assert formatted == "{\"result\":56}"
+      assert Jason.decode!(formatted) == %{"ok" => true, "result" => %{"result" => 56}}
     end
 
     test "sequential tool calls maintain state correctly", %{tools: tools} do
@@ -439,8 +439,8 @@ defmodule Jido.AI.Integration.ToolsPhase2Test do
 
       assert {:error, error, []} = result
       assert error.type == :execution_error
-      assert error.tool_name == "calculator"
-      assert error.error == "Division by zero"
+      assert error.details.tool_name == "calculator"
+      assert error.message == "Division by zero"
     end
   end
 

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -29,6 +29,23 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     end
   end
 
+  defmodule NonRetryTool do
+    use Jido.Action,
+      name: "non_retry_tool",
+      description: "Fails with a non-retryable error",
+      schema:
+        Zoi.object(%{
+          value: Zoi.integer()
+        })
+
+    def run(%{value: _value}, _context) do
+      key = {__MODULE__, :attempts}
+      attempt = :persistent_term.get(key, 0) + 1
+      :persistent_term.put(key, attempt)
+      {:error, :badarg}
+    end
+  end
+
   defmodule CalculatorTool do
     use Jido.Action,
       name: "calculator",
@@ -158,6 +175,7 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
   setup do
     on_exit(fn ->
       :persistent_term.erase({RetryTool, :attempts})
+      :persistent_term.erase({NonRetryTool, :attempts})
       :persistent_term.erase({__MODULE__, :llm_call_count})
     end)
 
@@ -699,6 +717,44 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     refute is_nil(tool_completed)
     assert tool_completed.data.attempts == 2
     assert match?({:ok, _, _}, tool_completed.data.result)
+  end
+
+  test "does not retry non-retryable tool failures" do
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      count = :persistent_term.get({__MODULE__, :llm_call_count}, 0) + 1
+      :persistent_term.put({__MODULE__, :llm_call_count}, count)
+
+      if count == 1 do
+        {:ok,
+         responses_stream_response(
+           [ReqLLM.StreamChunk.tool_call("non_retry_tool", %{"value" => 7}, %{id: "tc_non_retry"})],
+           %{finish_reason: :tool_calls, usage: %{input_tokens: 5, output_tokens: 3}},
+           model
+         )}
+      else
+        {:ok,
+         responses_stream_response(
+           [ReqLLM.StreamChunk.text("Tool failed")],
+           %{finish_reason: :stop, usage: %{input_tokens: 2, output_tokens: 1}},
+           model
+         )}
+      end
+    end)
+
+    config =
+      Config.new(%{
+        model: :capable,
+        tools: %{NonRetryTool.name() => NonRetryTool},
+        tool_max_retries: 2,
+        tool_retry_backoff_ms: 0
+      })
+
+    events = ReAct.stream("Run non-retry tool", config) |> Enum.to_list()
+
+    tool_completed = Enum.find(events, &(&1.kind == :tool_completed))
+    refute is_nil(tool_completed)
+    assert tool_completed.data.attempts == 1
+    assert match?({:error, _, _}, tool_completed.data.result)
   end
 
   test "emits tool_completed events in original tool call order for parallel tools" do

--- a/test/jido_ai/turn_test.exs
+++ b/test/jido_ai/turn_test.exs
@@ -6,6 +6,8 @@ defmodule Jido.AI.TurnTest do
 
   @moduletag :unit
 
+  defp decode_tool_content(content) when is_binary(content), do: Jason.decode!(content)
+
   defmodule Calculator do
     use Jido.Action,
       name: "calculator",
@@ -144,22 +146,47 @@ defmodule Jido.AI.TurnTest do
       assert tool_message.role == :tool
       assert tool_message.tool_call_id == "tc_1"
       assert tool_message.name == "calculator"
-      assert Turn.extract_from_content(tool_message.content) == "{\"result\":8}"
+
+      assert decode_tool_content(Turn.extract_from_content(tool_message.content)) == %{
+               "ok" => true,
+               "result" => %{"result" => 8}
+             }
     end
   end
 
   describe "format_tool_result_content/1" do
     test "formats common success and error shapes" do
-      assert Turn.format_tool_result_content({:ok, %{value: 1}}) == "{\"value\":1}"
-      assert Turn.format_tool_result_content({:error, %{message: "boom"}}) == "boom"
-      assert Turn.format_tool_result_content({:error, :badarg}) == ":badarg"
+      assert decode_tool_content(Turn.format_tool_result_content({:ok, %{value: 1}})) == %{
+               "ok" => true,
+               "result" => %{"value" => 1}
+             }
+
+      assert decode_tool_content(Turn.format_tool_result_content({:error, %{message: "boom"}})) == %{
+               "ok" => false,
+               "error" => %{
+                 "message" => "boom",
+                 "type" => "execution_error",
+                 "retryable?" => false,
+                 "details" => %{}
+               }
+             }
+
+      assert decode_tool_content(Turn.format_tool_result_content({:error, :badarg})) == %{
+               "ok" => false,
+               "error" => %{
+                 "message" => "badarg",
+                 "type" => "execution_error",
+                 "retryable?" => false,
+                 "details" => %{"reason" => "badarg"}
+               }
+             }
     end
 
     test "preserves explicit content parts alongside structured tool output" do
       image = ContentPart.image_url("https://example.com/chart.png")
 
       assert [
-               %ContentPart{type: :text, text: "{\"value\":1}"},
+               %ContentPart{type: :text, text: encoded_payload},
                %ContentPart{type: :image_url, url: "https://example.com/chart.png"}
              ] =
                Turn.format_tool_result_content(
@@ -169,6 +196,14 @@ defmodule Jido.AI.TurnTest do
                     value: 1
                   }}
                )
+
+      assert Jason.decode!(encoded_payload) == %{
+               "ok" => true,
+               "result" => %{
+                 "output" => %{"value" => 1},
+                 "content" => [%{"type" => "image_url", "url" => "https://example.com/chart.png"}]
+               }
+             }
     end
   end
 
@@ -190,7 +225,12 @@ defmodule Jido.AI.TurnTest do
       [tool_result] = updated_turn.tool_results
       assert tool_result.id == "tc_1"
       assert tool_result.name == "calculator"
-      assert tool_result.content == "{\"result\":8}"
+
+      assert decode_tool_content(tool_result.content) == %{
+               "ok" => true,
+               "result" => %{"result" => 8}
+             }
+
       assert tool_result.raw_result == {:ok, %{result: 8}, []}
     end
 


### PR DESCRIPTION
## Summary
- stacked on `#229`
- normalize model-facing tool payloads to `%{ok: true, result: ...}` / `%{ok: false, error: ...}`
- tighten tool failure shaping in `Turn`, `EmitToolError`, and ToT tool execution paths
- consolidate ReAct retryability decisions onto the shared signal helper contract

## Verification
- `mix test test/jido_ai/directive/deadlock_prevention_test.exs test/jido_ai/executor_test.exs test/jido_ai/integration/tools_phase2_test.exs test/jido_ai/plugins/policy_test.exs test/jido_ai/react/runtime_runner_test.exs test/jido_ai/turn_test.exs`