### PR TITLE
fix: sanitize unsafe tool response details

### DIFF
--- a/guides/developer/directives_runtime_contract.md
+++ b/guides/developer/directives_runtime_contract.md
@@ -46,6 +46,9 @@ Runtime-emitted failures for `ai.llm.response` and `ai.tool.result` normalize to
 Legacy error shapes may still enter at boundaries, but runtime helpers normalize
 them before the signal leaves the runtime layer.
 
+`details` is sanitized to JSON-safe values at this boundary so tuple/pid/ref terms
+cannot break downstream envelope encoding.
+
 ## Tool Result Content Contract
 
 For model follow-up turns, the canonical tool result semantics should be

--- a/guides/developer/error_model_and_recovery.md
+++ b/guides/developer/error_model_and_recovery.md
@@ -32,6 +32,10 @@ Upstream packages such as `jido_action` should stay generic. They can expose
 error type/message/details and retryability, but they should not define
 AI-specific contracts.
 
+At this boundary, envelope `details` are normalized to JSON-safe values. Raw
+runtime terms (for example tuples, pids, refs) are stringified so signal and
+telemetry payload encoding stays reliable.
+
 ## Example: Sanitized User Message + Full Log
 
 ```elixir

--- a/lib/jido_ai/signals/helpers.ex
+++ b/lib/jido_ai/signals/helpers.ex
@@ -25,7 +25,7 @@ defmodule Jido.AI.Signal.Helpers do
     %{
       type: type,
       message: message,
-      details: details,
+      details: normalize_json_safe_map(details),
       retryable?: retryable?
     }
   end
@@ -225,7 +225,42 @@ defmodule Jido.AI.Signal.Helpers do
 
   defp merge_error_details(details, extra_details) when is_map(details) and is_map(extra_details) do
     Map.merge(details, extra_details)
+    |> normalize_json_safe_map()
   end
+
+  defp normalize_json_safe_map(map) when is_map(map) do
+    Map.new(map, fn {key, value} ->
+      {normalize_json_safe_key(key), normalize_json_safe_value(value)}
+    end)
+  end
+
+  defp normalize_json_safe_key(key) when is_binary(key), do: key
+  defp normalize_json_safe_key(key) when is_atom(key), do: key
+  defp normalize_json_safe_key(key), do: inspect(key)
+
+  defp normalize_json_safe_value(value) when is_nil(value), do: nil
+  defp normalize_json_safe_value(value) when is_boolean(value), do: value
+  defp normalize_json_safe_value(value) when is_integer(value), do: value
+  defp normalize_json_safe_value(value) when is_float(value), do: value
+  defp normalize_json_safe_value(value) when is_binary(value), do: value
+
+  defp normalize_json_safe_value(value) when is_atom(value), do: value
+
+  defp normalize_json_safe_value(value) when is_list(value) do
+    Enum.map(value, &normalize_json_safe_value/1)
+  end
+
+  defp normalize_json_safe_value(%_{} = struct) do
+    struct
+    |> Map.from_struct()
+    |> normalize_json_safe_map()
+  end
+
+  defp normalize_json_safe_value(value) when is_map(value) do
+    normalize_json_safe_map(value)
+  end
+
+  defp normalize_json_safe_value(value), do: inspect(value)
 
   defp normalize_retryable(error, type) do
     cond do

--- a/test/jido_ai/signal/helpers_test.exs
+++ b/test/jido_ai/signal/helpers_test.exs
@@ -46,7 +46,43 @@ defmodule Jido.AI.Signal.HelpersTest do
                message: "boom",
                details: %{step: :list, retry: false},
                retryable?: false
-             }
+              }
+    end
+
+    test "normalizes details into JSON-safe values" do
+      envelope =
+        Helpers.normalize_error(%{
+          type: :execution_error,
+          message: "boom",
+          details: %{
+            pid: self(),
+            ref: make_ref(),
+            tuple: {:error, :bad},
+            nested: %{inner: {:ok, :value}}
+          }
+        })
+
+      assert is_binary(envelope.details.pid)
+      assert is_binary(envelope.details.ref)
+      assert is_binary(envelope.details.tuple)
+      assert is_binary(envelope.details.nested.inner)
+      assert Jason.encode!(envelope)
+    end
+
+    test "error_envelope/4 sanitizes direct details payloads" do
+      envelope =
+        Helpers.error_envelope(:execution_error, "boom", %{
+          pid: self(),
+          ref: make_ref(),
+          tuple: {:error, :bad},
+          map_key: %{1 => :one}
+        })
+
+      assert is_binary(envelope.details.pid)
+      assert is_binary(envelope.details.ref)
+      assert is_binary(envelope.details.tuple)
+      assert envelope.details.map_key["1"] == :one
+      assert Jason.encode!(envelope)
     end
   end
 

--- a/test/jido_ai/signal/helpers_test.exs
+++ b/test/jido_ai/signal/helpers_test.exs
@@ -46,7 +46,7 @@ defmodule Jido.AI.Signal.HelpersTest do
                message: "boom",
                details: %{step: :list, retry: false},
                retryable?: false
-              }
+             }
     end
 
     test "normalizes details into JSON-safe values" do


### PR DESCRIPTION
## Summary
- sanitize AI runtime error envelope details into JSON-safe values
- document sanitized details at the signal/runtime boundary
- format the helper tests so CI format passes

Supersedes #266 because that fork branch does not allow maintainer pushes.

## Tests
- mix format --check-formatted
- mix test test/jido_ai/signal/helpers_test.exs
- mix compile --warnings-as-errors
- mix precommit