### PR TITLE
fix: preserve LLM delta ordering metadata

### DIFF
--- a/guides/developer/signals_namespaces_contracts.md
+++ b/guides/developer/signals_namespaces_contracts.md
@@ -36,6 +36,7 @@ Typed signal modules define payload contracts and canonical signal types:
 
 ## Lifecycle Notes
 
+- `ai.llm.delta` carries incremental model text. Runtime-backed strategies may include optional ordering and correlation fields (`seq`, `request_id`, `run_id`, `iteration`). Consumers that need exact transcript reconstruction should order deltas by `seq` within the same `call_id` when it is present; delivery order alone is not a durable ordering contract.
 - `ai.tool.started` is the public start-of-execution contract for tool-capable runtimes.
 - `ai.tool.result` is the terminal contract for both success and failure.
 - `ai.request.started`, `ai.request.completed`, and `ai.request.failed` are expected across reasoning strategies, including AoT, CoT/CoD, GoT, ReAct, ToT, and TRM.

--- a/lib/jido_ai/reasoning/chain_of_thought/strategy.ex
+++ b/lib/jido_ai/reasoning/chain_of_thought/strategy.ex
@@ -479,7 +479,9 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Strategy do
             base_state
           end
 
-        signal = Signal.LLMDelta.new!(%{call_id: llm_call_id || "", delta: delta, chunk_type: chunk_type})
+        signal =
+          Signal.LLMDelta.new!(llm_delta_signal_data(event, request_id, run_id, llm_call_id, delta, chunk_type))
+
         {updated, [signal]}
 
       :llm_completed ->
@@ -604,6 +606,20 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Strategy do
   defp event_field(map, key, default \\ nil) when is_map(map) do
     Map.get(map, key, Map.get(map, Atom.to_string(key), default))
   end
+
+  defp llm_delta_signal_data(event, request_id, run_id, llm_call_id, delta, chunk_type) do
+    %{
+      call_id: llm_call_id || "",
+      delta: delta,
+      chunk_type: chunk_type
+    }
+    |> maybe_put(:seq, event_field(event, :seq))
+    |> maybe_put(:run_id, run_id)
+    |> maybe_put(:request_id, request_id)
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp normalize_event_map(event) when is_map(event), do: event
 

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -1547,12 +1547,9 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           end
 
         signal =
-          Signal.LLMDelta.new!(%{
-            call_id: llm_call_id || "",
-            delta: delta,
-            chunk_type: chunk_type,
-            metadata: runtime_signal_metadata(request_id, run_id, iteration, :generate_text)
-          })
+          Signal.LLMDelta.new!(
+            llm_delta_signal_data(event, request_id, run_id, iteration, llm_call_id, delta, chunk_type)
+          )
 
         emit_runtime_telemetry(state, :llm_delta, request_id, run_id, iteration, llm_call_id, event, data)
         {updated, [signal]}
@@ -1835,6 +1832,22 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   defp event_field(map, key, default \\ nil) when is_map(map) do
     Map.get(map, key, Map.get(map, Atom.to_string(key), default))
   end
+
+  defp llm_delta_signal_data(event, request_id, run_id, iteration, llm_call_id, delta, chunk_type) do
+    %{
+      call_id: llm_call_id || "",
+      delta: delta,
+      chunk_type: chunk_type,
+      metadata: runtime_signal_metadata(request_id, run_id, iteration, :generate_text)
+    }
+    |> maybe_put(:seq, event_field(event, :seq))
+    |> maybe_put(:run_id, run_id)
+    |> maybe_put(:request_id, request_id)
+    |> maybe_put(:iteration, iteration)
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp normalize_event_map(event) when is_map(event), do: event
 

--- a/lib/jido_ai/signals/llm_delta.ex
+++ b/lib/jido_ai/signals/llm_delta.ex
@@ -10,6 +10,10 @@ defmodule Jido.AI.Signal.LLMDelta do
       call_id: [type: :string, required: true, doc: "Correlation ID for the LLM call"],
       delta: [type: :string, required: true, doc: "Text chunk from the stream"],
       chunk_type: [type: :atom, default: :content, doc: "Type: :content or :thinking"],
