### PR TITLE
fix: tool_call_id is missing from certain tool call events in telemtery

### DIFF
--- a/lib/jido_ai/directive/tool_exec.ex
+++ b/lib/jido_ai/directive/tool_exec.ex
@@ -163,15 +163,13 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
              event_meta
            )
 
-           exec_context = Map.merge(context, %{call_id: call_id, tool_call_id: call_id})
-
            {result, retry_count} =
              execute_with_retries(
                task_supervisor,
                action_module,
                tool_name,
                arguments,
-               exec_context,
+               context,
                tools,
                timeout_ms,
                max_retries,
@@ -300,7 +298,8 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
           arguments,
           context,
           tools,
-          timeout_ms
+          timeout_ms,
+          event_meta
         )
 
       case result do
@@ -326,12 +325,13 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
          arguments,
          context,
          tools,
-         timeout_ms
+         timeout_ms,
+         event_meta
        ) do
     if is_integer(timeout_ms) and timeout_ms > 0 do
       task =
         Task.Supervisor.async_nolink(task_supervisor, fn ->
-          execute_action(action_module, tool_name, arguments, context, tools)
+          execute_action(action_module, tool_name, arguments, context, tools, event_meta)
         end)
 
       try do
@@ -351,19 +351,21 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
         Process.demonitor(task.ref, [:flush])
       end
     else
-      execute_action(action_module, tool_name, arguments, context, tools)
+      execute_action(action_module, tool_name, arguments, context, tools, event_meta)
       |> normalize_result(tool_name)
     end
   end
 
-  defp execute_action(action_module, tool_name, arguments, context, tools) do
+  defp execute_action(action_module, tool_name, arguments, context, tools, event_meta) do
     try do
+      telemetry_metadata = turn_telemetry_metadata(event_meta)
+
       case action_module do
         nil ->
-          Turn.execute(tool_name, arguments, context, tools: tools)
+          Turn.execute(tool_name, arguments, context, tools: tools, telemetry_metadata: telemetry_metadata)
 
         module when is_atom(module) ->
-          Turn.execute_module(module, arguments, context)
+          Turn.execute_module(module, arguments, context, telemetry_metadata: telemetry_metadata)
       end
     rescue
       e ->
@@ -384,6 +386,11 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
            false
          ), []}
     end
+  end
+
+  defp turn_telemetry_metadata(event_meta) when is_map(event_meta) do
+    call_id = Map.get(event_meta, :tool_call_id)
+    Map.put(event_meta, :call_id, call_id)
   end
 
   defp normalize_result({:ok, result, effects}, _tool_name), do: {:ok, result, List.wrap(effects)}

--- a/lib/jido_ai/directive/tool_exec.ex
+++ b/lib/jido_ai/directive/tool_exec.ex
@@ -163,13 +163,15 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
              event_meta
            )
 
