### PR TITLE
feat(plugin_stack): allow callers to skip / reconfigure default plugins

### DIFF
--- a/lib/jido_ai/plugin_stack.ex
+++ b/lib/jido_ai/plugin_stack.ex
@@ -1,6 +1,42 @@
 defmodule Jido.AI.PluginStack do
   @moduledoc """
   Centralized default plugin composition for Jido.AI agent macros.
+
+  ## Opting out of / reconfiguring default plugins
+
+  Every agent built with `use Jido.AI.Agent` gets
+  `TaskSupervisor`, `Policy`, and `ModelRouting` by default. Two
+  options let callers customise that stack:
+
+    * `:skip_default_plugins` — list of default-plugin modules to
+      drop from the stack. Typical when a default plugin's
+      defaults conflict with a specialised agent (e.g. the
+      100 KB / injection-pattern gate in `Policy` is wrong for an
+      agent that receives server-generated audit prompts rather
+      than user input).
+    * `:default_plugin_config` — keyword list keyed by default
+      plugin module; each value is a map (or keyword list) merged
+      into the plugin's `mount/2` config. Used to tune a default
+      plugin without replacing it wholesale.
+
+  `:default_plugin_config` takes precedence over
+  `:skip_default_plugins` — if a module appears in both, it is
+  kept (reconfigured, not removed).
+
+  ## Examples
+
+      # Reconfigure Policy to run in :monitor mode
+      use Jido.AI.Agent,
+        name: "audit_agent",
+        default_plugin_config: [
+          {Jido.AI.Plugins.Policy, %{mode: :monitor, block_on_validation_error: false}}
+        ]
+
+      # Drop Policy entirely (Agent still composes with ToolGuard
+      # and other callers' guardrails)
+      use Jido.AI.Agent,
+        name: "trusted_internal_agent",
+        skip_default_plugins: [Jido.AI.Plugins.Policy]
   """
 
   @default_plugins [
@@ -12,19 +48,56 @@ defmodule Jido.AI.PluginStack do
   @doc """
   Returns the default runtime plugin list for AI agent macros.
 
-  Always includes `TaskSupervisor`, `Policy`, and `ModelRouting`.
-  Optional plugins are enabled via `:retrieval` and `:quota` options.
+  Always includes `TaskSupervisor`, `Policy`, and `ModelRouting`
+  unless overridden via `:skip_default_plugins` /
+  `:default_plugin_config`. Optional plugins are enabled via
+  `:retrieval` and `:quota` options.
   """
   @spec default_plugins(keyword()) :: [module() | {module(), map()}]
   def default_plugins(opts \\ []) when is_list(opts) do
+    skip = Keyword.get(opts, :skip_default_plugins, []) |> List.wrap()
+    overrides = Keyword.get(opts, :default_plugin_config, []) |> normalise_overrides()
+
     @default_plugins
+    |> Enum.flat_map(fn plugin_module ->
+      cond do
+        Map.has_key?(overrides, plugin_module) ->
+          [{plugin_module, Map.fetch!(overrides, plugin_module)}]
+
+        plugin_module in skip ->
+          []
+
+        true ->
+          [plugin_module]
+      end
+    end)
     |> maybe_add_optional(Jido.AI.Plugins.Retrieval, Keyword.get(opts, :retrieval, false))
     |> maybe_add_optional(Jido.AI.Plugins.Quota, Keyword.get(opts, :quota, false))
   end
 
+  defp normalise_overrides(list) when is_list(list) do
+    Enum.reduce(list, %{}, fn
+      {module, config}, acc when is_atom(module) and is_map(config) ->
+        Map.put(acc, module, config)
+
+      {module, config}, acc when is_atom(module) and is_list(config) ->
+        Map.put(acc, module, Map.new(config))
+
+      _other, acc ->
+        acc
+    end)
+  end
+
+  defp normalise_overrides(_), do: %{}
+
   defp maybe_add_optional(plugins, _module, false), do: plugins
   defp maybe_add_optional(plugins, module, true), do: plugins ++ [module]
-  defp maybe_add_optional(plugins, module, config) when is_map(config), do: plugins ++ [{module, config}]
-  defp maybe_add_optional(plugins, module, config) when is_list(config), do: plugins ++ [{module, Map.new(config)}]
+
+  defp maybe_add_optional(plugins, module, config) when is_map(config),
+    do: plugins ++ [{module, config}]
+
+  defp maybe_add_optional(plugins, module, config) when is_list(config),
+    do: plugins ++ [{module, Map.new(config)}]
+
   defp maybe_add_optional(plugins, _module, _), do: plugins
 end

--- a/test/jido_ai/plugin_stack_test.exs
+++ b/test/jido_ai/plugin_stack_test.exs
@@ -29,4 +29,73 @@ defmodule Jido.AI.PluginStackTest do
 
     assert {Jido.AI.Plugins.Quota, %{max_total_tokens: 1000}} in plugins
   end
+
+  describe "default plugin overrides" do
+    test ":skip_default_plugins drops named modules from the stack" do
+      plugins =
+        PluginStack.default_plugins(skip_default_plugins: [Jido.AI.Plugins.Policy])
+
+      plugin_mods = plugin_modules(plugins)
+
+      refute Jido.AI.Plugins.Policy in plugin_mods
+      assert Jido.AI.Plugins.TaskSupervisor in plugin_mods
+      assert Jido.AI.Plugins.ModelRouting in plugin_mods
+    end
+
+    test ":default_plugin_config replaces a bare module entry with a {module, config} tuple" do
+      plugins =
+        PluginStack.default_plugins(
+          default_plugin_config: [
+            {Jido.AI.Plugins.Policy, %{mode: :monitor, block_on_validation_error: false}}
+          ]
+        )
+
+      assert {Jido.AI.Plugins.Policy, %{mode: :monitor, block_on_validation_error: false}} in plugins
+      # And it stays in position (doesn't accidentally get removed or duplicated).
+      refute Jido.AI.Plugins.Policy in plugins
+      assert length(Enum.filter(plugins, &matches_policy?/1)) == 1
+    end
+
+    test ":default_plugin_config accepts keyword-list config and normalises to map" do
+      plugins =
+        PluginStack.default_plugins(
+          default_plugin_config: [{Jido.AI.Plugins.Policy, [mode: :monitor]}]
+        )
+
+      assert {Jido.AI.Plugins.Policy, %{mode: :monitor}} in plugins
+    end
+
+    test ":default_plugin_config wins over :skip_default_plugins for the same module" do
+      plugins =
+        PluginStack.default_plugins(
+          skip_default_plugins: [Jido.AI.Plugins.Policy],
+          default_plugin_config: [{Jido.AI.Plugins.Policy, %{mode: :monitor}}]
+        )
+
+      assert {Jido.AI.Plugins.Policy, %{mode: :monitor}} in plugins
+    end
+
+    test "optional plugins still layer on top of overrides" do
+      plugins =
+        PluginStack.default_plugins(
+          retrieval: true,
+          skip_default_plugins: [Jido.AI.Plugins.Policy]
+        )
+
+      plugin_mods = plugin_modules(plugins)
+      refute Jido.AI.Plugins.Policy in plugin_mods
+      assert Jido.AI.Plugins.Retrieval in plugin_mods
+    end
+  end
+
+  defp plugin_modules(plugins) do
+    Enum.map(plugins, fn
+      {mod, _cfg} -> mod
+      mod -> mod
+    end)
+  end
+
+  defp matches_policy?({Jido.AI.Plugins.Policy, _}), do: true
+  defp matches_policy?(Jido.AI.Plugins.Policy), do: true
+  defp matches_policy?(_), do: false
 end


### PR DESCRIPTION
## Problem

Every agent built via \`use Jido.AI.Agent\` receives the default plugin stack \`[TaskSupervisor, Policy, ModelRouting]\`, each mounted with empty config (\`%{}\`). Callers can \`plugins: [...]\` to *append* plugins, but can't:

- Drop a default plugin whose defaults don't apply (e.g. \`Policy\`'s 100 KB / injection-pattern prompt validator is wrong for an agent that handles server-generated prompts rather than untrusted user input).
- Reconfigure a default plugin's \`mount/2\` config.

Attempting \`plugins: [{Jido.AI.Plugins.Policy, %{...}}]\` fails at compile time with \`Duplicate plugin state_keys: [:policy]\` because \`Jido.Plugin\` enforces uniqueness on \`:state_key\` and the default \`Policy\` is already in \`ai_plugins\`.

## Solution

Two new opts forwarded from \`use Jido.AI.Agent\` → \`PluginStack.default_plugins/1\`:

- **\`:skip_default_plugins\`** — list of default-plugin modules to drop from the stack entirely.
- **\`:default_plugin_config\`** — keyword list keyed by default plugin module; each value is merged into the plugin's \`mount/2\` config. If a module appears in both \`:default_plugin_config\` and \`:skip_default_plugins\`, the config override wins.

Both are additive; agents that don't set them keep today's stack unchanged. No change needed in \`Jido.AI.Agent\` — \`opts\` already flows into \`default_plugins/1\` wholesale at \`lib/jido_ai/agent.ex:336\`.

## Example

\`\`\`elixir
defmodule MyAuditAgent do
  use Jido.AI.Agent,
    name: "audit_agent",
    tools: [ReadFile, SearchFiles],
    # Server-generated prompts: long, internally trusted.
    # Monitor violations for observability but don't block.
    default_plugin_config: [
      {Jido.AI.Plugins.Policy,
       %{mode: :monitor, block_on_validation_error: false}}
    ]
end
\`\`\`

## Real-world use case

Our PR-review pipeline runs a \`Verifier\` agent that receives prompts constructed from the bucket diff + workspace rules + conceptual docs + Mattermost excerpts + linked GitHub issues + Phase 1 reviewer findings. These are our *own* concatenation of structured data, not a chat surface — but they routinely exceed \`Jido.AI.Plugins.Policy\`'s default 100 KB byte-size cap, causing every verify bucket to fail fast with \`{:rejected, :policy_violation, "request blocked by policy"}\`.

Prompt-injection defence makes sense against untrusted input; it's the wrong threat model for server-generated audit prompts. We want \`Policy\` running in \`:monitor\` mode (log violations for observability, don't short-circuit).

## Tests

Extended \`test/jido_ai/plugin_stack_test.exs\` with five cases covering:

- \`:skip_default_plugins\` drops named modules
- \`:default_plugin_config\` replaces bare-module entry with \`{module, config}\`
- Keyword-list config is normalised to map
- Override wins over skip for the same module
- Optional plugins (\`:retrieval\`, \`:quota\`) still layer on top

8/8 PluginStack tests green; existing three tests unchanged.

## Backwards compatibility

Zero. No change to \`default_plugins([])\` output when neither new opt is set. No change to the \`Jido.AI.Agent\` macro surface. Every existing agent keeps its current plugin stack.