### PR TITLE
fix: add direct tool registration API

### DIFF
--- a/lib/jido_ai.ex
+++ b/lib/jido_ai.ex
@@ -82,6 +82,7 @@ defmodule Jido.AI do
   alias Jido.Agent.Strategy.State, as: StratState
   alias Jido.AI.ModelAliases
   alias Jido.AI.Reasoning.ReAct
+  alias Jido.AI.ToolAdapter
   alias Jido.AI.Turn
   alias ReqLLM.Context
 
@@ -490,6 +491,41 @@ defmodule Jido.AI do
   # ============================================================================
 
   @doc """
+  Registers a tool module directly on an agent struct.
+
+  This is the struct-level equivalent of `register_tool/3` — safe to call from
+  within the agent process or an action already executing inside the agent. It
+  updates the ReAct strategy tool config without sending an `AgentServer` signal.
+
+  ## Options
+
+    * `:validate` - Validate tool implements required callbacks (default: true)
+  """
+  @spec register_tool_direct(Jido.Agent.t(), module(), keyword()) ::
+          {:ok, Jido.Agent.t()} | {:error, term()}
+  def register_tool_direct(%Jido.Agent{} = agent, tool_module, opts \\ [])
+      when is_atom(tool_module) do
+    if Keyword.get(opts, :validate, true) do
+      with :ok <- validate_tool_module(tool_module) do
+        {:ok, add_tool_to_agent(agent, tool_module)}
+      end
+    else
+      {:ok, add_tool_to_agent(agent, tool_module)}
+    end
+  end
+
+  @doc """
+  Unregisters a tool directly from an agent struct by tool name.
+
+  This is the struct-level equivalent of `unregister_tool/3` — safe to call from
+  within the agent process or an action already executing inside the agent.
+  """
+  @spec unregister_tool_direct(Jido.Agent.t(), String.t()) :: {:ok, Jido.Agent.t()}
+  def unregister_tool_direct(%Jido.Agent{} = agent, tool_name) when is_binary(tool_name) do
+    {:ok, remove_tool_from_agent(agent, tool_name)}
+  end
+
+  @doc """
   Sets the system prompt directly on the agent's strategy config.
 
   This is the struct-level equivalent of `set_system_prompt/3` — safe to call
@@ -584,6 +620,35 @@ defmodule Jido.AI do
       _ ->
         strat_state
     end
+  end
+
+  defp add_tool_to_agent(%Jido.Agent{} = agent, tool_module) do
+    update_agent_tools(agent, fn tools ->
+      [tool_module | tools] |> Enum.uniq()
+    end)
+  end
+
+  defp remove_tool_from_agent(%Jido.Agent{} = agent, tool_name) do
+    update_agent_tools(agent, fn tools ->
+      Enum.reject(tools, fn module -> module.name() == tool_name end)
+    end)
+  end
+
+  defp update_agent_tools(%Jido.Agent{} = agent, update_fun) when is_function(update_fun, 1) do
+    StratState.update(agent, fn strat_state ->
+      config = Map.get(strat_state, :config, %{})
+      tools = config |> Map.get(:tools, []) |> List.wrap() |> update_fun.()
+      actions_by_name = Map.new(tools, &{&1.name(), &1})
+      reqllm_tools = ToolAdapter.from_actions(tools)
+
+      updated_config =
+        config
+        |> Map.put(:tools, tools)
+        |> Map.put(:actions_by_name, actions_by_name)
+        |> Map.put(:reqllm_tools, reqllm_tools)
+
+      Map.put(strat_state, :config, updated_config)
+    end)
   end
 
   # Private helpers for tool management

--- a/test/jido_ai/jido_ai_core_test.exs
+++ b/test/jido_ai/jido_ai_core_test.exs
@@ -234,6 +234,36 @@ defmodule Jido.AI.CoreTest do
       assert {:ok, :registered} = AI.register_tool(self(), ValidTool)
     end
 
+    test "register_tool_direct validates and updates strategy tool config without AgentServer call" do
+      agent = %Jido.Agent{state: %{}}
+
+      assert {:error, {:not_loaded, Missing.Tool}} =
+               AI.register_tool_direct(agent, Missing.Tool)
+
+      assert {:error, :not_a_tool} = AI.register_tool_direct(agent, IncompleteTool)
+
+      assert {:ok, agent} = AI.register_tool_direct(agent, ValidTool)
+
+      config = AI.get_strategy_config(agent)
+      assert config.tools == [ValidTool]
+      assert config.actions_by_name == %{"valid_tool" => ValidTool}
+      assert AI.list_tools(agent) == [ValidTool]
+      assert AI.has_tool?(agent, "valid_tool")
+    end
+
+    test "unregister_tool_direct removes tool config without AgentServer call" do
+      agent = %Jido.Agent{state: %{}}
+      assert {:ok, agent} = AI.register_tool_direct(agent, ValidTool)
+      assert {:ok, agent} = AI.unregister_tool_direct(agent, "valid_tool")
+
+      config = AI.get_strategy_config(agent)
+      assert config.tools == []
+      assert config.actions_by_name == %{}
+      assert config.reqllm_tools == []
+      assert AI.list_tools(agent) == []
+      refute AI.has_tool?(agent, "valid_tool")
+    end
+
     test "unregister_tool and set_system_prompt wrap signals and delegate call" do
       Mimic.stub(Jido.AgentServer, :call, fn _server, signal, timeout ->
         assert timeout == 5_000


### PR DESCRIPTION
## Summary
- add struct-level `register_tool_direct/3` and `unregister_tool_direct/2` APIs
- keep ReAct tools, actions_by_name, and reqllm_tools synchronized without AgentServer signals
- cover direct registration validation and unregistration behavior

## Verification
- `mix test test/jido_ai/jido_ai_core_test.exs`
- `mix test`

## Notes
This is the tactical unblocker for actions already executing inside an agent, such as dynamic MCP sync. A first-class dynamic tool provider remains the cleaner longer-term direction.