### PR TITLE
feat: Support rich model specs in aliases (maps, tuples, structs)

### DIFF
--- a/lib/jido_ai.ex
+++ b/lib/jido_ai.ex
@@ -28,6 +28,18 @@ defmodule Jido.AI do
           capable: "provider:your-capable-model"
         }
 
+  Aliases can also point at full direct model specs when you need richer
+  ReqLLM metadata, such as a custom OpenAI-compatible `base_url`:
+
+      config :jido_ai,
+        model_aliases: %{
+          capable: %{
+            provider: :openai,
+            id: "moonshotai.kimi-k2.5",
+            base_url: "https://proxy.example.com/v1"
+          }
+        }
+
   A broad list of provider/model IDs is available at: https://llmdb.xyz
 
   ## LLM Defaults
@@ -76,13 +88,7 @@ defmodule Jido.AI do
   @type model_alias ::
           :fast | :capable | :thinking | :reasoning | :planning | :image | :embedding | atom()
   @type model_spec :: String.t()
-  @type resolved_model_input ::
-          model_spec()
-          | map()
-          | {atom(), model_spec(), keyword()}
-          | {atom(), keyword()}
-          | %LLMDB.Model{}
-  @type model_input :: model_alias() | resolved_model_input()
+  @type model_input :: model_alias() | ReqLLM.model_input()
   @type llm_kind :: :text | :object | :stream
   @type llm_generation_opts :: %{
           optional(:model) => model_input(),
@@ -124,7 +130,7 @@ defmodule Jido.AI do
       iex> is_binary(aliases[:fast])
       true
   """
-  @spec model_aliases() :: %{model_alias() => model_spec()}
+  @spec model_aliases() :: %{model_alias() => ReqLLM.model_input()}
   def model_aliases, do: ModelAliases.model_aliases()
 
   @doc """
@@ -163,8 +169,8 @@ defmodule Jido.AI do
   Resolves a model alias or passes through a direct ReqLLM model input.
 
   Model aliases are atoms like `:fast`, `:capable`, `:reasoning` that map
-  to full ReqLLM model specifications. Direct model inputs are passed through
-  unchanged and may be strings, ReqLLM tuples, inline maps, or `%LLMDB.Model{}`
+  to full ReqLLM model specifications. Both alias values and direct model
+  inputs may be strings, ReqLLM tuples, inline maps, or `%LLMDB.Model{}`
   structs.
 
   ## Arguments
@@ -189,7 +195,7 @@ defmodule Jido.AI do
       Jido.AI.resolve_model(:unknown_alias)
       # raises ArgumentError with unknown alias message
   """
-  @spec resolve_model(model_input()) :: resolved_model_input()
+  @spec resolve_model(model_input()) :: ReqLLM.model_input()
   def resolve_model(model) when is_atom(model), do: ModelAliases.resolve_model(model)
   def resolve_model(model) when is_binary(model), do: model
   def resolve_model(%LLMDB.Model{} = model), do: model
@@ -199,7 +205,9 @@ defmodule Jido.AI do
       when is_atom(provider) and is_binary(model_id) and is_list(provider_opts),
       do: model
 
-  def resolve_model({provider, provider_opts} = model) when is_atom(provider) and is_list(provider_opts), do: model
+  def resolve_model({provider, provider_opts} = model)
+      when is_atom(provider) and is_list(provider_opts),
+      do: model
 
   def resolve_model(model) do
     raise ArgumentError,
@@ -211,7 +219,7 @@ defmodule Jido.AI do
   Returns a stable human-readable label for a model input.
   """
   @spec model_label(model_input()) :: String.t()
-  def model_label(model) when is_atom(model), do: resolve_model(model)
+  def model_label(model) when is_atom(model), do: model |> resolve_model() |> model_label()
   def model_label(model) when is_binary(model), do: model
 
   def model_label(model) do
@@ -223,7 +231,9 @@ defmodule Jido.AI do
 
   @doc false
   @spec model_fingerprint_segment(model_input()) :: String.t()
-  def model_fingerprint_segment(model) when is_atom(model), do: resolve_model(model)
+  def model_fingerprint_segment(model) when is_atom(model),
+    do: model |> resolve_model() |> model_fingerprint_segment()
+
   def model_fingerprint_segment(model) when is_binary(model), do: model
 
   def model_fingerprint_segment(model) do

--- a/lib/jido_ai/model_aliases.ex
+++ b/lib/jido_ai/model_aliases.ex
@@ -5,7 +5,6 @@ defmodule Jido.AI.ModelAliases do
 
   @type model_alias ::
           :fast | :capable | :thinking | :reasoning | :planning | :image | :embedding | atom()
-  @type model_spec :: String.t()
 
   @default_aliases %{
     fast: "anthropic:claude-haiku-4-5",
@@ -20,18 +19,16 @@ defmodule Jido.AI.ModelAliases do
   @doc """
   Returns configured model aliases merged over built-in defaults.
   """
-  @spec model_aliases() :: %{model_alias() => model_spec()}
+  @spec model_aliases() :: %{model_alias() => ReqLLM.model_input()}
   def model_aliases do
     configured = Application.get_env(:jido_ai, :model_aliases, %{}) |> normalize_model_aliases()
     Map.merge(@default_aliases, configured)
   end
 
   @doc """
-  Resolves an alias atom to a provider model spec or passes through a model spec.
+  Resolves an alias atom to a provider model spec.
   """
-  @spec resolve_model(model_alias() | model_spec()) :: model_spec()
-  def resolve_model(model) when is_binary(model), do: model
-
+  @spec resolve_model(model_alias()) :: ReqLLM.model_input()
   def resolve_model(model) when is_atom(model) do
     aliases = model_aliases()
 
@@ -42,10 +39,55 @@ defmodule Jido.AI.ModelAliases do
                 "Available aliases: #{inspect(Map.keys(aliases))}"
 
       spec ->
-        spec
+        validate_alias_spec!(model, spec)
     end
   end
 
   defp normalize_model_aliases(aliases) when is_map(aliases), do: aliases
   defp normalize_model_aliases(_), do: %{}
+
+  defp validate_alias_spec!(alias_name, spec) do
+    cond do
+      is_binary(spec) ->
+        spec
+
+      valid_reqllm_input_shape?(spec) ->
+        validate_reqllm_model_input!(alias_name, spec)
+
+      true ->
+        raise_invalid_alias_spec!(alias_name, spec, "unsupported value shape")
+    end
+  end
+
+  defp validate_reqllm_model_input!(alias_name, spec) do
+    case ReqLLM.model(spec) do
+      {:ok, _model} ->
+        spec
+
+      {:error, reason} ->
+        raise_invalid_alias_spec!(alias_name, spec, format_reason(reason))
+    end
+  end
+
+  defp valid_reqllm_input_shape?(%LLMDB.Model{}), do: true
+  defp valid_reqllm_input_shape?(spec) when is_map(spec) and not is_struct(spec), do: true
+
+  defp valid_reqllm_input_shape?({provider, model_id, provider_opts})
+       when is_atom(provider) and is_binary(model_id) and is_list(provider_opts),
+       do: true
+
+  defp valid_reqllm_input_shape?({provider, provider_opts})
+       when is_atom(provider) and is_list(provider_opts),
+       do: true
+
+  defp valid_reqllm_input_shape?(_), do: false
+
+  defp raise_invalid_alias_spec!(alias_name, spec, detail) do
+    raise ArgumentError,
+          "Invalid model spec configured for alias #{inspect(alias_name)}: #{inspect(spec)}. " <>
+            "Expected a valid ReqLLM model input. #{detail}"
+  end
+
+  defp format_reason(reason) when is_exception(reason), do: Exception.message(reason)
+  defp format_reason(reason), do: inspect(reason)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule JidoAi.MixProject do
 
       # Dialyzer
       dialyzer: [
-        plt_add_apps: [:mix]
+        plt_add_apps: [:mix, :llm_db]
       ]
     ]
   end

--- a/test/jido_ai/jido_ai_core_test.exs
+++ b/test/jido_ai/jido_ai_core_test.exs
@@ -42,14 +42,38 @@ defmodule Jido.AI.CoreTest do
     :ok
   end
 
+  defp with_model_aliases(aliases, fun) do
+    original = Application.get_env(:jido_ai, :model_aliases)
+    Application.put_env(:jido_ai, :model_aliases, aliases)
+
+    on_exit(fn ->
+      if is_nil(original) do
+        Application.delete_env(:jido_ai, :model_aliases)
+      else
+        Application.put_env(:jido_ai, :model_aliases, original)
+      end
+    end)
+
+    fun.()
+  end
+
   describe "model aliases and llm defaults" do
     test "model_aliases/0 merges configured aliases over defaults" do
-      Application.put_env(:jido_ai, :model_aliases, %{fast: "openai:gpt-4.1-mini", custom: "test:custom"})
-      aliases = AI.model_aliases()
+      aliases =
+        with_model_aliases(%{fast: "openai:gpt-4.1-mini", custom: "test:custom"}, fn ->
+          AI.model_aliases()
+        end)
 
       assert aliases[:fast] == "openai:gpt-4.1-mini"
       assert aliases[:custom] == "test:custom"
       assert is_binary(aliases[:capable])
+    end
+
+    test "model_aliases/0 supports direct model specs for configured aliases" do
+      inline_model = %{provider: :openai, id: "gpt-4.1", base_url: "http://localhost:4000/v1"}
+
+      aliases = with_model_aliases(%{capable: inline_model}, fn -> AI.model_aliases() end)
+      assert aliases[:capable] == inline_model
     end
 
     test "resolve_model/1 passes strings, resolves aliases, and raises for unknown alias" do
@@ -59,6 +83,14 @@ defmodule Jido.AI.CoreTest do
       assert_raise ArgumentError, ~r/Unknown model alias/, fn ->
         AI.resolve_model(:does_not_exist)
       end
+    end
+
+    test "resolve_model/1 resolves aliases to direct model specs" do
+      inline_model = %{provider: :openai, id: "gpt-4.1", base_url: "http://localhost:4000/v1"}
+
+      with_model_aliases(%{capable: inline_model}, fn ->
+        assert AI.resolve_model(:capable) == inline_model
+      end)
     end
 
     test "resolve_model/1 accepts ReqLLM tuple, inline map, and model struct inputs" do
@@ -78,6 +110,24 @@ defmodule Jido.AI.CoreTest do
       assert AI.model_label(tuple_model) == "openai:gpt-4.1"
       assert is_binary(AI.model_fingerprint_segment(tuple_model))
       assert AI.provider_opt_keys(:fast) |> is_map()
+    end
+
+    test "model helpers normalize labels and fingerprints for alias-backed inline specs" do
+      inline_model = %{provider: :openai, id: "gpt-4.1", base_url: "http://localhost:4000/v1"}
+
+      with_model_aliases(%{capable: inline_model}, fn ->
+        assert AI.model_label(:capable) == "openai:gpt-4.1"
+        assert is_binary(AI.model_fingerprint_segment(:capable))
+        assert AI.provider_opt_keys(:capable) |> is_map()
+      end)
+    end
+
+    test "resolve_model/1 raises for invalid configured alias specs" do
+      with_model_aliases(%{capable: [:invalid]}, fn ->
+        assert_raise ArgumentError, ~r/Invalid model spec configured for alias :capable/, fn ->
+          AI.resolve_model(:capable)
+        end
+      end)
     end
 
     test "resolve_model/1 raises for unsupported direct model inputs" do

--- a/test/jido_ai_test.exs
+++ b/test/jido_ai_test.exs
@@ -16,29 +16,40 @@ defmodule Jido.AITest do
     end)
   end
 
