### PR TITLE
[codex] normalize action error structs before map fallback

### DIFF
--- a/lib/jido_ai/signals/helpers.ex
+++ b/lib/jido_ai/signals/helpers.ex
@@ -61,16 +61,6 @@ defmodule Jido.AI.Signal.Helpers do
     )
   end
 
-  def normalize_error(%{message: message} = error, fallback_type, _fallback_message, extra_details)
-      when not is_nil(message) and is_map(extra_details) do
-    details =
-      error
-      |> Map.drop([:message, :retryable, :retryable?])
-      |> merge_error_details(extra_details)
-
-    error_envelope(fallback_type, normalize_message(message), details, normalize_retryable(error, fallback_type))
-  end
-
   def normalize_error(%module{} = reason, fallback_type, fallback_message, extra_details)
       when is_map(extra_details) do
     cond do
@@ -96,6 +86,16 @@ defmodule Jido.AI.Signal.Helpers do
           false
         )
     end
+  end
+
+  def normalize_error(%{message: message} = error, fallback_type, _fallback_message, extra_details)
+      when not is_nil(message) and is_map(extra_details) do
+    details =
+      error
+      |> Map.drop([:message, :retryable, :retryable?])
+      |> merge_error_details(extra_details)
+
+    error_envelope(fallback_type, normalize_message(message), details, normalize_retryable(error, fallback_type))
   end
 
   def normalize_error({type, message}, _fallback_type, _fallback_message, extra_details)

--- a/lib/jido_ai/signals/helpers.ex
+++ b/lib/jido_ai/signals/helpers.ex
@@ -64,7 +64,8 @@ defmodule Jido.AI.Signal.Helpers do
   def normalize_error(%module{} = reason, fallback_type, fallback_message, extra_details)
       when is_map(extra_details) do
     cond do
-      function_exported?(Jido.Error, :to_map, 1) and function_exported?(module, :message, 1) ->
+      Code.ensure_loaded?(Jido.Error) and function_exported?(Jido.Error, :to_map, 1) and
+          function_exported?(module, :message, 1) ->
         reason
         |> Jido.Error.to_map()
         |> Map.drop([:stacktrace])

--- a/test/jido_ai/executor_test.exs
+++ b/test/jido_ai/executor_test.exs
@@ -236,7 +236,7 @@ defmodule Jido.AI.TurnExecutionTest do
       result = Turn.execute("calculator", %{}, %{}, tools: tools)
 
       assert {:error, error, []} = result
-      assert error.type == :execution_error
+      assert error.type == :validation_error
       assert error.details.tool_name == "calculator"
       # Error message should mention missing required option
       assert String.contains?(error.message, "required")

--- a/test/jido_ai/integration/tools_phase2_test.exs
+++ b/test/jido_ai/integration/tools_phase2_test.exs
@@ -331,7 +331,7 @@ defmodule Jido.AI.Integration.ToolsPhase2Test do
       result = Turn.execute("calculator", %{}, %{}, tools: tools)
 
       assert {:error, error, []} = result
-      assert error.type == :execution_error
+      assert error.type == :validation_error
       assert String.contains?(error.message, "required")
     end
 

--- a/test/jido_ai/signal/helpers_test.exs
+++ b/test/jido_ai/signal/helpers_test.exs
@@ -2,6 +2,7 @@ defmodule Jido.AI.Signal.HelpersTest do
   use ExUnit.Case, async: true
 
   alias Jido.AI.Signal.Helpers
+  alias Jido.Action.Error, as: ActionError
 
   describe "normalize_result/3" do
     test "passes through ok and error tuples and wraps invalid values" do
@@ -34,6 +35,17 @@ defmodule Jido.AI.Signal.HelpersTest do
                message: "transient_error",
                details: %{},
                retryable?: true
+             }
+    end
+
+    test "normalizes Jido.Action error structs through Jido.Error.to_map/1" do
+      error = ActionError.execution_error("boom", %{step: :list, retry: false})
+
+      assert Helpers.normalize_error(error) == %{
+               type: :execution_error,
+               message: "boom",
+               details: %{step: :list, retry: false},
+               retryable?: false
              }
     end
   end

