### PR TITLE
ci: roll out jido workflows v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main
@@ -10,16 +11,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
-  lint:
-    name: Lint
-    uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@v3
-    secrets: inherit
+permissions:
+  actions: read
+  contents: read
 
-  test:
-    name: Test
-    uses: agentjido/github-actions/.github/workflows/elixir-test.yml@v3
+jobs:
+  ci:
+    name: CI
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v4
+    secrets: inherit
     with:
       otp_versions: '["27", "28"]'
       elixir_versions: '["1.18", "1.19"]'
+      experimental_compile_elixir_versions: '["v1.20.0-rc.4"]'
+      experimental_compile_otp_versions: '["28.4.1"]'
+      experimental_compile_otp_name: '28'
+      credo_command: mix credo --min-priority high --all
+      docs_command: mix docs -f html
       test_command: mix test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,25 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
+      operation:
+        description: "Release operation: auto, prepare, or publish"
+        required: false
+        type: choice
+        default: auto
+        options:
+          - auto
+          - prepare
+          - publish
+      tag_name:
+        description: "Optional v-prefixed tag for publish simulation"
+        required: false
+        type: string
+        default: ""
       dry_run:
         description: "Dry run (no git push, no tag, no GitHub release, no Hex publish)"
         required: false
@@ -18,16 +35,25 @@ on:
         required: false
         type: boolean
         default: false
+      version_override:
+        description: "Optional bare SemVer override (for example 1.2.3, not v1.2.3)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
+  actions: read
   contents: write
 
 jobs:
   release:
     name: Release
-    uses: agentjido/github-actions/.github/workflows/elixir-release.yml@v3
+    uses: agentjido/github-actions/.github/workflows/jido-release.yml@v4
     with:
-      dry_run: ${{ inputs.dry_run }}
-      hex_dry_run: ${{ inputs.hex_dry_run }}
-      skip_tests: ${{ inputs.skip_tests }}
+      operation: ${{ inputs.operation || 'auto' }}
+      tag_name: ${{ inputs.tag_name || '' }}
+      dry_run: ${{ inputs.dry_run || false }}
+      hex_dry_run: ${{ inputs.hex_dry_run || false }}
+      skip_tests: ${{ inputs.skip_tests || false }}
+      version_override: ${{ inputs.version_override || '' }}
     secrets: inherit

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,21 @@
+name: Jido Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    name: Jido Review
+    uses: agentjido/github-actions/.github/workflows/jido-review.yml@v4


### PR DESCRIPTION
## Summary

- switch CI to `agentjido/github-actions/.github/workflows/jido-ci.yml@v4`
- add merge queue coverage and read-only workflow permissions
- keep the package's current Credo quality threshold with `mix credo --min-priority high --all`
- switch release to the tag-driven `jido-release.yml@v4` lane with dispatch-supported git_ops prep
- add `jido-review.yml@v4` for advisory PR review and conventional commit title checks

## Validation

- `mix deps.get`
- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix hex.audit`
- `mix credo --min-priority high --all`
- `mix deps.unlock --check-unused`
- `mix docs -f html`
- `mix test`
- `HEX_API_KEY=dry-run mix hex.publish --dry-run --yes`
- YAML parse for workflows
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`

## Notes

This PR uses the published `@v4` workflow tag. No package release or publish is performed by this PR.

Dialyzer is left to GitHub CI for this rollout pass.

Rollout template: https://github.com/agentjido/github-actions/blob/main/JIDO_PACKAGE_ROLLOUT.md
