### PR TITLE
feat: support multimodal ReAct queries

### DIFF
--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -514,9 +514,9 @@ defmodule Jido.AI.Agent do
           {:ok, result} = MyAgent.await(request)
 
       """
-      @spec ask(pid() | atom() | {:via, module(), term()}, String.t(), keyword()) ::
+      @spec ask(pid() | atom() | {:via, module(), term()}, String.t() | [ReqLLM.Message.ContentPart.t()], keyword()) ::
               {:ok, Request.Handle.t()} | {:error, term()}
-      def ask(pid, query, opts \\ []) when is_binary(query) do
+      def ask(pid, query, opts \\ []) when is_binary(query) or is_list(query) do
         Request.create_and_send(
           pid,
           query,
@@ -548,9 +548,13 @@ defmodule Jido.AI.Agent do
           {:ok, result} = MyAgent.await(request)
 
       """
-      @spec ask_stream(pid() | atom() | {:via, module(), term()}, String.t(), keyword()) ::
+      @spec ask_stream(
+              pid() | atom() | {:via, module(), term()},
+              String.t() | [ReqLLM.Message.ContentPart.t()],
+              keyword()
+            ) ::
               {:ok, %{request: Request.Handle.t(), events: Enumerable.t()}} | {:error, term()}
-      def ask_stream(pid, query, opts \\ []) when is_binary(query) do
+      def ask_stream(pid, query, opts \\ []) when is_binary(query) or is_list(query) do
         opts = Keyword.put(opts, :stream_to, {:pid, self()})
 
         with {:ok, request} <- ask(pid, query, opts) do