--- a/test/jido_ai/signal/helpers_test.exs
+++ b/test/jido_ai/signal/helpers_test.exs
@@ -38,15 +38,23 @@ defmodule Jido.AI.Signal.HelpersTest do
              }
     end
 
-    test "normalizes Jido.Action error structs through Jido.Error.to_map/1" do
+    test "normalizes Jido.Action error structs before the generic map fallback" do
       error = ActionError.execution_error("boom", %{step: :list, retry: false})
 
-      assert Helpers.normalize_error(error) == %{
-               type: :execution_error,
-               message: "boom",
-               details: %{step: :list, retry: false},
-               retryable?: false
-             }
+      normalized = Helpers.normalize_error(error)
+
+      assert normalized.type == :execution_error
+      assert normalized.message == "boom"
+      assert normalized.retryable? == false
+      refute Map.get(normalized.details, :reason)
+
+      details =
+        case normalized.details do
+          %{details: details} when is_map(details) -> details
+          details when is_map(details) -> details
+        end
+
+      assert details == %{step: :list, retry: false}
     end
   end
 

--- a/test/jido_ai/signal/helpers_test.exs
+++ b/test/jido_ai/signal/helpers_test.exs
@@ -38,23 +38,15 @@ defmodule Jido.AI.Signal.HelpersTest do
              }
     end
 
-    test "normalizes Jido.Action error structs before the generic map fallback" do
+    test "normalizes Jido.Action error structs through Jido.Error.to_map/1" do
       error = ActionError.execution_error("boom", %{step: :list, retry: false})
 
-      normalized = Helpers.normalize_error(error)
-
-      assert normalized.type == :execution_error
-      assert normalized.message == "boom"
-      assert normalized.retryable? == false
-      refute Map.get(normalized.details, :reason)
-
-      details =
-        case normalized.details do
-          %{details: details} when is_map(details) -> details
-          details when is_map(details) -> details
-        end
-
-      assert details == %{step: :list, retry: false}
+      assert Helpers.normalize_error(error) == %{
+               type: :execution_error,
+               message: "boom",
+               details: %{step: :list, retry: false},
+               retryable?: false
+             }
     end
   end
 

--- a/test/jido_ai/turn_test.exs
+++ b/test/jido_ai/turn_test.exs
@@ -4,6 +4,7 @@ defmodule Jido.AI.TurnTest do
   import ExUnit.CaptureLog
 
   alias Jido.AI.Turn
+  alias Jido.Action.Error, as: ActionError
   alias ReqLLM.Message.ContentPart
   alias ReqLLM.ToolResult
 
@@ -268,6 +269,20 @@ defmodule Jido.AI.TurnTest do
                  "type" => "execution_error",
                  "retryable?" => false,
                  "details" => %{"reason" => "badarg"}
+               }
+             }
+    end
+
+    test "formats Jido.Action error structs without leaking struct metadata into details" do
+      error = ActionError.execution_error("boom", %{step: :list, retry: false})
+
+      assert decode_tool_content(Turn.format_tool_result_content({:error, error})) == %{
+               "ok" => false,
+               "error" => %{
+                 "message" => "boom",
+                 "type" => "execution_error",
+                 "retryable?" => false,
+                 "details" => %{"step" => "list", "retry" => false}
                }
              }
     end


### PR DESCRIPTION
## Summary
- route `Jido.Action.Error.*` structs through the struct-specific `normalize_error/4` path before the generic `%{message: ...}` fallback
- add regression coverage for `Jido.Action.Error.ExecutionFailureError` in both `Signal.Helpers.normalize_error/1` and `Turn.format_tool_result_content/1`

## Root Cause
`Jido.Action.Error.ExecutionFailureError` is a struct and therefore also matches the generic `%{message: ...}` clause in `Jido.AI.Signal.Helpers.normalize_error/4`. Because that clause ran first, it dropped `:message` from the struct-shaped map while leaving `__struct__` and `__exception__`, which could later crash JSON encoding when tool errors were appended to the turn context.

## Validation
- `mix test test/jido_ai/turn_test.exs test/jido_ai/signal/helpers_test.exs`

## Issue Links
Fixes #249
Refs agentjido/jido_action#157