### PR TITLE
[codex] Fix lazy-loaded plugin-routed action execution

### DIFF
--- a/lib/jido_ai/reasoning/helpers.ex
+++ b/lib/jido_ai/reasoning/helpers.ex
@@ -59,7 +59,7 @@ defmodule Jido.AI.Reasoning.Helpers do
   end
 
   @doc """
-  Executes an instruction if its action is a module implementing `run/2`.
+  Executes an instruction if its action is a loadable module implementing `run/2`.
 
   Returns `:noop` when the action is not an executable module.
   """
@@ -68,12 +68,18 @@ defmodule Jido.AI.Reasoning.Helpers do
   def maybe_execute_action_instruction(%Agent{} = agent, %Jido.Instruction{} = instruction, ctx \\ %{}) do
     action = instruction.action
 
-    if is_atom(action) and function_exported?(action, :run, 2) do
+    if executable_action_module?(action) do
       execute_action_instruction(agent, instruction, ctx)
     else
       :noop
     end
   end
+
+  defp executable_action_module?(action) when is_atom(action) do
+    Code.ensure_loaded?(action) and function_exported?(action, :run, 2)
+  end
+
+  defp executable_action_module?(_), do: false
 
   @doc """
   Builds normalized context for plugin-routed action execution.

--- a/test/jido_ai/integration/jido_v2_migration_test.exs
+++ b/test/jido_ai/integration/jido_v2_migration_test.exs
@@ -78,6 +78,23 @@ defmodule Jido.AI.Integration.JidoV2MigrationTest do
       assert updated_agent.state.plugin_fallback_executed == true
       assert is_list(directives)
     end
+
+    test "ReAct strategy lazy-loads plugin-routed action modules before fallback execution" do
+      agent = %Agent{id: "test-agent", name: "test", state: %{}}
+      {agent, _} = ReAct.init(agent, %{strategy_opts: [tools: [TestCalculator]]})
+
+      action = compile_lazy_plugin_action()
+      assert :code.is_loaded(action) == false
+
+      instruction = %Jido.Instruction{action: action, params: %{}}
+
+      {updated_agent, directives} =
+        ReAct.cmd(agent, [instruction], %{agent_module: __MODULE__, strategy_opts: [tools: [TestCalculator]]})
+
+      assert updated_agent.state.plugin_fallback_executed == true
+      assert is_list(directives)
+      assert match?({:file, _}, :code.is_loaded(action))
+    end
   end
 
   describe "Direct Action Execution" do
@@ -221,5 +238,42 @@ defmodule Jido.AI.Integration.JidoV2MigrationTest do
       assert function_exported?(helpers, :execute_action_instruction, 3)
       assert function_exported?(helpers, :action_context, 2)
     end
+  end
+
+  defp compile_lazy_plugin_action do
+    suffix = System.unique_integer([:positive, :monotonic])
+    module = Module.concat(__MODULE__, :"LazyPluginFallbackAction#{suffix}")
+    dir = Path.join(System.tmp_dir!(), "jido_ai_lazy_plugin_action_#{suffix}")
+    beam_file = Path.join(dir, Atom.to_string(module) <> ".beam")
+
+    File.mkdir_p!(dir)
+
+    source = """
+    defmodule #{inspect(module)} do
+      use Jido.Action,
+        name: "lazy_plugin_fallback_action_#{suffix}",
+        description: "sets a marker in state"
+
+      def run(_params, _context), do: {:ok, %{plugin_fallback_executed: true}}
+    end
+    """
+
+    [{^module, beam}] = Code.compile_string(source)
+    File.write!(beam_file, beam)
+    Code.prepend_path(dir)
+    unload_module(module)
+
+    on_exit(fn ->
+      unload_module(module)
+      Code.delete_path(dir)
+      File.rm_rf!(dir)
+    end)
+
+    module
+  end
+
+  defp unload_module(module) do
+    :code.delete(module)
+    :code.purge(module)
   end
 end


### PR DESCRIPTION
## Summary
- ensure plugin-routed action modules are loaded before ReAct strategy fallback checks `run/2`
- add a regression test for the compiled-but-unloaded module case that previously no-oped
- preserve the existing fallback behavior for non-action instructions

## Root Cause
Built-in reasoning strategies route unknown non-strategy instructions through `Jido.AI.Reasoning.Helpers.maybe_execute_action_instruction/3`.
That helper checked `function_exported?(action, :run, 2)` directly, which returns `false` for an unloaded module.
As a result, plugin signal routes could silently no-op until something else had already loaded the target action module into the VM.

## Why This Matters
This surfaced with MCP plugin signal routes, where the route target existed and was compiled but had not yet been loaded at runtime.
The fix makes plugin-routed action execution deterministic instead of depending on incidental prior module loads.

## Validation
- `mix test test/jido_ai/integration/jido_v2_migration_test.exs`

## Issue Links
- Refs agentjido/jido_mcp#1
- Follow-up to agentjido/jido_mcp#6