@@ -607,9 +611,13 @@ defmodule Jido.AI.Agent do
           {:ok, result} = MyAgent.ask_sync(pid, "What is 2+2?", timeout: 10_000)
 
       """
-      @spec ask_sync(pid() | atom() | {:via, module(), term()}, String.t(), keyword()) ::
+      @spec ask_sync(
+              pid() | atom() | {:via, module(), term()},
+              String.t() | [ReqLLM.Message.ContentPart.t()],
+              keyword()
+            ) ::
               {:ok, any()} | {:error, term()}
-      def ask_sync(pid, query, opts \\ []) when is_binary(query) do
+      def ask_sync(pid, query, opts \\ []) when is_binary(query) or is_list(query) do
         Request.send_and_await(
           pid,
           query,

--- a/lib/jido_ai/context.ex
+++ b/lib/jido_ai/context.ex
@@ -96,8 +96,8 @@ defmodule Jido.AI.Context do
   @doc """
   Append a user message to the thread.
   """
-  @spec append_user(t(), String.t(), keyword()) :: t()
-  def append_user(thread, content, opts \\ []) when is_binary(content) do
+  @spec append_user(t(), String.t() | [ContentPart.t()], keyword()) :: t()
+  def append_user(thread, content, opts \\ []) when is_binary(content) or is_list(content) do
     refs = Keyword.get(opts, :refs)
     append(thread, %Entry{role: :user, content: content, refs: refs})
   end
@@ -465,10 +465,12 @@ defmodule Jido.AI.Context do
     }
   end
 
-  defp normalize_entry_content(:tool, content, _text_content) when is_list(content),
-    do: normalize_tool_content_parts(content)
+  defp normalize_entry_content(role, content, _text_content) when role in [:user, :tool] and is_list(content),
+    do: normalize_content_parts(content)
 
   defp normalize_entry_content(_role, _content, text_content), do: text_content
+
+  defp normalize_content_parts(parts), do: normalize_tool_content_parts(parts)
 
   defp normalize_tool_content_parts(parts) do
     Enum.flat_map(parts, fn

--- a/lib/jido_ai/query.ex
+++ b/lib/jido_ai/query.ex
@@ -1,0 +1,59 @@
+defmodule Jido.AI.Query do
+  @moduledoc "Shared schema and helpers for text or multimodal user queries."
+
+  alias ReqLLM.Message.ContentPart
+
+  @type t :: String.t() | [ContentPart.t()]
+
+  @doc "Returns a Zoi schema that accepts text or a non-empty list of ReqLLM content parts."
+  @spec schema(keyword()) :: Zoi.schema()
+  def schema(opts \\ []) do
+    description = Keyword.get(opts, :description, "User query or multimodal content parts")
+
+    Zoi.union(
+      [
+        Zoi.string(description: description),
+        Zoi.list(Zoi.any(), description: description)
+        |> Zoi.refine({__MODULE__, :validate_content_parts, []})
+      ],
+      opts
+    )
+  end
+
+  @doc "Validates that a parsed multimodal query is a non-empty list of content parts."
+  @spec validate_content_parts(term(), keyword()) :: :ok | {:error, String.t()}
+  def validate_content_parts([_ | _] = parts, _opts) do
+    if Enum.all?(parts, &content_part?/1) do
+      :ok
+    else
+      {:error, "query content must be a non-empty list of ReqLLM content parts"}
+    end
+  end
+
+  def validate_content_parts(_parts, _opts),
+    do: {:error, "query content must be a non-empty list of ReqLLM content parts"}
+
+  @doc "Returns true when a term is a ReqLLM content part or compatible content-part map."
+  @spec content_part?(term()) :: boolean()
+  def content_part?(%ContentPart{}), do: true
+
+  def content_part?(%{type: type}) when type in [:text, :image, :image_url, :thinking], do: true
+  def content_part?(%{"type" => type}) when type in ["text", "image", "image_url", "thinking"], do: true
+  def content_part?(_part), do: false
+
+  @doc "Builds a text summary for event metadata without discarding the original query."
+  @spec summarize(t()) :: String.t()
+  def summarize(query) when is_binary(query), do: query
+
+  def summarize(parts) when is_list(parts) do
+    Enum.map_join(parts, "\n", fn
+      %ContentPart{type: :text, text: text} when is_binary(text) -> text
+      %ContentPart{type: type} when type in [:image, :image_url] -> "[Image]"
+      %{type: type, text: text} when type in [:text, "text"] and is_binary(text) -> text
+      %{type: type} when type in [:image, :image_url, "image", "image_url"] -> "[Image]"
+      %{"type" => type, "text" => text} when type == "text" and is_binary(text) -> text
+      %{"type" => type} when type in ["image", "image_url"] -> "[Image]"
+      part -> inspect(part)
+    end)
+  end
+end

--- a/lib/jido_ai/reasoning/react.ex
+++ b/lib/jido_ai/reasoning/react.ex
@@ -14,8 +14,8 @@ defmodule Jido.AI.Reasoning.ReAct do
   @doc """
   Starts a new ReAct run and returns a lazy event stream.
   """
-  @spec stream(String.t(), config_input(), keyword()) :: Enumerable.t()
-  def stream(query, config, opts \\ []) when is_binary(query) and is_list(opts) do
+  @spec stream(String.t() | [ReqLLM.Message.ContentPart.t()], config_input(), keyword()) :: Enumerable.t()
+  def stream(query, config, opts \\ []) when (is_binary(query) or is_list(query)) and is_list(opts) do
     config = build_config(config)
     Runner.stream(query, config, opts)
   end
@@ -32,8 +32,8 @@ defmodule Jido.AI.Reasoning.ReAct do
   @doc """
   Runs ReAct to completion and returns an aggregated result map.
   """
-  @spec run(String.t(), config_input(), keyword()) :: map()
-  def run(query, config, opts \\ []) when is_binary(query) and is_list(opts) do
+  @spec run(String.t() | [ReqLLM.Message.ContentPart.t()], config_input(), keyword()) :: map()
+  def run(query, config, opts \\ []) when (is_binary(query) or is_list(query)) and is_list(opts) do
     query
     |> stream(config, opts)
     |> collect_stream()
@@ -42,8 +42,9 @@ defmodule Jido.AI.Reasoning.ReAct do
   @doc """
   Starts a run and returns run metadata plus a stream handle.
   """
-  @spec start(String.t(), config_input(), keyword()) :: {:ok, map()} | {:error, term()}
-  def start(query, config, opts \\ []) when is_binary(query) and is_list(opts) do
+  @spec start(String.t() | [ReqLLM.Message.ContentPart.t()], config_input(), keyword()) ::
+          {:ok, map()} | {:error, term()}
+  def start(query, config, opts \\ []) when (is_binary(query) or is_list(query)) and is_list(opts) do
     config = build_config(config)
 
     state = State.new(query, config.system_prompt, Keyword.take(opts, [:request_id, :run_id]))

--- a/lib/jido_ai/reasoning/react/actions/collect.ex
+++ b/lib/jido_ai/reasoning/react/actions/collect.ex
@@ -3,6 +3,8 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Collect do
   Collect a terminal result from ReAct events or a checkpoint token.
   """
 
