### PR TITLE
Forward default plugin overrides from AI agents

### DIFF
--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -334,6 +334,11 @@ defmodule Jido.AI.Agent do
     # that need to be evaluated in the calling module's context
     plugins = Keyword.get(opts, :plugins, [])
 
+    default_plugins =
+      opts
+      |> Keyword.get(:default_plugins)
+      |> __MODULE__.expand_and_eval_literal_option(__CALLER__)
+
     ai_plugins = Jido.AI.PluginStack.default_plugins(opts)
 
     # Extract tool_context at macro expansion time
@@ -433,6 +438,7 @@ defmodule Jido.AI.Agent do
         description: unquote(description),
         tags: unquote(tags),
         plugins: unquote(ai_plugins) ++ unquote(plugins),
+        default_plugins: unquote(Macro.escape(default_plugins)),
         strategy: {Jido.AI.Reasoning.ReAct.Strategy, unquote(strategy_opts_ast)},
         schema: unquote(base_schema_ast)
 

--- a/test/jido_ai/agent_test.exs
+++ b/test/jido_ai/agent_test.exs
@@ -47,6 +47,26 @@ defmodule Jido.AI.AgentTest do
     def transform_request(request, _state, _config, _context), do: {:ok, request}
   end
 
+  defmodule ReplacementMemoryPlugin do
+    @moduledoc false
+    @state_schema Zoi.object(%{namespace: Zoi.string() |> Zoi.default("agent:replacement")})
+    @config_schema Zoi.object(%{namespace: Zoi.string() |> Zoi.default("agent:replacement")})
+
+    use Jido.Plugin,
+      name: "replacement_memory",
+      state_key: :__memory__,
+      actions: [],
+      schema: @state_schema,
+      config_schema: @config_schema,
+      singleton: true,
+      capabilities: [:memory]
+
+    @impl true
+    def mount(_agent, config) do
+      {:ok, %{namespace: Map.get(config, :namespace, "agent:replacement")}}
+    end
+  end
+
   # ============================================================================
   # Test Agents Using Agent Macro
   # ============================================================================
@@ -156,6 +176,20 @@ defmodule Jido.AI.AgentTest do
       system_prompt: nil
   end
 
+  defmodule AgentWithoutDefaultMemory do
+    use Jido.AI.Agent,
+      name: "agent_without_default_memory",
+      tools: [TestCalculator],
+      default_plugins: %{__memory__: false}
+  end
+
+  defmodule AgentWithReplacementMemory do
+    use Jido.AI.Agent,
+      name: "agent_with_replacement_memory",
+      tools: [TestCalculator],
+      default_plugins: %{__memory__: {ReplacementMemoryPlugin, %{namespace: "agent:ai-replacement"}}}
+  end
+
   # ============================================================================
   # expand_aliases_in_ast/2 Tests
   # ============================================================================
@@ -237,6 +271,23 @@ defmodule Jido.AI.AgentTest do
     test "agent has correct description" do
       agent = BasicAgent.new()
       assert agent.description == "A basic test agent"
+    end
+
+    test "forwards default plugin exclusions to Jido.Agent" do
+      modules = Enum.map(AgentWithoutDefaultMemory.plugin_instances(), & &1.module)
+
+      refute Jido.Memory.Plugin in modules
+      assert Jido.Thread.Plugin in modules
+      assert Jido.Identity.Plugin in modules
+    end
+
+    test "forwards default plugin replacements with config to Jido.Agent" do
+      modules = Enum.map(AgentWithReplacementMemory.plugin_instances(), & &1.module)
+      agent = AgentWithReplacementMemory.new()
+
+      assert ReplacementMemoryPlugin in modules
+      refute Jido.Memory.Plugin in modules
+      assert agent.state[:__memory__].namespace == "agent:ai-replacement"
     end
 
     test "tool_context with module aliases resolves correctly" do


### PR DESCRIPTION
## Summary
- evaluate the `default_plugins` option in `Jido.AI.Agent`
- forward default plugin overrides into the generated `use Jido.Agent` call
- add regression coverage for disabling and replacing the canonical `:__memory__` default plugin

## Tests
- `mix format --check-formatted`
- `mix test test/jido_ai/agent_test.exs`