+           exec_context = Map.merge(context, %{call_id: call_id, tool_call_id: call_id})
+
            {result, retry_count} =
              execute_with_retries(
                task_supervisor,
                action_module,
                tool_name,
                arguments,
-               context,
+               exec_context,
                tools,
                timeout_ms,
                max_retries,

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -862,12 +862,13 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   defp do_execute_tool_with_retries(%PendingToolCall{} = pending_call, module, %Config{} = config, context, attempt) do
     start_ms = System.monotonic_time(:millisecond)
     timeout_ms = normalize_timeout(config.tool_exec[:timeout_ms])
-    context = Map.merge(context, %{call_id: pending_call.id, tool_call_id: pending_call.id})
+    telemetry_metadata = %{call_id: pending_call.id, tool_call_id: pending_call.id}
 
     result =
       safe_execute_module(module, pending_call.arguments, context,
         timeout: timeout_ms,
-        max_retries: 0
+        max_retries: 0,
+        telemetry_metadata: telemetry_metadata
       )
 
     duration_ms = max(System.monotonic_time(:millisecond) - start_ms, 0)

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -779,6 +779,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   defp do_execute_tool_with_retries(%PendingToolCall{} = pending_call, module, %Config{} = config, context, attempt) do
     start_ms = System.monotonic_time(:millisecond)
     timeout_ms = normalize_timeout(config.tool_exec[:timeout_ms])
+    context = Map.merge(context, %{call_id: pending_call.id, tool_call_id: pending_call.id})
 
     result =
       safe_execute_module(module, pending_call.arguments, context,

--- a/lib/jido_ai/turn.ex
+++ b/lib/jido_ai/turn.ex
@@ -660,11 +660,13 @@ defmodule Jido.AI.Turn do
 
   defp start_execute_telemetry(tool_name, params, context) do
     obs_cfg = context[:observability] || %{}
+    tool_call_id = context[:tool_call_id] || context[:call_id]
 
     metadata =
       %{
         tool_name: tool_name,
         params: Observe.sanitize_sensitive(params),
+        tool_call_id: tool_call_id,
         call_id: context[:call_id],
         request_id: context[:request_id] || context[:run_id],
         run_id: context[:run_id],
@@ -685,11 +687,13 @@ defmodule Jido.AI.Turn do
   defp stop_execute_telemetry(tool_name, result, start_time, context) do
     obs_cfg = context[:observability] || %{}
     duration_native = System.monotonic_time() - start_time
+    tool_call_id = context[:tool_call_id] || context[:call_id]
 
     metadata =
       %{
         tool_name: tool_name,
         result: result,
+        tool_call_id: tool_call_id,
         call_id: context[:call_id],
         request_id: context[:request_id] || context[:run_id],
         run_id: context[:run_id],
@@ -711,11 +715,13 @@ defmodule Jido.AI.Turn do
   defp exception_execute_telemetry(tool_name, reason, start_time, context) do
     obs_cfg = context[:observability] || %{}
     duration_native = System.monotonic_time() - start_time
+    tool_call_id = context[:tool_call_id] || context[:call_id]
 
     metadata =
       %{
         tool_name: tool_name,
         reason: reason,
+        tool_call_id: tool_call_id,
         call_id: context[:call_id],
         request_id: context[:request_id] || context[:run_id],
         run_id: context[:run_id],

--- a/lib/jido_ai/turn.ex
+++ b/lib/jido_ai/turn.ex
@@ -24,7 +24,11 @@ defmodule Jido.AI.Turn do
 
   @type response_type :: :tool_calls | :final_answer
   @type tools_map :: %{String.t() => module()}
-  @type execute_opts :: [timeout: pos_integer() | nil, tools: tools_map() | [module()] | module() | nil]
+  @type execute_opts :: [
+          timeout: pos_integer() | nil,
+          tools: tools_map() | [module()] | module() | nil,
+          telemetry_metadata: map()
+        ]
   @type execute_result :: {:ok, term(), [term()]} | {:error, term(), [term()]}
   @type run_opts :: [timeout: pos_integer() | nil, tools: map() | [module()] | module() | nil]
 
@@ -179,11 +183,12 @@ defmodule Jido.AI.Turn do
   def execute(tool_name, params, context, opts \\ []) when is_binary(tool_name) do
     context = normalize_context(context)
     timeout = Keyword.get(opts, :timeout, @default_timeout)
-    exec_opts = Keyword.delete(opts, :timeout)
+    exec_opts = opts |> Keyword.delete(:timeout) |> Keyword.delete(:telemetry_metadata)
     tools = opts |> Keyword.get(:tools, %{}) |> ToolAdapter.to_action_map()
+    telemetry_context = telemetry_context(context, opts)
     start_time = System.monotonic_time()
 
-    start_execute_telemetry(tool_name, params, context)
+    start_execute_telemetry(tool_name, params, telemetry_context)
 
     result =
       case Map.fetch(tools, tool_name) do
@@ -200,7 +205,7 @@ defmodule Jido.AI.Turn do
            ), []}
       end
 
-    finalize_execute_telemetry(tool_name, result, start_time, context)
+    finalize_execute_telemetry(tool_name, result, start_time, telemetry_context)
     result
   end
 
@@ -211,13 +216,14 @@ defmodule Jido.AI.Turn do
   def execute_module(module, params, context, opts \\ []) do
     context = normalize_context(context)
     timeout = Keyword.get(opts, :timeout, @default_timeout)
-    exec_opts = Keyword.delete(opts, :timeout)
+    exec_opts = opts |> Keyword.delete(:timeout) |> Keyword.delete(:telemetry_metadata)
+    telemetry_context = telemetry_context(context, opts)
     tool_name = module.name()
     start_time = System.monotonic_time()
 
-    start_execute_telemetry(tool_name, params, context)
+    start_execute_telemetry(tool_name, params, telemetry_context)
     result = execute_internal(module, tool_name, params, context, timeout, exec_opts)
-    finalize_execute_telemetry(tool_name, result, start_time, context)
+    finalize_execute_telemetry(tool_name, result, start_time, telemetry_context)
 
     result
   end
@@ -750,6 +756,18 @@ defmodule Jido.AI.Turn do
   defp normalize_context(context) when is_map(context), do: context
   defp normalize_context(_), do: %{}
 
+  defp telemetry_context(context, opts) do
+    telemetry_metadata =
+      opts
+      |> Keyword.get(:telemetry_metadata, %{})
+      |> normalize_context()
+
+    Map.merge(context, telemetry_metadata)
+  end
+
+  defp tool_call_telemetry_metadata(""), do: nil
+  defp tool_call_telemetry_metadata(call_id), do: %{call_id: call_id, tool_call_id: call_id}
+
   defp run_single_tool(tool_call, context, tools, timeout) do
     call_id = normalize_text(extract_tool_call_id(tool_call))
     tool_name = normalize_text(extract_tool_call_name(tool_call))
@@ -758,6 +776,7 @@ defmodule Jido.AI.Turn do
     exec_opts =
       [tools: tools]
       |> maybe_add_timeout(timeout)
+      |> maybe_put_keyword(:telemetry_metadata, tool_call_telemetry_metadata(call_id))
 
     raw_result =
       case tool_name do

--- a/test/jido_ai/directive/exec_runtime_test.exs
+++ b/test/jido_ai/directive/exec_runtime_test.exs
@@ -372,10 +372,12 @@ defmodule Jido.AI.Directive.ExecRuntimeTest do
       supervisor = DirectiveSupport.start_task_supervisor!()
       on_exit(fn -> DirectiveSupport.stop_task_supervisor(supervisor) end)
 
-      Mimic.stub(Jido.AI.Turn, :execute_module, fn module, params, context ->
+      Mimic.stub(Jido.AI.Turn, :execute_module, fn module, params, context, opts ->
         assert module == DummyAction
         assert params == %{"value" => 7}
         assert context == %{origin: :test}
+        assert get_in(opts, [:telemetry_metadata, :tool_call_id]) == "tool_ok"
+        assert get_in(opts, [:telemetry_metadata, :call_id]) == "tool_ok"
         {:ok, %{value: 8}}
       end)
 
@@ -406,7 +408,7 @@ defmodule Jido.AI.Directive.ExecRuntimeTest do
       supervisor = DirectiveSupport.start_task_supervisor!()
       on_exit(fn -> DirectiveSupport.stop_task_supervisor(supervisor) end)
 
-      Mimic.stub(Jido.AI.Turn, :execute_module, fn _module, _params, _context ->
+      Mimic.stub(Jido.AI.Turn, :execute_module, fn _module, _params, _context, _opts ->
         Process.sleep(50)
         {:ok, %{slow: true}}
       end)
@@ -532,7 +534,7 @@ defmodule Jido.AI.Directive.ExecRuntimeTest do
         end
       end)
 
-      Mimic.stub(Jido.AI.Turn, :execute_module, fn _module, _params, _context ->
+      Mimic.stub(Jido.AI.Turn, :execute_module, fn _module, _params, _context, _opts ->
         {:ok, %{value: :ok}}
       end)
 

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -61,6 +61,22 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     def run(%{a: a, b: b}, _context), do: {:ok, %{result: a + b}}
   end
 
+  defmodule ContextEchoTool do
+    use Jido.Action,
+      name: "context_echo_tool",
+      description: "returns selected execution context flags",
+      schema: Zoi.object(%{})
+
+    def run(_params, context) do
+      {:ok,
+       %{
+         marker: context[:marker],
+         has_call_id: Map.has_key?(context, :call_id),
+         has_tool_call_id: Map.has_key?(context, :tool_call_id)
+       }}
+    end
+  end
+
   defmodule SlowOrderTool do
     use Jido.Action,
       name: "slow_order_tool",
@@ -1182,6 +1198,65 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     assert state.status == :completed
     assert state.termination_reason == :final_answer
     assert agent.state.react_order_marker == :fast
+  end
+
+  test "keeps telemetry ids out of standalone tool action context" do
+    test_pid = self()
+    handler_id = "react-tool-execute-stop-id-#{System.unique_integer([:positive])}"
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:jido, :ai, :tool, :execute, :stop],
+        fn _event, _measurements, metadata, _config ->
+          send(test_pid, {:stop_metadata, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      count = :persistent_term.get({__MODULE__, :llm_call_count}, 0) + 1
+      :persistent_term.put({__MODULE__, :llm_call_count}, count)
+
+      if count == 1 do
+        {:ok,
+         responses_stream_response(
+           [ReqLLM.StreamChunk.tool_call("context_echo_tool", %{}, %{id: "tc_context_echo"})],
+           %{finish_reason: :tool_calls, usage: %{input_tokens: 4, output_tokens: 2}},
+           model
+         )}
+      else
+        {:ok,
+         responses_stream_response(
+           [ReqLLM.StreamChunk.text("Done")],
+           %{finish_reason: :stop, usage: %{input_tokens: 2, output_tokens: 1}},
+           model
+         )}
+      end
+    end)
+
+    config =
+      Config.new(%{
+        model: :capable,
+        tools: %{ContextEchoTool.name() => ContextEchoTool},
+        tool_max_retries: 0,
+        tool_retry_backoff_ms: 0
+      })
+
+    events =
+      ReAct.stream("Echo context", config, context: %{marker: :kept})
+      |> Enum.to_list()
+
+    tool_completed = Enum.find(events, &(&1.kind == :tool_completed and &1.data.tool_call_id == "tc_context_echo"))
+
+    assert {:ok, %{marker: :kept, has_call_id: false, has_tool_call_id: false}, _effects} =
+             tool_completed.data.result
+
+    assert_receive {:stop_metadata, stop_metadata}
+    assert stop_metadata.tool_call_id == "tc_context_echo"
+    assert stop_metadata.call_id == "tc_context_echo"
   end
 
   test "refreshes tool context state snapshot between rounds when state effects are allowed" do

--- a/test/jido_ai/turn_test.exs
+++ b/test/jido_ai/turn_test.exs
@@ -27,6 +27,22 @@ defmodule Jido.AI.TurnTest do
     def run(_params, _context), do: {:error, :unsupported_operation}
   end
 
+  defmodule ContextEcho do
+    use Jido.Action,
+      name: "context_echo",
+      description: "Returns selected execution context flags",
+      schema: Zoi.object(%{})
+
+    def run(_params, context) do
+      {:ok,
+       %{
+         origin: context[:origin],
+         has_call_id: Map.has_key?(context, :call_id),
+         has_tool_call_id: Map.has_key?(context, :tool_call_id)
+       }}
+    end
+  end
+
   describe "from_response/2" do
     test "classifies final answer and extracts thinking/text content" do
       response = %{
@@ -397,6 +413,50 @@ defmodule Jido.AI.TurnTest do
       turn = %Turn{type: :final_answer, text: "done", tool_calls: []}
       assert {:ok, ^turn} = Turn.run_tools(turn, %{})
     end
+
+    test "emits per-tool telemetry id without changing action context" do
+      test_pid = self()
+      handler_id = "turn-run-tools-stop-id-#{System.unique_integer([:positive])}"
+
+      :ok =
+        :telemetry.attach(
+          handler_id,
+          [:jido, :ai, :tool, :execute, :stop],
+          fn _event, _measurements, metadata, _config ->
+            send(test_pid, {:stop_metadata, metadata})
+          end,
+          nil
+        )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      turn = %Turn{
+        type: :tool_calls,
+        text: "",
+        tool_calls: [
+          %{id: "tc_run_tools_1", name: "context_echo", arguments: %{}}
+        ]
+      }
+
+      context = %{
+        tools: %{ContextEcho.name() => ContextEcho},
+        observability: %{emit_telemetry?: true},
+        origin: :test
+      }
+
+      assert {:ok, updated_turn} = Turn.run_tools(turn, context)
+
+      assert [
+               %{
+                 id: "tc_run_tools_1",
+                 raw_result: {:ok, %{origin: :test, has_call_id: false, has_tool_call_id: false}, []}
+               }
+             ] = updated_turn.tool_results
+
+      assert_receive {:stop_metadata, stop_metadata}
+      assert stop_metadata.tool_call_id == "tc_run_tools_1"
+      assert stop_metadata.call_id == "tc_run_tools_1"
+    end
   end
 
   describe "tool execution telemetry" do
@@ -427,6 +487,37 @@ defmodule Jido.AI.TurnTest do
       assert is_integer(measurements.duration_ms)
       assert measurements.duration_ms >= 0
       assert is_integer(measurements.duration)
+    end
+
+    test "execute_module telemetry metadata does not change action context" do
+      test_pid = self()
+      stop_handler_id = "turn-stop-metadata-id-#{System.unique_integer([:positive])}"
+
+      :ok =
+        :telemetry.attach(
+          stop_handler_id,
+          [:jido, :ai, :tool, :execute, :stop],
+          fn _event, _measurements, metadata, _config ->
+            send(test_pid, {:stop_metadata, metadata})
+          end,
+          nil
+        )
+
+      on_exit(fn -> :telemetry.detach(stop_handler_id) end)
+
+      context = %{observability: %{emit_telemetry?: true}, origin: :test}
+
+      assert {:ok, %{origin: :test, has_call_id: false, has_tool_call_id: false}, _effects} =
+               Turn.execute_module(
+                 ContextEcho,
+                 %{},
+                 context,
+                 telemetry_metadata: %{call_id: "tc_meta_1", tool_call_id: "tc_meta_1"}
+               )
+
+      assert_receive {:stop_metadata, stop_metadata}
+      assert stop_metadata.tool_call_id == "tc_meta_1"
+      assert stop_metadata.call_id == "tc_meta_1"
     end
 
     test "execute telemetry uses tool_call_id from context" do

--- a/test/jido_ai/turn_test.exs
+++ b/test/jido_ai/turn_test.exs
@@ -428,6 +428,76 @@ defmodule Jido.AI.TurnTest do
       assert measurements.duration_ms >= 0
       assert is_integer(measurements.duration)
     end
+
+    test "execute telemetry uses tool_call_id from context" do
+      test_pid = self()
+      start_handler_id = "turn-start-id-#{System.unique_integer([:positive])}"
+      stop_handler_id = "turn-stop-id-#{System.unique_integer([:positive])}"
+
+      :ok =
+        :telemetry.attach(
+          start_handler_id,
+          [:jido, :ai, :tool, :execute, :start],
+          fn _event, _measurements, metadata, _config ->
+            send(test_pid, {:start_metadata, metadata})
+          end,
+          nil
+        )
+
+      :ok =
+        :telemetry.attach(
+          stop_handler_id,
+          [:jido, :ai, :tool, :execute, :stop],
+          fn _event, _measurements, metadata, _config ->
+            send(test_pid, {:stop_metadata, metadata})
+          end,
+          nil
+        )
+
+      on_exit(fn ->
+        :telemetry.detach(start_handler_id)
+        :telemetry.detach(stop_handler_id)
+      end)
+
+      assert {:ok, _result, _effects} =
+               Turn.execute_module(
+                 Calculator,
+                 %{operation: "add", a: 1, b: 2},
+                 %{observability: %{emit_telemetry?: true}, tool_call_id: "tc_ctx_1"}
+               )
+
+      assert_receive {:start_metadata, start_metadata}
+      assert_receive {:stop_metadata, stop_metadata}
+      assert start_metadata.tool_call_id == "tc_ctx_1"
+      assert stop_metadata.tool_call_id == "tc_ctx_1"
+    end
+
+    test "execute telemetry falls back to call_id when tool_call_id is missing" do
+      test_pid = self()
+      stop_handler_id = "turn-stop-fallback-id-#{System.unique_integer([:positive])}"
+
+      :ok =
+        :telemetry.attach(
+          stop_handler_id,
+          [:jido, :ai, :tool, :execute, :stop],
+          fn _event, _measurements, metadata, _config ->
+            send(test_pid, {:stop_metadata, metadata})
+          end,
+          nil
+        )
+
+      on_exit(fn -> :telemetry.detach(stop_handler_id) end)
+
+      assert {:ok, _result, _effects} =
+               Turn.execute_module(
+                 Calculator,
+                 %{operation: "add", a: 1, b: 2},
+                 %{observability: %{emit_telemetry?: true}, call_id: "tc_legacy_1"}
+               )
+
+      assert_receive {:stop_metadata, stop_metadata}
+      assert stop_metadata.tool_call_id == "tc_legacy_1"
+    end
   end
 
   describe "log_level propagation" do


### PR DESCRIPTION
in tool execute start|stop we had the params and response but no tool_call_id (set to nil)

This PR fixes this issue