+  alias Jido.AI.Query
+
   use Jido.Action,
     name: "react_collect",
     description: "Collect terminal output from ReAct runtime events/checkpoint",
@@ -14,7 +16,7 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Collect do
         events: Zoi.any() |> Zoi.optional(),
         checkpoint_token: Zoi.string() |> Zoi.optional(),
         run_until_terminal?: Zoi.boolean() |> Zoi.default(true),
-        query: Zoi.string() |> Zoi.optional(),
+        query: Query.schema() |> Zoi.optional(),
         model: Zoi.any() |> Zoi.optional(),
         system_prompt: Zoi.string() |> Zoi.optional(),
         tools: Zoi.any() |> Zoi.optional(),
@@ -39,8 +41,8 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Collect do
         runtime_context: Zoi.map() |> Zoi.optional()
       })
 
-  alias Jido.AI.Reasoning.ReAct.Actions.Helpers
   alias Jido.AI.Reasoning.ReAct
+  alias Jido.AI.Reasoning.ReAct.Actions.Helpers
 
   @impl Jido.Action
   def run(params, context) do

--- a/lib/jido_ai/reasoning/react/actions/continue.ex
+++ b/lib/jido_ai/reasoning/react/actions/continue.ex
@@ -3,6 +3,8 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Continue do
   Continue a ReAct runtime execution from a signed checkpoint token.
   """
 
+  alias Jido.AI.Query
+
   use Jido.Action,
     name: "react_continue",
     description: "Resume a Task-based ReAct runtime stream from checkpoint token",
@@ -12,7 +14,7 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Continue do
     schema:
       Zoi.object(%{
         checkpoint_token: Zoi.string(description: "Signed ReAct checkpoint token"),
-        query: Zoi.string() |> Zoi.optional(),
+        query: Query.schema() |> Zoi.optional(),
         model: Zoi.any() |> Zoi.optional(),
         system_prompt: Zoi.string() |> Zoi.optional(),
         tools: Zoi.any() |> Zoi.optional(),
@@ -43,8 +45,8 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Continue do
         runtime_context: Zoi.map() |> Zoi.optional()
       })
 
-  alias Jido.AI.Reasoning.ReAct.Actions.Helpers
   alias Jido.AI.Reasoning.ReAct
+  alias Jido.AI.Reasoning.ReAct.Actions.Helpers
 
   @impl Jido.Action
   def run(params, context) do

--- a/lib/jido_ai/reasoning/react/actions/start.ex
+++ b/lib/jido_ai/reasoning/react/actions/start.ex
@@ -3,6 +3,8 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Start do
   Start a ReAct runtime execution and return an event stream.
   """
 
+  alias Jido.AI.Query
+
   use Jido.Action,
     name: "react_start",
     description: "Start a Task-based ReAct runtime stream",
@@ -11,7 +13,7 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Start do
     vsn: "1.0.0",
     schema:
       Zoi.object(%{
-        query: Zoi.string(description: "User query for ReAct execution"),
+        query: Query.schema(description: "User query for ReAct execution"),
         request_id: Zoi.string() |> Zoi.optional(),
         run_id: Zoi.string() |> Zoi.optional(),
         model: Zoi.any() |> Zoi.optional(),
@@ -44,30 +46,47 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Start do
         runtime_context: Zoi.map() |> Zoi.optional()
       })
 
