### PR TITLE
refactor(react): tighten queued control boundaries

### DIFF
--- a/lib/jido_ai.ex
+++ b/lib/jido_ai.ex
@@ -69,6 +69,7 @@ defmodule Jido.AI do
 
   alias Jido.Agent.Strategy.State, as: StratState
   alias Jido.AI.ModelAliases
+  alias Jido.AI.Reasoning.ReAct
   alias Jido.AI.Turn
   alias ReqLLM.Context
 
@@ -397,38 +398,21 @@ defmodule Jido.AI do
   end
 
   @doc """
-  Steers an active ReAct run with additional user-visible input.
-
-  Returns `{:ok, agent}` when the input is queued for the active run or
-  `{:error, {:rejected, reason}}` when no eligible run is available.
-
-  Queued input is best-effort. If the active run terminates before the runtime
-  drains the queue into conversation state, the queued input is dropped.
-
-  ## Options
-
-    * `:timeout` - Call timeout in milliseconds (default: 5000)
-    * `:expected_request_id` - Optional guard for the currently active request
-    * `:source` - Optional source marker recorded with the injected input
-    * `:extra_refs` - Optional refs merged into the injected user message
-
+  Compatibility wrapper for `Jido.AI.Reasoning.ReAct.steer/3`.
   """
   @spec steer(GenServer.server(), String.t(), keyword()) ::
           {:ok, Jido.Agent.t()} | {:error, term()}
   def steer(agent_server, content, opts \\ []) when is_binary(content) do
-    control_agent(agent_server, "ai.react.steer", content, opts, :steer)
+    ReAct.steer(agent_server, content, Keyword.put_new(opts, :source, "/jido/ai"))
   end
 
   @doc """
-  Injects user-visible input into an active ReAct run.
-
-  This is intended for programmatic or inter-agent steering and follows the same
-  queuing rules as `steer/3`.
+  Compatibility wrapper for `Jido.AI.Reasoning.ReAct.inject/3`.
   """
   @spec inject(GenServer.server(), String.t(), keyword()) ::
           {:ok, Jido.Agent.t()} | {:error, term()}
   def inject(agent_server, content, opts \\ []) when is_binary(content) do
-    control_agent(agent_server, "ai.react.inject", content, opts, :inject)
+    ReAct.inject(agent_server, content, Keyword.put_new(opts, :source, "/jido/ai"))
   end
 
   @doc """
@@ -589,47 +573,6 @@ defmodule Jido.AI do
 
       _ ->
         strat_state
-    end
-  end
-
-  defp control_agent(agent_server, signal_type, content, opts, kind)
-       when is_binary(signal_type) and is_binary(content) and kind in [:steer, :inject] do
-    timeout = Keyword.get(opts, :timeout, 5_000)
-
-    signal =
-      Jido.Signal.new!(
-        signal_type,
-        %{
-          content: content
-        }
-        |> maybe_put_control_opt(:expected_request_id, Keyword.get(opts, :expected_request_id))
-        |> maybe_put_control_opt(:source, Keyword.get(opts, :source, "/jido/ai"))
-        |> maybe_put_control_opt(:extra_refs, Keyword.get(opts, :extra_refs)),
-        source: "/jido/ai"
-      )
-
-    case Jido.AgentServer.call(agent_server, signal, timeout) do
-      {:ok, agent} ->
-        normalize_control_result(agent, kind)
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp maybe_put_control_opt(payload, _key, nil), do: payload
-  defp maybe_put_control_opt(payload, key, value), do: Map.put(payload, key, value)
-
-  defp normalize_control_result(%Jido.Agent{} = agent, kind) do
-    case StratState.get(agent, %{}) |> Map.get(:last_pending_input_control) do
-      %{kind: ^kind, status: :queued} ->
-        {:ok, agent}
-
-      %{kind: ^kind, status: :rejected, reason: reason} ->
-        {:error, {:rejected, reason}}
-
-      _ ->
-        {:error, :unknown_control_result}
     end
   end
 

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -756,7 +756,7 @@ defmodule Jido.AI.Agent do
       @spec steer(pid() | atom() | {:via, module(), term()}, String.t(), keyword()) ::
               {:ok, Jido.Agent.t()} | {:error, term()}
       def steer(pid, content, opts \\ []) when is_binary(content) do
-        Jido.AI.steer(pid, content, Keyword.put_new(opts, :source, "/ai/react/agent"))
+        Jido.AI.Reasoning.ReAct.steer(pid, content, Keyword.put_new(opts, :source, "/ai/react/agent"))
       end
 
       @doc """