+  defp with_model_aliases(aliases, fun) do
+    original = Application.get_env(:jido_ai, :model_aliases)
+    Application.put_env(:jido_ai, :model_aliases, aliases)
+
+    on_exit(fn ->
+      if is_nil(original) do
+        Application.delete_env(:jido_ai, :model_aliases)
+      else
+        Application.put_env(:jido_ai, :model_aliases, original)
+      end
+    end)
+
+    fun.()
+  end
+
   describe "model_aliases/0 and resolve_model/1" do
     test "loads built-in defaults" do
       assert is_binary(AI.resolve_model(:fast))
     end
 
     test "merges configured aliases over defaults" do
-      original = Application.get_env(:jido_ai, :model_aliases)
-
-      Application.put_env(:jido_ai, :model_aliases, %{
-        fast: "test:fast",
-        custom: "test:custom"
-      })
-
-      on_exit(fn ->
-        if is_nil(original) do
-          Application.delete_env(:jido_ai, :model_aliases)
-        else
-          Application.put_env(:jido_ai, :model_aliases, original)
-        end
+      with_model_aliases(%{fast: "test:fast", custom: "test:custom"}, fn ->
+        assert AI.resolve_model(:fast) == "test:fast"
+        assert AI.resolve_model(:custom) == "test:custom"
       end)
+    end
 
-      assert AI.resolve_model(:fast) == "test:fast"
-      assert AI.resolve_model(:custom) == "test:custom"
+    test "configured aliases can resolve to inline model specs" do
+      inline_model = %{provider: :openai, id: "gpt-4.1", base_url: "http://localhost:4000/v1"}
+
+      with_model_aliases(%{capable: inline_model}, fn ->
+        assert AI.resolve_model(:capable) == inline_model
+        assert AI.model_label(:capable) == "openai:gpt-4.1"
+      end)
     end
   end
 


### PR DESCRIPTION
Model aliases previously only accepted "provider:model-id" strings.

This change expands aliases to the broader ReqLLM model input space, so they can resolve to inline model maps, ReqLLM tuples, and `%LLMDB.Model{}` values in addition to strings.

This allows jido_ai apps to use semantic aliases for richer model configuration, including custom base_url and provider-specific options, instead of hardcoding full model specs at the agent call site.

This is useful for configuring things like OpenAI-compatible gateways and proxy endpoints, such as Bedrock Mantle, where aliases need to carry richer model metadata (eg. `base_url`).

It also fixes model_label/1 and model_fingerprint_segment/1 to recurse through resolve_model/1 for atom inputs, and validates alias-backed rich specs at resolution time.