-  alias Jido.AI.Reasoning.ReAct.Actions.Helpers
   alias Jido.AI.Reasoning.ReAct
+  alias Jido.AI.Reasoning.ReAct.Actions.Helpers
   alias Jido.AI.Validation
 
   @impl Jido.Action
   def run(params, context) do
-    with {:ok, _} <- Validation.validate_string(params[:query], max_length: Validation.max_input_length()) do
-      config = Helpers.build_config(params, context)
-      opts = Helpers.build_runner_opts(params, context)
-      request_id = params[:request_id] || "req_#{Jido.Util.generate_id()}"
-      run_id = params[:run_id] || "run_#{Jido.Util.generate_id()}"
+    case validate_query(params[:query]) do
+      :ok ->
+        config = Helpers.build_config(params, context)
+        opts = Helpers.build_runner_opts(params, context)
+        request_id = params[:request_id] || "req_#{Jido.Util.generate_id()}"
+        run_id = params[:run_id] || "run_#{Jido.Util.generate_id()}"
 
-      events = ReAct.stream(params[:query], config, Keyword.merge(opts, request_id: request_id, run_id: run_id))
+        events = ReAct.stream(params[:query], config, Keyword.merge(opts, request_id: request_id, run_id: run_id))
 
-      {:ok,
-       %{
-         run_id: run_id,
-         request_id: request_id,
-         events: events,
-         checkpoint_token: nil
-       }}
-    else
-      {:error, :empty_string} -> {:error, :query_required}
-      {:error, reason} -> {:error, reason}
+        {:ok,
+         %{
+           run_id: run_id,
+           request_id: request_id,
+           events: events,
+           checkpoint_token: nil
+         }}
+
+      {:error, :empty_string} ->
+        {:error, :query_required}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
+
+  defp validate_query(query) when is_binary(query) do
+    case Validation.validate_string(query, max_length: Validation.max_input_length()) do
+      {:ok, _query} -> :ok
+      error -> error
+    end
+  end
+
+  defp validate_query([_ | _] = query) do
+    Query.validate_content_parts(query, [])
+  end
+
+  defp validate_query(_query), do: {:error, :query_required}
 end

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -6,8 +6,9 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   state outside of caller-owned checkpoint tokens.
   """
 
-  alias Jido.AI.PendingInputServer
   alias Jido.AI.Output
+  alias Jido.AI.PendingInputServer
+  alias Jido.AI.Query
   alias Jido.AI.Reasoning.ReAct.{Config, Event, PendingToolCall, State, Token, ToolSelection}
   alias Jido.AI.Effects
   alias Jido.AI.Context, as: AIContext
@@ -36,7 +37,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   Starts a new ReAct coordinator task and returns a lazy event stream.
   """
   @spec stream(String.t(), Config.t(), [stream_opt()]) :: Enumerable.t()
-  def stream(query, %Config{} = config, opts \\ []) when is_binary(query) do
+  def stream(query, %Config{} = config, opts \\ []) when is_binary(query) or is_list(query) do
     initial_state =
       case Keyword.get(opts, :state) do
         %State{} = state -> state
@@ -56,6 +57,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     state =
       case query do
         q when is_binary(q) and q != "" -> append_query(state, q)
+        q when is_list(q) -> append_query(state, q)
         _ -> state
       end
 
@@ -1126,11 +1128,12 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   defp latest_query(%State{} = state) do
     case AIContext.last_entry(state.context) do
       %{role: :user, content: content} when is_binary(content) -> content
+      %{role: :user, content: content} when is_list(content) -> Query.summarize(content)
       _ -> ""
     end
   end
 
-  defp append_query(%State{} = state, query) when is_binary(query) do
+  defp append_query(%State{} = state, query) when is_binary(query) or is_list(query) do
     %{state | context: AIContext.append_user(state.context, query), status: :running, updated_at_ms: now_ms()}
   end
 

