### PR TITLE
fix: prevent struct errors from hitting plain-map `normalize_error` clause

### DIFF
--- a/lib/jido_ai/signals/helpers.ex
+++ b/lib/jido_ai/signals/helpers.ex
@@ -62,7 +62,7 @@ defmodule Jido.AI.Signal.Helpers do
   end
 
   def normalize_error(%{message: message} = error, fallback_type, _fallback_message, extra_details)
-      when not is_nil(message) and is_map(extra_details) do
+      when not is_nil(message) and not is_struct(error) and is_map(extra_details) do
     details =
       error
       |> Map.drop([:message, :retryable, :retryable?])

--- a/test/jido_ai/executor_test.exs
+++ b/test/jido_ai/executor_test.exs
@@ -236,7 +236,7 @@ defmodule Jido.AI.TurnExecutionTest do
       result = Turn.execute("calculator", %{}, %{}, tools: tools)
 
       assert {:error, error, []} = result
-      assert error.type == :execution_error
+      assert error.type == :validation_error
       assert error.details.tool_name == "calculator"
       # Error message should mention missing required option
       assert String.contains?(error.message, "required")

--- a/test/jido_ai/integration/tools_phase2_test.exs
+++ b/test/jido_ai/integration/tools_phase2_test.exs
@@ -331,7 +331,7 @@ defmodule Jido.AI.Integration.ToolsPhase2Test do
       result = Turn.execute("calculator", %{}, %{}, tools: tools)
 
       assert {:error, error, []} = result
-      assert error.type == :execution_error
+      assert error.type == :validation_error
       assert String.contains?(error.message, "required")
     end
 

--- a/test/jido_ai/signal/helpers_test.exs
+++ b/test/jido_ai/signal/helpers_test.exs
@@ -63,6 +63,25 @@ defmodule Jido.AI.Signal.HelpersTest do
     end
   end
 
+  describe "normalize_error with exception structs" do
+    test "exception struct dispatches to Jido.Error.to_map, not the plain-map clause" do
+      error =
+        Jido.Action.Error.ExecutionFailureError.exception(
+          message: "missing mcp_session in tool context",
+          details: %{type: :transport}
+        )
+
+      result = Helpers.normalize_error(error, :execution_error, "fallback", %{tool_name: "bash"})
+
+      assert result.message == "missing mcp_session in tool context"
+      assert result.type == :execution_error
+      # details must NOT contain __struct__ — that indicates Map.drop on a struct
+      refute Map.has_key?(result.details, :__struct__)
+      assert result.details[:tool_name] == "bash"
+      assert result.details[:type] == :transport
+    end
+  end
+
   describe "sanitize_delta/2" do
     test "removes control bytes and truncates by max chars" do
       assert Helpers.sanitize_delta("abc" <> <<1>> <> "def", 10) == "abcdef"


### PR DESCRIPTION
The `normalize_error` clause for `%{message: message}` matches any map with a `:message` key — including exception structs. When a struct hit this clause, `Map.drop` preserved `__struct__` and `__exception__` in the details, producing a map that masquerades as a struct but has the wrong fields. Downstream JSON encoding then crashes on the malformed map.

Add `not is_struct(error)` guard so structs dispatch to the dedicated struct clause, which uses `Jido.Error.to_map` for proper field extraction. Two tests that asserted `:execution_error` for `InvalidInputError` now correctly expect `:validation_error`.