### PR TITLE
fix(adaptive): preserve compatibility strings for raw failures

### DIFF
--- a/lib/jido_ai/agents/strategies/adaptive_agent.ex
+++ b/lib/jido_ai/agents/strategies/adaptive_agent.ex
@@ -345,7 +345,7 @@ defmodule Jido.AI.AdaptiveAgent do
             agent
             | state:
                 Map.merge(agent.state, %{
-                  last_result: snap.result || "",
+                  last_result: compat_result(snap.result),
                   completed: true,
                   selected_strategy: selected_strategy
                 })
@@ -357,6 +357,10 @@ defmodule Jido.AI.AdaptiveAgent do
           }
         end
       end
+
+      defp compat_result(nil), do: ""
+      defp compat_result(value) when is_binary(value), do: value
+      defp compat_result(value), do: inspect(value)
 
       defp request_id_from_action({_, params}, fallback) when is_map(params) do
         params[:request_id] ||

--- a/lib/jido_ai/reasoning/adaptive/cli_adapter.ex
+++ b/lib/jido_ai/reasoning/adaptive/cli_adapter.ex
@@ -81,9 +81,9 @@ defmodule Jido.AI.Reasoning.Adaptive.CLIAdapter do
           if status.snapshot.done? do
             answer =
               case status.snapshot.result do
-                nil -> Map.get(status.raw_state, :last_result, "")
-                "" -> Map.get(status.raw_state, :last_result, "")
-                result -> result
+                nil -> format_cli_answer(Map.get(status.raw_state, :last_result, ""))
+                "" -> format_cli_answer(Map.get(status.raw_state, :last_result, ""))
+                result -> format_cli_answer(result)
               end
 
             {:ok, %{answer: answer, meta: extract_meta(status)}}
@@ -110,4 +110,8 @@ defmodule Jido.AI.Reasoning.Adaptive.CLIAdapter do
       available_strategies: Map.get(details, :available_strategies, [])
     }
   end
+
+  defp format_cli_answer(nil), do: ""
+  defp format_cli_answer(value) when is_binary(value), do: value
+  defp format_cli_answer(value), do: inspect(value)
 end

--- a/test/jido_ai/adaptive_agent_test.exs
+++ b/test/jido_ai/adaptive_agent_test.exs
@@ -105,6 +105,25 @@ defmodule Jido.AI.AdaptiveAgentTest do
       assert updated_agent.state.completed == true
     end
 
+    test "on_after_cmd keeps last_result string while request failure stores raw term" do
+      raw_error = %{type: :provider_error, status: 503, message: "busy"}
+
+      agent =
+        TestAdaptiveAgent.new()
+        |> Request.start_request("req_failed", "query")
+        |> with_failed_strategy(raw_error)
+
+      {:ok, updated_agent, directives} =
+        TestAdaptiveAgent.on_after_cmd(agent, {:adaptive_start, %{request_id: "req_failed"}}, [:noop])
+
+      assert directives == [:noop]
+      assert get_in(updated_agent.state, [:requests, "req_failed", :status]) == :failed
+      assert match?({:failed, _, ^raw_error}, get_in(updated_agent.state, [:requests, "req_failed", :error]))
+      assert updated_agent.state.last_result == inspect(raw_error)
+      assert updated_agent.state.selected_strategy == :cod
+      assert updated_agent.state.completed == true
+    end
+
     test "on_after_cmd preserves pending request when strategy is still running" do
       agent =
         TestAdaptiveAgent.new()
@@ -135,6 +154,17 @@ defmodule Jido.AI.AdaptiveAgentTest do
       selected_strategy: ChainOfDraft,
       strategy_type: :cod,
       status: :completed,
+      result: result
+    }
+
+    put_in(agent.state[:__strategy__], strategy_state)
+  end
+
+  defp with_failed_strategy(agent, result) do
+    strategy_state = %{
+      selected_strategy: ChainOfDraft,
+      strategy_type: :cod,
+      status: :error,
       result: result
     }
 

--- a/test/jido_ai/cli/adapters/adaptive_test.exs
+++ b/test/jido_ai/cli/adapters/adaptive_test.exs
@@ -113,5 +113,16 @@ defmodule Jido.AI.Reasoning.Adaptive.CLIAdapterTest do
       assert meta.task_type == :reasoning
       assert meta.available_strategies == [:cot, :react]
     end
+
+    test "await inspects non-binary failure results for CLI-safe output" do
+      status = AdapterTestSupport.status(result: {:provider_error, :overloaded}, snapshot_status: :failure)
+
+      expect(Jido.AgentServer, :status, fn _pid -> {:ok, status} end)
+
+      assert {:ok, %{answer: "{:provider_error, :overloaded}", meta: meta}} =
+               AdaptiveAdapter.await(self(), 100, %{})
+
+      assert meta.status == :failure
+    end
   end
 end


### PR DESCRIPTION
## Summary
- stringify non-binary Adaptive CLI results at the CLI boundary so failed runs remain printable/JSON-safe
- keep `AdaptiveAgent` legacy `last_result` string-valued while request failures still preserve the raw term
- add Adaptive regression tests for CLI-safe failure output and compatibility-state behavior

## Context
Follow-up to the merged raw-error propagation work in #223. This patch fixes the remaining Adaptive spillover path without reverting that change.

## Testing
- mix test test/jido_ai/cli/adapters/adaptive_test.exs test/jido_ai/adaptive_agent_test.exs
- mix test test/jido_ai/cli/adapters/cot_test.exs test/jido_ai/cli/adapters/cod_test.exs test/jido_ai/cli/adapters/react_test.exs test/jido_ai/cot_agent_test.exs test/jido_ai/cod_agent_test.exs test/jido_ai/agent_test.exs