--- a/lib/jido_ai/reasoning/react/state.ex
+++ b/lib/jido_ai/reasoning/react/state.ex
@@ -50,7 +50,7 @@ defmodule Jido.AI.Reasoning.ReAct.State do
   Creates initial runtime state for a new query.
   """
   @spec new(String.t(), String.t() | nil, keyword()) :: t()
-  def new(query, system_prompt, opts \\ []) when is_binary(query) do
+  def new(query, system_prompt, opts \\ []) when is_binary(query) or is_list(query) do
     now = now_ms()
 
     request_id = Keyword.get(opts, :request_id, "req_#{Jido.Util.generate_id()}")

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -38,6 +38,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   alias Jido.Agent.Strategy.State, as: StratState
   alias Jido.AI.Observe
   alias Jido.AI.Output
+  alias Jido.AI.Query
   alias Jido.AI.Directive
   alias Jido.AI.Effects
   alias Jido.AI.Request.Stream, as: RequestStream
@@ -182,7 +183,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     @start => %{
       schema:
         Zoi.object(%{
-          query: Zoi.string(),
+          query: Query.schema(),
           request_id: Zoi.string() |> Zoi.optional(),
           tool_context: Zoi.map() |> Zoi.optional(),
           tools: Zoi.any() |> Zoi.optional(),
@@ -575,7 +576,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     end
   end
 
-  defp process_start(agent, %{query: query} = params) when is_binary(query) do
+  defp process_start(agent, %{query: query} = params) when is_binary(query) or is_list(query) do
     state = StratState.get(agent, %{})
     config = state[:config] || %{}
     request_id = Map.get(params, :request_id, generate_call_id())
@@ -1996,7 +1997,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   end
 
   defp runtime_state_from_context(%AIContext{} = context, query, request_id, run_id)
-       when is_binary(query) and is_binary(request_id) and is_binary(run_id) do
+       when (is_binary(query) or is_list(query)) and is_binary(request_id) and is_binary(run_id) do
     ReActState.new(query, context.system_prompt, request_id: request_id, run_id: run_id)
     |> Map.put(:context, context)
   end

--- a/lib/jido_ai/reasoning/react/worker/strategy.ex
+++ b/lib/jido_ai/reasoning/react/worker/strategy.ex
@@ -6,6 +6,7 @@ defmodule Jido.AI.Reasoning.ReAct.Worker.Strategy do
   alias Jido.Agent
   alias Jido.Agent.Directive, as: AgentDirective
   alias Jido.Agent.Strategy.State, as: StratState
+  alias Jido.AI.Query
   alias Jido.AI.Reasoning.ReAct.{Config, Event, Runner, Signal}
 
   @start :react_worker_start
@@ -22,7 +23,7 @@ defmodule Jido.AI.Reasoning.ReAct.Worker.Strategy do
         Zoi.object(%{
           request_id: Zoi.string(),
           run_id: Zoi.string(),
-          query: Zoi.string(),
+          query: Query.schema(),
           config: Zoi.any(),
           state: Zoi.any() |> Zoi.optional(),
           context: Zoi.map() |> Zoi.default(%{}),

--- a/lib/jido_ai/request.ex
+++ b/lib/jido_ai/request.ex
@@ -61,6 +61,7 @@ defmodule Jido.AI.Request do
   """
 
   alias Jido.AI.Request.Stream, as: RequestStream
+  alias Jido.AI.Query
   alias Jido.Signal
 
   @type status :: :pending | :completed | :failed | :timeout
