### PR TITLE
feat(react): emit tool_call streaming deltas from ReAct runner

### DIFF
--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -899,6 +899,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
 
   defp visible_chunk?(%ReqLLM.StreamChunk{type: :content, text: text}, trace_cfg), do: delta_captured?(text, trace_cfg)
   defp visible_chunk?(%ReqLLM.StreamChunk{type: :thinking, text: text}, trace_cfg), do: delta_captured?(text, trace_cfg)
+  defp visible_chunk?(%ReqLLM.StreamChunk{type: :tool_call}, trace_cfg), do: trace_cfg[:capture_deltas?] == true
   defp visible_chunk?(_chunk, _trace_cfg), do: false
 
   defp delta_captured?(text, trace_cfg), do: trace_cfg[:capture_deltas?] == true and is_binary(text) and text != ""
@@ -913,6 +914,9 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     end)
     |> maybe_put_stream_callback(trace_cfg, :on_thinking, fn text ->
       emit_stream_delta(state_key, owner, ref, :thinking, text)
+    end)
+    |> maybe_put_stream_callback(trace_cfg, :on_tool_call, fn chunk ->
+      emit_stream_delta(state_key, owner, ref, :tool_call, chunk.name || "")
     end)
   end
 


### PR DESCRIPTION
## Summary

Adds `:on_tool_call` callback to the ReAct runner's `stream_process_opts` so tool call argument streaming emits `:llm_delta` events with `chunk_type: :tool_call`. Also updates `visible_chunk?/2` to include `:tool_call` chunks.

## Why

When the LLM decides to use a tool, it streams tool call arguments for 30-60+ seconds (for large inputs like document creation). During this time, **zero events are emitted** — the runner only registers `:on_result` and `:on_thinking` callbacks, not `:on_tool_call`. Consumers have no way to show real-time UI feedback while tool call arguments are being generated.

The infrastructure already exists in ReqLLM (`process_stream/2` supports `:on_tool_call`). This PR wires it into the runner.

## Changes

**`lib/jido_ai/reasoning/react/runner.ex`** (2 changes):

1. `visible_chunk?/2` — added clause for `:tool_call` chunks (gated by `capture_deltas?`)
2. `stream_process_opts/5` — added `:on_tool_call` callback that emits `emit_stream_delta` with `chunk_type: :tool_call`

## How consumers use this

```elixir
# In on_before_cmd, match tool_call deltas for early UI feedback:
def on_before_cmd(agent, {@noop, %{delta: _name, chunk_type: :tool_call}} = action) do
  ChatPubSub.broadcast_tool_used(agent.state.conversation_id, "tool_call", %{})
  super(agent, action)
end
```

Closes #246