@@ -768,7 +768,7 @@ defmodule Jido.AI.Agent do
       @spec inject(pid() | atom() | {:via, module(), term()}, String.t(), keyword()) ::
               {:ok, Jido.Agent.t()} | {:error, term()}
       def inject(pid, content, opts \\ []) when is_binary(content) do
-        Jido.AI.inject(pid, content, Keyword.put_new(opts, :source, "/ai/react/agent"))
+        Jido.AI.Reasoning.ReAct.inject(pid, content, Keyword.put_new(opts, :source, "/ai/react/agent"))
       end
 
       defoverridable on_before_cmd: 2,

--- a/lib/jido_ai/reasoning/react.ex
+++ b/lib/jido_ai/reasoning/react.ex
@@ -6,6 +6,7 @@ defmodule Jido.AI.Reasoning.ReAct do
   by actions and strategies.
   """
 
+  alias Jido.Agent.Strategy.State, as: StratState
   alias Jido.AI.Reasoning.ReAct.{Config, Runner, State, Token}
 
   @type config_input :: Config.t() | map() | keyword()
@@ -130,6 +131,33 @@ defmodule Jido.AI.Reasoning.ReAct do
   end
 
   @doc """
+  Steers an active ReAct-backed agent with additional user-visible input.
+
+  Returns `{:ok, agent}` when the input is queued for the current run or
+  `{:error, {:rejected, reason}}` when no eligible run is active.
+
+  Queued input is best-effort. If the run terminates before the runtime drains
+  the queue into conversation state, the queued input is dropped.
+  """
+  @spec steer(GenServer.server(), String.t(), keyword()) ::
+          {:ok, Jido.Agent.t()} | {:error, term()}
+  def steer(agent_server, content, opts \\ []) when is_binary(content) and is_list(opts) do
+    control(agent_server, "ai.react.steer", content, opts, :steer)
+  end
+
+  @doc """
+  Injects user-visible input into an active ReAct-backed agent.
+
+  This is intended for programmatic or inter-agent steering and follows the same
+  queuing rules as `steer/3`.
+  """
+  @spec inject(GenServer.server(), String.t(), keyword()) ::
+          {:ok, Jido.Agent.t()} | {:error, term()}
+  def inject(agent_server, content, opts \\ []) when is_binary(content) and is_list(opts) do
+    control(agent_server, "ai.react.inject", content, opts, :inject)
+  end
+
+  @doc """
   Normalizes user-provided configuration into a `Config` struct.
   """
   @spec build_config(config_input()) :: Config.t()
@@ -192,4 +220,45 @@ defmodule Jido.AI.Reasoning.ReAct do
   defp decode_termination_reason(%State{status: :failed}), do: :failed
   defp decode_termination_reason(%State{status: :cancelled}), do: :cancelled
   defp decode_termination_reason(_), do: nil
+
+  defp control(agent_server, signal_type, content, opts, kind)
+       when is_binary(signal_type) and is_binary(content) and kind in [:steer, :inject] do
+    timeout = Keyword.get(opts, :timeout, 5_000)
+
+    signal =
+      Jido.Signal.new!(
+        signal_type,
+        %{
+          content: content
+        }
+        |> maybe_put_control_opt(:expected_request_id, Keyword.get(opts, :expected_request_id))
+        |> maybe_put_control_opt(:source, Keyword.get(opts, :source, "/ai/react"))
+        |> maybe_put_control_opt(:extra_refs, Keyword.get(opts, :extra_refs)),
+        source: "/ai/react"
+      )
+
+    case Jido.AgentServer.call(agent_server, signal, timeout) do
+      {:ok, agent} ->
+        normalize_control_result(agent, kind)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp maybe_put_control_opt(payload, _key, nil), do: payload
+  defp maybe_put_control_opt(payload, key, value), do: Map.put(payload, key, value)
+
+  defp normalize_control_result(%Jido.Agent{} = agent, kind) do
+    case StratState.get(agent, %{}) |> Map.get(:last_pending_input_control) do
+      %{kind: ^kind, status: :queued} ->
+        {:ok, agent}
+
+      %{kind: ^kind, status: :rejected, reason: reason} ->
+        {:error, {:rejected, reason}}
+
+      _ ->
+        {:error, :unknown_control_result}
+    end
+  end
 end

--- a/lib/jido_ai/reasoning/react/pending_input.ex
+++ b/lib/jido_ai/reasoning/react/pending_input.ex
@@ -1,0 +1,123 @@
+defmodule Jido.AI.Reasoning.ReAct.PendingInput do
+  @moduledoc """
+  Pending-input helpers for delegated ReAct runs.
+
+  This module keeps the acceptance rules and queue lifecycle for `steer` and
+  `inject` control input out of the main ReAct strategy so the public
+  orchestration path stays easier to follow.
+  """
+
+  alias Jido.AI.PendingInputServer
+
+  @type control_kind :: :steer | :inject
+  @type strategy_state :: map()
+
+  @open_statuses [:awaiting_llm, :awaiting_tool, :completed]
+
+  @doc """
+  Starts a queue owned by the calling strategy process for the given request.
+  """
+  @spec start(String.t(), pid()) :: {:ok, pid()} | {:error, :pending_input_unavailable}
+  def start(request_id, owner \\ self()) when is_binary(request_id) and is_pid(owner) do
+    case PendingInputServer.start(owner: owner, request_id: request_id) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, _reason} -> {:error, :pending_input_unavailable}
+    end
+  end
+
+  @doc """
+  Stops the tracked queue server, if any, and clears it from strategy state.
+  """
+  @spec stop(strategy_state()) :: strategy_state()
+  def stop(state) when is_map(state) do
+    case Map.get(state, :pending_input_server) do
+      pid when is_pid(pid) ->
+        PendingInputServer.stop(pid)
+        Map.put(state, :pending_input_server, nil)
+
+      _ ->
+        Map.put(state, :pending_input_server, nil)
+    end
+  end
+
+  @doc """
+  Returns whether the current strategy state still accepts queued user input.
+  """
+  @spec open?(strategy_state()) :: boolean()
+  def open?(state) when is_map(state) do
+    is_binary(state[:active_request_id]) and state[:status] in @open_statuses
+  end
+
+  @doc """
+  Attempts to queue a `steer` or `inject` control input and records the outcome.
+  """
+  @spec accept_control(strategy_state(), map(), control_kind()) ::
+          {:ok, strategy_state()} | {:error, strategy_state()}
+  def accept_control(state, %{content: content} = params, kind)
+      when is_map(state) and is_binary(content) and kind in [:steer, :inject] do
+    with {:ok, request_id} <- resolve_request_id(state, params),
+         {:ok, server} <- fetch_server(state),
+         :ok <- PendingInputServer.enqueue(server, queued_item(content, params)) do
+      {:ok, record_control(state, kind, status: :queued, request_id: request_id)}
+    else
+      {:error, reason} ->
+        {:error,
+         record_control(state, kind,
+           status: :rejected,
+           reason: reason,
+           request_id: Map.get(state, :active_request_id)
+         )}
+    end
+  end
+
+  defp resolve_request_id(state, params) do
+    expected_request_id = Map.get(params, :expected_request_id)
+    active_request_id = Map.get(state, :active_request_id)
+
+    cond do
+      not open?(state) ->
+        {:error, :idle}
+
+      is_binary(expected_request_id) and expected_request_id != active_request_id ->
+        {:error, :request_mismatch}
+
+      is_binary(active_request_id) ->
+        {:ok, active_request_id}
+
+      true ->
+        {:error, :idle}
+    end
+  end
+
+  defp fetch_server(state) do
+    case Map.get(state, :pending_input_server) do
+      pid when is_pid(pid) ->
+        if Process.alive?(pid), do: {:ok, pid}, else: {:error, :pending_input_unavailable}
+
+      _ ->
+        {:error, :pending_input_unavailable}
+    end
+  end
+
+  defp queued_item(content, params) do
+    %{
+      content: content,
+      source: Map.get(params, :source),
+      refs: normalize_optional_refs(Map.get(params, :extra_refs))
+    }
+  end
+
+  defp record_control(state, kind, attrs) do
+    result =
+      attrs
+      |> Keyword.put(:kind, kind)
+      |> Keyword.put(:at_ms, System.system_time(:millisecond))
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
+
+    Map.put(state, :last_pending_input_control, result)
+  end
+
+  defp normalize_optional_refs(%{} = refs), do: refs
+  defp normalize_optional_refs(_), do: nil
+end

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -39,7 +39,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   alias Jido.AI.Observe
   alias Jido.AI.Directive
   alias Jido.AI.Effects
-  alias Jido.AI.PendingInputServer
+  alias Jido.AI.Reasoning.ReAct.PendingInput
   alias Jido.AI.Reasoning.ReAct.RequestTransformer
   alias Jido.AI.Reasoning.ReAct.State, as: ReActState
   alias Jido.AI.Reasoning.ReAct.Config, as: ReActRuntimeConfig
@@ -595,11 +595,11 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       base_llm_opts = normalize_llm_opts(config[:base_llm_opts], provider_opt_keys_by_string)
       effective_llm_opts = Keyword.merge(base_llm_opts, run_llm_opts)
       state_snapshot = normalize_map_opt(Map.get(agent, :state, %{}))
-      state = stop_pending_input_server(state)
+      state = PendingInput.stop(state)
 
       with {:ok, effective_tools} <- resolve_request_tools(config, params),
            {:ok, request_transformer} <- resolve_request_transformer(config, params),
-           {:ok, pending_input_server} <- start_pending_input_server(request_id) do
+           {:ok, pending_input_server} <- PendingInput.start(request_id) do
         runtime_config =
           runtime_config_from_strategy(config,
             req_http_options: effective_req_http_options,
@@ -699,25 +699,11 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
        when is_binary(content) and kind in [:steer, :inject] do
     state = StratState.get(agent, %{})
 
-    with {:ok, request_id} <- resolve_pending_input_request_id(state, params),
-         {:ok, server} <- fetch_pending_input_server(state),
-         :ok <- PendingInputServer.enqueue(server, pending_input_item(content, params)) do
-      new_state =
-        record_pending_input_control(state, kind,
-          status: :queued,
-          request_id: request_id
-        )
+    case PendingInput.accept_control(state, params, kind) do
+      {:ok, new_state} ->
+        {put_strategy_state(agent, new_state), []}
 
-      {put_strategy_state(agent, new_state), []}
-    else
-      {:error, reason} ->
-        new_state =
-          record_pending_input_control(state, kind,
-            status: :rejected,
-            reason: reason,
-            request_id: state[:active_request_id]
-          )
-
+      {:error, new_state} ->
         {put_strategy_state(agent, new_state), []}
     end
   end
@@ -907,10 +893,6 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
 
   defp active_run?(state) do
     is_binary(state[:active_request_id]) and state[:status] in [:awaiting_llm, :awaiting_tool]
-  end
-
-  defp pending_input_run?(state) do
-    is_binary(state[:active_request_id]) and state[:status] in [:awaiting_llm, :awaiting_tool, :completed]
   end
 
   defp apply_context_op(agent, state, %{op_id: op_id} = context_op) do
@@ -1456,7 +1438,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
             |> Map.put(:termination_reason, :error)
             |> Map.put(:result, error)
             |> Map.put(:active_request_id, nil)
-            |> stop_pending_input_server()
+            |> PendingInput.stop()
             |> Map.put(:run_context, nil)
             |> Map.delete(:run_tool_context)
             |> Map.delete(:run_req_http_options)
@@ -1679,7 +1661,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
 
         updated =
           base_state
-          |> stop_pending_input_server()
+          |> PendingInput.stop()
           |> Map.put(:status, :completed)
           |> Map.put(:result, result)
           |> Map.put(:termination_reason, termination_reason)
@@ -1705,7 +1687,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
 
         updated =
           base_state
-          |> stop_pending_input_server()
+          |> PendingInput.stop()
           |> Map.put(:status, :error)
           |> Map.put(:result, error)
           |> Map.put(:termination_reason, :error)
@@ -1727,7 +1709,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
 
         updated =
           base_state
-          |> stop_pending_input_server()
+          |> PendingInput.stop()
           |> Map.put(:status, :error)
           |> Map.put(:result, error)
           |> Map.put(:termination_reason, :cancelled)
@@ -1948,75 +1930,6 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     config[:request_policy] == :reject and state[:status] in [:awaiting_llm, :awaiting_tool] and
       is_binary(state[:active_request_id])
   end
-
-  defp start_pending_input_server(request_id) when is_binary(request_id) do
-    case PendingInputServer.start(owner: self(), request_id: request_id) do
-      {:ok, pid} -> {:ok, pid}
-      {:error, _reason} -> {:error, :pending_input_unavailable}
-    end
-  end
-
-  defp fetch_pending_input_server(state) do
-    case Map.get(state, :pending_input_server) do
-      pid when is_pid(pid) ->
-        if Process.alive?(pid), do: {:ok, pid}, else: {:error, :pending_input_unavailable}
-
-      _ ->
-        {:error, :pending_input_unavailable}
-    end
-  end
-
-  defp stop_pending_input_server(state) do
-    case Map.get(state, :pending_input_server) do
-      pid when is_pid(pid) ->
-        PendingInputServer.stop(pid)
-        Map.put(state, :pending_input_server, nil)
-
-      _ ->
-        Map.put(state, :pending_input_server, nil)
-    end
-  end
-
-  defp resolve_pending_input_request_id(state, params) do
-    expected_request_id = Map.get(params, :expected_request_id)
-    active_request_id = state[:active_request_id]
-
-    cond do
-      not pending_input_run?(state) ->
-        {:error, :idle}
-
-      is_binary(expected_request_id) and expected_request_id != active_request_id ->
-        {:error, :request_mismatch}
-
-      is_binary(active_request_id) ->
-        {:ok, active_request_id}
-
-      true ->
-        {:error, :idle}
-    end
-  end
-
-  defp pending_input_item(content, params) do
-    %{
-      content: content,
-      source: Map.get(params, :source),
-      refs: normalize_optional_refs(Map.get(params, :extra_refs))
-    }
-  end
-
-  defp record_pending_input_control(state, kind, attrs) when kind in [:steer, :inject] and is_list(attrs) do
-    result =
-      attrs
-      |> Keyword.put(:kind, kind)
-      |> Keyword.put(:at_ms, System.system_time(:millisecond))
-      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
-      |> Map.new()
-
-    Map.put(state, :last_pending_input_control, result)
-  end
-
-  defp normalize_optional_refs(%{} = refs), do: refs
-  defp normalize_optional_refs(_), do: nil
 
   defp maybe_mark_worker_ready(state, kind) when kind in [:request_completed, :request_failed, :request_cancelled] do
     Map.put(state, :react_worker_status, :ready)

--- a/test/jido_ai/integration/react_steering_integration_test.exs
+++ b/test/jido_ai/integration/react_steering_integration_test.exs
@@ -3,6 +3,7 @@ defmodule Jido.AI.Integration.ReActSteeringIntegrationTest do
   use Mimic
 
   alias Jido.AI
+  alias Jido.AI.Reasoning.ReAct
   alias Jido.AI.TestSupport.StreamResponseFactory
 
   defmodule SteeringAgent do
@@ -79,7 +80,7 @@ defmodule Jido.AI.Integration.ReActSteeringIntegrationTest do
     assert assistant_contents(first_messages) == []
 
     assert {:ok, _agent} =
-             SteeringAgent.steer(
+             ReAct.steer(
                pid,
                "Q2",
                expected_request_id: request.id,


### PR DESCRIPTION
## Summary
- move queued `steer`/`inject` control handling into `Jido.AI.Reasoning.ReAct`
- keep `Jido.AI` as a compatibility wrapper instead of owning ReAct-specific control logic
- extract pending-input queue lifecycle and acceptance rules into a dedicated ReAct helper to slim the strategy module
- exercise the ReAct-scoped control entrypoint in the steering integration test

## Verification
- `mix compile --warnings-as-errors`
- `mix doctor --summary --raise`
- `mix test.fast`
- `mix test`
- `mix test test/jido_ai/react/public_api_test.exs test/jido_ai/react/runtime_runner_test.exs test/jido_ai/strategy/react_test.exs test/jido_ai/integration/react_steering_integration_test.exs test/jido_ai/pending_input_server_test.exs`
- `mix test test/jido_ai/react/public_api_test.exs test/jido_ai/strategy/react_test.exs test/jido_ai/integration/react_steering_integration_test.exs`