@@ -86,7 +87,7 @@ defmodule Jido.AI.Request do
               %{
                 id: Zoi.string(description: "Unique request identifier (UUID)"),
                 server: Zoi.any(description: "The agent server (pid, atom, or via tuple)"),
-                query: Zoi.string(description: "The original query/prompt"),
+                query: Query.schema(description: "The original query/prompt"),
                 status:
                   Zoi.enum([:pending, :completed, :failed, :timeout],
                     description: "Current request status"
@@ -180,9 +181,9 @@ defmodule Jido.AI.Request do
         source: "/ai/react/agent"
       )
   """
-  @spec create_and_send(server(), String.t(), keyword()) ::
+  @spec create_and_send(server(), String.t() | [ReqLLM.Message.ContentPart.t()], keyword()) ::
           {:ok, Handle.t()} | {:error, term()}
-  def create_and_send(server, query, opts) when is_binary(query) do
+  def create_and_send(server, query, opts) when is_binary(query) or is_list(query) do
     signal_type = Keyword.fetch!(opts, :signal_type)
     source = Keyword.fetch!(opts, :source)
     tool_context = Keyword.get(opts, :tool_context, %{})
@@ -245,9 +246,9 @@ defmodule Jido.AI.Request do
         source: "/ai/react/agent"
       )
   """
-  @spec send_and_await(server(), String.t(), keyword()) ::
+  @spec send_and_await(server(), String.t() | [ReqLLM.Message.ContentPart.t()], keyword()) ::
           {:ok, any()} | {:error, term()}
-  def send_and_await(server, query, opts) when is_binary(query) do
+  def send_and_await(server, query, opts) when is_binary(query) or is_list(query) do
     timeout = Keyword.get(opts, :timeout, @default_timeout)
 
     with {:ok, request} <- create_and_send(server, query, opts) do

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -8,6 +8,7 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
   alias Jido.AI.Reasoning.ReAct
   alias Jido.AI.Reasoning.ReAct.Config
   alias Jido.AI.Reasoning.ReAct.Strategy, as: ReActStrategy
+  alias ReqLLM.Message.ContentPart
 
   defmodule RetryTool do
     use Jido.Action,
@@ -198,6 +199,32 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     end)
 
     :ok
+  end
+
+  test "streams multimodal user content to ReqLLM" do
+    parent = self()
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, messages, _opts ->
+      send(parent, {:messages, messages})
+
+      {:ok,
+       responses_stream_response(
+         [ReqLLM.StreamChunk.text("I can see it")],
+         %{finish_reason: :stop},
+         model
+       )}
+    end)
+
+    image = ContentPart.image_url("data:image/png;base64,AQID")
+    query = [ContentPart.text("Describe this"), image]
+    config = Config.new(%{model: :capable, tools: %{}})
+
+    events = ReAct.stream(query, config, request_id: "req_multimodal", run_id: "run_multimodal") |> Enum.to_list()
+
+    assert_receive {:messages, messages}
+    assert Enum.any?(events, &(&1.kind == :request_started and &1.data.query =~ "[Image]"))
+    assert [%{role: :user, content: [text, ^image]}] = messages
+    assert text.text == "Describe this"
   end
 
   test "emits ordered event envelopes for a final-answer run" do

--- a/test/jido_ai/thread_test.exs
+++ b/test/jido_ai/thread_test.exs
@@ -59,6 +59,16 @@ defmodule Jido.AI.ContextTest do
       assert first.content == "First"
       assert second.content == "Second"
     end
+
+    test "appends multimodal user content" do
+      parts = [ContentPart.text("Describe this"), ContentPart.image_url("data:image/png;base64,AQID")]
+
+      thread =
+        AIContext.new()
+        |> AIContext.append_user(parts)
+
+      assert [%{role: :user, content: ^parts}] = AIContext.to_messages(thread)
+    end
   end
 
   describe "append_assistant/3" do


### PR DESCRIPTION
## Summary

- add a bounded `Jido.AI.Query` contract for text or multimodal user queries
- allow ReAct request, runner, and action entrypoints to accept ReqLLM content parts
- preserve multimodal user entries through `Jido.AI.Context` and request projection
- summarize multimodal queries for runtime event metadata while sending full content to ReqLLM

## Why

ReqLLM already supports message content parts for multimodal providers. ReAct previously required `String.t()` queries, forcing callers to tunnel image content through request transformers or side channels instead of passing the user prompt semantically.

## Tests

- `mix compile --warnings-as-errors`
- `mix test test/jido_ai/thread_test.exs test/jido_ai/react/runtime_runner_test.exs`
- `mix test.fast`
- `mix precommit`