-      metadata: [type: :map, default: %{}, doc: "Optional request/run metadata for correlation"]
+      metadata: [type: :map, default: %{}, doc: "Optional request/run metadata for correlation"],
+      seq: [type: :integer, doc: "Monotonic runtime sequence number for this delta, when available"],
+      run_id: [type: :string, doc: "Runtime run identifier, when available"],
+      request_id: [type: :string, doc: "Request correlation identifier, when available"],
+      iteration: [type: :integer, doc: "ReAct/runtime iteration number, when available"]
     ]
 end

--- a/test/jido_ai/signal_test.exs
+++ b/test/jido_ai/signal_test.exs
@@ -185,6 +185,23 @@ defmodule Jido.AI.SignalTest do
       assert signal.data.metadata == %{request_id: "req_1", run_id: "req_1", strategy: :react}
     end
 
+    test "creates partial signal with runtime ordering metadata" do
+      signal =
+        LLMDelta.new!(%{
+          call_id: "call_partial_6",
+          delta: "ordered",
+          seq: 42,
+          run_id: "run_1",
+          request_id: "req_1",
+          iteration: 3
+        })
+
+      assert signal.data.seq == 42
+      assert signal.data.run_id == "run_1"
+      assert signal.data.request_id == "req_1"
+      assert signal.data.iteration == 3
+    end
+
     test "creates multiple partial signals for streaming" do
       chunks = ["Hello", ", ", "world", "!"]
 

--- a/test/jido_ai/strategy/chain_of_thought_test.exs
+++ b/test/jido_ai/strategy/chain_of_thought_test.exs
@@ -200,6 +200,25 @@ defmodule Jido.AI.Reasoning.ChainOfThought.StrategyTest do
       assert state[:cot_worker_status] == :ready
     end
 
+    test "propagates runtime ordering metadata to LLMDelta signals" do
+      agent = create_agent()
+      request_id = "req_cot_delta_meta"
+
+      event = worker_event(:llm_delta, request_id, 23, %{chunk_type: :content, delta: "ordered"})
+
+      {_agent, []} =
+        ChainOfThought.cmd(agent, [instruction(:cot_worker_event, %{request_id: request_id, event: event})], %{})
+
+      assert_receive {:"$gen_cast", {:signal, signal}}
+      assert signal.type == "ai.llm.delta"
+      assert signal.data.call_id == "cot_call_req_cot_delta_meta"
+      assert signal.data.delta == "ordered"
+      assert signal.data.chunk_type == :content
+      assert signal.data.seq == 23
+      assert signal.data.run_id == request_id
+      assert signal.data.request_id == request_id
+    end
+
     test "request_failed worker event transitions to error state" do
       agent = create_agent()
 

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -973,6 +973,26 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
                       }}
     end
 
+    test "propagates runtime ordering metadata to LLMDelta signals" do
+      agent = create_agent(tools: [TestCalculator])
+      request_id = "req_delta_meta"
+
+      event = runtime_event(:llm_delta, request_id, 17, %{chunk_type: :content, delta: "ordered"})
+
+      {_agent, []} =
+        ReAct.cmd(agent, [instruction(:ai_react_worker_event, %{request_id: request_id, event: event})], %{})
+
+      assert_receive {:"$gen_cast", {:signal, signal}}
+      assert signal.type == "ai.llm.delta"
+      assert signal.data.call_id == "call_req_delta_meta"
+      assert signal.data.delta == "ordered"
+      assert signal.data.chunk_type == :content
+      assert signal.data.seq == 17
+      assert signal.data.run_id == request_id
+      assert signal.data.request_id == request_id
+      assert signal.data.iteration == 1
+    end
+
     test "stores request trace up to 2000 events then marks truncated" do
       agent = create_agent(tools: [TestCalculator])
       request_id = "req_trace"


### PR DESCRIPTION
## Summary

- add optional ordering/correlation fields to `ai.llm.delta`
- propagate runtime `seq`, `run_id`, `request_id`, and `iteration` from ReAct deltas
- propagate available worker metadata from ChainOfThought deltas
- document that consumers should order deltas by `seq` within a `call_id` when exact transcript reconstruction matters

## Why

Runtime-backed strategies already have ordered runtime events, but derived `ai.llm.delta` signals dropped that metadata. Consumers receiving deltas out of delivery order could not reconstruct the intended stream.

## Tests

- `mix test test/jido_ai/signal_test.exs test/jido_ai/strategy/react_test.exs test/jido_ai/strategy/chain_of_thought_test.exs`
- `mix test.fast`
- `mix compile --warnings-as-errors`