### PR TITLE
refactor: fix ex_slop findings and remove DualKeyAccess

### DIFF
--- a/lib/jido_ai/actions/helpers.ex
+++ b/lib/jido_ai/actions/helpers.ex
@@ -140,9 +140,9 @@ defmodule Jido.AI.Actions.Helpers do
       %{input_tokens: 10, output_tokens: 20, total_tokens: 30}
   """
   def extract_usage(%{usage: usage}) when is_map(usage) do
-    input_tokens = Map.get(usage, :input_tokens) || Map.get(usage, "input_tokens") || 0
-    output_tokens = Map.get(usage, :output_tokens) || Map.get(usage, "output_tokens") || 0
-    total_tokens = Map.get(usage, :total_tokens) || Map.get(usage, "total_tokens") || input_tokens + output_tokens
+    input_tokens = usage[:input_tokens] || 0
+    output_tokens = usage[:output_tokens] || 0
+    total_tokens = usage[:total_tokens] || input_tokens + output_tokens
 
     %{
       input_tokens: input_tokens,

--- a/lib/jido_ai/actions/planning/prioritize.ex
+++ b/lib/jido_ai/actions/planning/prioritize.ex
@@ -228,7 +228,7 @@ defmodule Jido.AI.Actions.Planning.Prioritize do
     order_section
     |> String.split("\n")
     |> Enum.map(&extract_task_from_line/1)
-    |> Enum.filter(fn t -> t != nil end)
+    |> Enum.reject(&is_nil/1)
   end
 
   defp extract_task_from_line(line) do

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -880,8 +880,8 @@ defmodule Jido.AI.Agent do
       @impl true
       @spec restore(map(), map()) :: {:ok, Jido.Agent.t()} | {:error, term()}
       def restore(data, ctx) when is_map(data) and is_map(ctx) do
-        agent = new(id: data[:id] || data["id"])
-        base_state = data[:state] || data["state"] || %{}
+        agent = new(id: data[:id])
+        base_state = data[:state] || %{}
         agent = %{agent | state: Map.merge(agent.state, base_state)}
         externalized_keys = data[:externalized_keys] || %{}
 

--- a/lib/jido_ai/directive/llm_generate.ex
+++ b/lib/jido_ai/directive/llm_generate.ex
@@ -245,8 +245,8 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.LLMGenerate do
   defp emit_usage_report(_agent_pid, _call_id, _model, nil), do: :ok
 
   defp emit_usage_report(agent_pid, call_id, model, usage) when is_map(usage) do
-    input_tokens = Map.get(usage, :input_tokens) || Map.get(usage, "input_tokens") || 0
-    output_tokens = Map.get(usage, :output_tokens) || Map.get(usage, "output_tokens") || 0
+    input_tokens = usage[:input_tokens] || 0
+    output_tokens = usage[:output_tokens] || 0
 
     if input_tokens > 0 or output_tokens > 0 do
       signal =

--- a/lib/jido_ai/directive/llm_stream.ex
+++ b/lib/jido_ai/directive/llm_stream.ex
@@ -305,8 +305,8 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.LLMStream do
   defp emit_usage_report(_agent_pid, _call_id, _model, nil), do: :ok
 
   defp emit_usage_report(agent_pid, call_id, model, usage) when is_map(usage) do
-    input_tokens = Map.get(usage, :input_tokens) || Map.get(usage, "input_tokens") || 0
-    output_tokens = Map.get(usage, :output_tokens) || Map.get(usage, "output_tokens") || 0
+    input_tokens = usage[:input_tokens] || 0
+    output_tokens = usage[:output_tokens] || 0
 
     if input_tokens > 0 or output_tokens > 0 do
       signal =

--- a/lib/jido_ai/output.ex
+++ b/lib/jido_ai/output.ex
@@ -41,14 +41,10 @@ defmodule Jido.AI.Output do
   def new(attrs) when is_list(attrs) or is_map(attrs) do
     attrs = Map.new(attrs)
 
-    schema =
-      Map.get(attrs, :schema) ||
-        Map.get(attrs, "schema") ||
-        Map.get(attrs, :object_schema) ||
-        Map.get(attrs, "object_schema")
+    schema = attrs[:schema] || attrs[:object_schema]
 
-    retries = Map.get(attrs, :retries, Map.get(attrs, "retries", @default_retries))
-    mode = Map.get(attrs, :on_validation_error, Map.get(attrs, "on_validation_error", @default_on_validation_error))
+    retries = Map.get(attrs, :retries, @default_retries)
+    mode = Map.get(attrs, :on_validation_error, @default_on_validation_error)
 
     with {:ok, schema_kind} <- schema_kind(schema),
          {:ok, retries} <- normalize_retries(retries),
@@ -224,8 +220,8 @@ defmodule Jido.AI.Output do
   @doc false
   @spec imported_schema?(term()) :: boolean()
   def imported_schema?(%{} = schema) do
-    type = Map.get(schema, "type") || Map.get(schema, :type)
-    properties = Map.get(schema, "properties") || Map.get(schema, :properties)
+    type = schema[:type]
+    properties = schema[:properties]
     type in ["object", :object] and is_map(properties)
   end
 

--- a/lib/jido_ai/plugins/task_supervisor.ex
+++ b/lib/jido_ai/plugins/task_supervisor.ex
@@ -60,11 +60,6 @@ defmodule Jido.AI.Plugins.TaskSupervisor do
 
   # Starts a new anonymous Task.Supervisor.
   defp start_supervisor do
-    # Start the supervisor without a name (anonymous)
-    # This ensures each agent instance gets its own supervisor
-    case Task.Supervisor.start_link() do
-      {:ok, pid} -> {:ok, pid}
-      {:error, reason} -> {:error, reason}
-    end
+    Task.Supervisor.start_link()
   end
 end

--- a/lib/jido_ai/reasoning/adaptive/strategy.ex
+++ b/lib/jido_ai/reasoning/adaptive/strategy.ex
@@ -414,7 +414,7 @@ defmodule Jido.AI.Reasoning.Adaptive.Strategy do
         execute_action_instructions(agent, instructions, ctx)
 
       %{params: params} ->
-        prompt = Map.get(params, :prompt) || Map.get(params, "prompt") || ""
+        prompt = params[:prompt] || ""
 
         # Select strategy
         {strategy_type, complexity_score, task_type} =

--- a/lib/jido_ai/reasoning/graph_of_thoughts/strategy.ex
+++ b/lib/jido_ai/reasoning/graph_of_thoughts/strategy.ex
@@ -326,11 +326,12 @@ defmodule Jido.AI.Reasoning.GraphOfThoughts.Strategy do
   defp resolve_model_spec(model), do: Jido.AI.resolve_model(model)
 
   defp process_instruction(agent, %{action: @start, params: params}, _ctx) do
+    params = normalize_keys(params)
     state = StratState.get(agent, %{})
     machine = Machine.from_map(state)
 
-    prompt = Map.get(params, :prompt) || Map.get(params, "prompt")
-    request_id = Map.get(params, :request_id) || Map.get(params, "request_id") || Machine.generate_call_id()
+    prompt = params[:prompt]
+    request_id = params[:request_id] || Machine.generate_call_id()
 
     {updated_machine, directives} = Machine.update(machine, {:start, prompt, request_id}, %{})
     lifted = lift_directives(directives, state)
@@ -351,11 +352,12 @@ defmodule Jido.AI.Reasoning.GraphOfThoughts.Strategy do
   end
 
   defp process_instruction(agent, %{action: @llm_result, params: params}, _ctx) do
+    params = normalize_keys(params)
     state = StratState.get(agent, %{})
     machine = Machine.from_map(state)
 
-    call_id = Map.get(params, :call_id) || Map.get(params, "call_id")
-    result = Map.get(params, :result) || Map.get(params, "result")
+    call_id = params[:call_id]
+    result = params[:result]
 
     {updated_machine, directives} = Machine.update(machine, {:llm_result, call_id, result}, %{})
     lifted = lift_directives(directives, state)
@@ -372,12 +374,13 @@ defmodule Jido.AI.Reasoning.GraphOfThoughts.Strategy do
   end
 
   defp process_instruction(agent, %{action: @llm_partial, params: params}, _ctx) do
+    params = normalize_keys(params)
     state = StratState.get(agent, %{})
     machine = Machine.from_map(state)
 
-    call_id = Map.get(params, :call_id) || Map.get(params, "call_id")
-    delta = Map.get(params, :delta) || Map.get(params, "delta")
-    chunk_type = Map.get(params, :chunk_type) || Map.get(params, "chunk_type") || :content
+    call_id = params[:call_id]
+    delta = params[:delta]
+    chunk_type = params[:chunk_type] || :content
 
     {updated_machine, directives} =
       Machine.update(machine, {:llm_partial, call_id, delta, chunk_type}, %{})
@@ -395,9 +398,10 @@ defmodule Jido.AI.Reasoning.GraphOfThoughts.Strategy do
   end
 
   defp process_instruction(agent, %{action: @request_error, params: params}, _ctx) do
-    request_id = Map.get(params, :request_id) || Map.get(params, "request_id")
-    reason = Map.get(params, :reason) || Map.get(params, "reason")
-    message = Map.get(params, :message) || Map.get(params, "message")
+    params = normalize_keys(params)
+    request_id = params[:request_id]
+    reason = params[:reason]
+    message = params[:message]
 
     if is_binary(request_id) do
       state = StratState.get(agent, %{})
@@ -553,4 +557,15 @@ defmodule Jido.AI.Reasoning.GraphOfThoughts.Strategy do
     {:ok, context} = Context.normalize(conversation, validate: false)
     Context.to_list(context)
   end
+
+  defp normalize_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
+      pair -> pair
+    end)
+  rescue
+    ArgumentError -> map
+  end
+
+  defp normalize_keys(other), do: other
 end

--- a/lib/jido_ai/reasoning/helpers.ex
+++ b/lib/jido_ai/reasoning/helpers.ex
@@ -567,8 +567,8 @@ defmodule Jido.AI.Reasoning.Helpers do
   defp extract_plugin_state(%Agent{} = agent, %{agent_module: agent_module})
        when is_atom(agent_module) do
     if function_exported?(agent_module, :plugin_specs, 0) do
-      Enum.reduce(agent_module.plugin_specs(), %{}, fn spec, acc ->
-        Map.put(acc, spec.state_key, Map.get(agent.state, spec.state_key))
+      Map.new(agent_module.plugin_specs(), fn spec ->
+        {spec.state_key, Map.get(agent.state, spec.state_key)}
       end)
     else
       agent.state || %{}

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -491,11 +491,11 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
 
   defp extract_response_id(%ReqLLM.Response{message: %ReqLLM.Message{metadata: metadata}})
        when is_map(metadata) do
-    metadata[:response_id] || metadata["response_id"]
+    metadata[:response_id]
   end
 
   defp extract_response_id(%{message: %{metadata: metadata}}) when is_map(metadata) do
-    metadata[:response_id] || metadata["response_id"]
+    metadata[:response_id]
   end
 
   defp extract_response_id(_), do: nil
@@ -737,9 +737,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   end
 
   defp maybe_apply_tool_guardrail_callback(tool_call, context) when is_map(context) do
-    callback =
-      Map.get(context, :__tool_guardrail_callback__) ||
-        Map.get(context, "__tool_guardrail_callback__")
+    callback = context[:__tool_guardrail_callback__]
 
     case callback do
       fun when is_function(fun, 1) -> fun.(tool_call)
@@ -1529,8 +1527,8 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   defp tool_call_signature(tool_calls) when is_list(tool_calls) do
     tool_calls
     |> Enum.map(fn tc ->
-      name = Map.get(tc, :name) || Map.get(tc, "name") || ""
-      args = Map.get(tc, :arguments) || Map.get(tc, "arguments") || ""
+      name = Map.get(tc, :name, "")
+      args = Map.get(tc, :arguments, "")
       "#{name}:#{inspect(args)}"
     end)
     |> Enum.sort()

--- a/lib/jido_ai/reasoning/react/token.ex
+++ b/lib/jido_ai/reasoning/react/token.ex
@@ -114,11 +114,9 @@ defmodule Jido.AI.Reasoning.ReAct.Token do
   end
 
   defp decode_payload(payload_bin) do
-    try do
-      {:ok, :erlang.binary_to_term(payload_bin, [:safe])}
-    rescue
-      _ -> {:error, :invalid_token_payload}
-    end
+    {:ok, :erlang.binary_to_term(payload_bin, [:safe])}
+  rescue
+    _ -> {:error, :invalid_token_payload}
   end
 
   defp validate_payload(payload, %Config{} = config) when is_map(payload) do

--- a/lib/jido_ai/reasoning/trm/strategy.ex
+++ b/lib/jido_ai/reasoning/trm/strategy.ex
@@ -318,6 +318,7 @@ defmodule Jido.AI.Reasoning.TRM.Strategy do
   defp resolve_model_spec(model), do: Jido.AI.resolve_model(model)
 
   defp process_instruction(agent, %Jido.Instruction{action: action, params: params} = instruction, ctx) do
+    params = normalize_keys(params)
     normalized_action = normalize_action(action)
     state = StratState.get(agent, %{})
 
@@ -353,14 +354,14 @@ defmodule Jido.AI.Reasoning.TRM.Strategy do
   defp normalize_action(action), do: action
 
   defp to_machine_msg(@start, params, _status) do
-    prompt = Map.get(params, :prompt) || Map.get(params, "prompt")
-    request_id = Map.get(params, :request_id) || Map.get(params, "request_id") || Machine.generate_call_id()
+    prompt = params[:prompt]
+    request_id = params[:request_id] || Machine.generate_call_id()
     {:start, prompt, request_id}
   end
 
   defp to_machine_msg(@llm_result, params, status) do
-    call_id = Map.get(params, :call_id) || Map.get(params, "call_id")
-    result = Map.get(params, :result) || Map.get(params, "result")
+    call_id = params[:call_id]
+    result = params[:result]
     phase = resolve_result_phase(params, result, status)
 
     # Convert to appropriate machine message based on phase
@@ -373,9 +374,9 @@ defmodule Jido.AI.Reasoning.TRM.Strategy do
   end
 
   defp to_machine_msg(@llm_partial, params, _status) do
-    call_id = Map.get(params, :call_id) || Map.get(params, "call_id")
-    delta = Map.get(params, :delta) || Map.get(params, "delta")
-    chunk_type = Map.get(params, :chunk_type) || Map.get(params, "chunk_type") || :content
+    call_id = params[:call_id]
+    delta = params[:delta]
+    chunk_type = params[:chunk_type] || :content
     {:llm_partial, call_id, delta, chunk_type}
   end
 
@@ -391,20 +392,18 @@ defmodule Jido.AI.Reasoning.TRM.Strategy do
   end
 
   defp extract_phase_from_params(params) when is_map(params) do
-    Map.get(params, :phase) ||
-      Map.get(params, "phase") ||
-      (params[:metadata] && extract_phase_from_metadata(params[:metadata])) ||
-      (params["metadata"] && extract_phase_from_metadata(params["metadata"]))
+    params[:phase] ||
+      (params[:metadata] && extract_phase_from_metadata(params[:metadata]))
   end
 
   defp extract_phase_from_result({:ok, result}) when is_map(result) do
-    extract_phase_from_metadata(Map.get(result, :metadata) || Map.get(result, "metadata"))
+    extract_phase_from_metadata(result[:metadata])
   end
 
   defp extract_phase_from_result(_), do: nil
 
   defp extract_phase_from_metadata(metadata) when is_map(metadata) do
-    Map.get(metadata, :phase) || Map.get(metadata, "phase")
+    metadata[:phase]
   end
 
   defp extract_phase_from_metadata(_), do: nil
@@ -421,9 +420,9 @@ defmodule Jido.AI.Reasoning.TRM.Strategy do
   defp normalize_phase(_), do: nil
 
   defp process_request_error(agent, params) do
-    request_id = Map.get(params, :request_id) || Map.get(params, "request_id")
-    reason = Map.get(params, :reason) || Map.get(params, "reason")
-    message = Map.get(params, :message) || Map.get(params, "message")
+    request_id = params[:request_id]
+    reason = params[:reason]
+    message = params[:message]
 
     if is_binary(request_id) do
       state = StratState.get(agent, %{})
@@ -617,4 +616,15 @@ defmodule Jido.AI.Reasoning.TRM.Strategy do
   def default_improvement_prompt do
     Supervision.default_improvement_system_prompt()
   end
+
+  defp normalize_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
+      pair -> pair
+    end)
+  rescue
+    ArgumentError -> map
+  end
+
+  defp normalize_keys(other), do: other
 end

--- a/lib/jido_ai/retrieval/store.ex
+++ b/lib/jido_ai/retrieval/store.ex
@@ -20,11 +20,12 @@ defmodule Jido.AI.Retrieval.Store do
   @spec upsert(String.t(), memory()) :: memory()
   def upsert(namespace, memory) when is_binary(namespace) and is_map(memory) do
     ensure_table!()
+    memory = normalize_keys(memory)
 
     now = System.system_time(:millisecond)
-    id = to_string(Map.get(memory, :id) || Map.get(memory, "id") || "mem_#{Jido.Util.generate_id()}")
-    text = to_string(Map.get(memory, :text) || Map.get(memory, "text") || "")
-    metadata = Map.get(memory, :metadata) || Map.get(memory, "metadata") || %{}
+    id = to_string(memory[:id] || "mem_#{Jido.Util.generate_id()}")
+    text = to_string(memory[:text] || "")
+    metadata = memory[:metadata] || %{}
 
     existing =
       case :ets.lookup(@table, {namespace, id}) do
@@ -181,5 +182,14 @@ defmodule Jido.AI.Retrieval.Store do
       _ ->
         heir_loop()
     end
+  end
+
+  defp normalize_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
+      pair -> pair
+    end)
+  rescue
+    ArgumentError -> map
   end
 end

--- a/lib/jido_ai/signals/helpers.ex
+++ b/lib/jido_ai/signals/helpers.ex
@@ -307,18 +307,15 @@ defmodule Jido.AI.Signal.Helpers do
   defp extract_retry_hint(_), do: nil
 
   defp extract_nested_reason(%{} = map) do
-    Map.get(map, :reason) ||
-      Map.get(map, "reason") ||
-      if(is_atom(Map.get(map, :message)), do: Map.get(map, :message), else: nil) ||
-      if(is_atom(Map.get(map, "message")), do: Map.get(map, "message"), else: nil)
+    map[:reason] ||
+      if(is_atom(map[:message]), do: map[:message], else: nil)
   end
 
   defp extract_nested_reason(_), do: nil
 
   defp extract_retry_value(%{} = map) do
     cond do
-      Map.has_key?(map, :retry) -> Map.get(map, :retry)
-      Map.has_key?(map, "retry") -> Map.get(map, "retry")
+      Map.has_key?(map, :retry) -> map[:retry]
       true -> nil
     end
   end

--- a/test/jido_ai/live/request_stream_live_test.exs
+++ b/test/jido_ai/live/request_stream_live_test.exs
@@ -97,7 +97,7 @@ defmodule Jido.AI.Live.RequestStreamLiveTest do
     streamed_text =
       event_list
       |> Enum.filter(&(&1.kind == :llm_delta))
-      |> Enum.map_join(&to_string(&1.data[:delta] || &1.data["delta"] || ""))
+      |> Enum.map_join(&to_string(&1.data[:delta] || ""))
 
     assert String.length(streamed_text) > 0
 

--- a/test/jido_ai/skill/runtime_contracts_test.exs
+++ b/test/jido_ai/skill/runtime_contracts_test.exs
@@ -4,8 +4,8 @@ defmodule Jido.AI.Skill.RuntimeContractsTest do
   alias Jido.AI.Skill
   alias Jido.AI.Skill.{Error, Loader, Prompt, Registry, Spec}
 
-  @code_review_skill Path.expand("../../../priv/skills/code-review/SKILL.md", __DIR__)
-  @skills_glob Path.expand("../../../priv/skills/**/SKILL.md", __DIR__)
+  @code_review_skill Application.app_dir(:jido_ai, "priv/skills/code-review/SKILL.md")
+  @skills_glob Application.app_dir(:jido_ai, "priv/skills/**/SKILL.md")
 
   setup do
     start_supervised!(Registry)

--- a/test/jido_ai/thread_test.exs
+++ b/test/jido_ai/thread_test.exs
@@ -726,12 +726,6 @@ defmodule Jido.AI.ContextTest do
       messages =
         original.entries
         |> Enum.reverse()
-        |> Enum.map(fn entry ->
-          case entry do
-            %{role: :user, content: c} -> %{role: :user, content: c}
-            %{role: :assistant, content: c} -> %{role: :assistant, content: c}
-          end
-        end)
 
       # Rebuild
       rebuilt =

--- a/test/support/fake_req_llm.ex
+++ b/test/support/fake_req_llm.ex
@@ -61,7 +61,7 @@ defmodule Jido.AI.TestSupport.FakeReqLLM do
   def stream_text(model, messages, _opts) do
     prompt = extract_latest_user_prompt(messages)
     chunks = ["Stubbed ", "stream ", "for ", prompt]
-    content = Enum.join(chunks, "")
+    content = Enum.join(chunks)
 
     {:ok,
      %{


### PR DESCRIPTION
## Description

Code quality improvements found with [`ex_slop`](https://hex.pm/packages/ex_slop).

**60 issues resolved across 19 files.**

### Commit 1: ex_slop refactoring findings (8 fixes)

- Remove blanket rescue in token decoding (use function-level rescue)
- Replace `Enum.reduce + Map.put` with `Map.new/2`
- Replace `Enum.filter(fn t -> t != nil end)` with `Enum.reject(&is_nil/1)`
- Remove identity case passthrough in task_supervisor
- Remove identity map in thread_test
- Remove redundant `Enum.join` separator
- Use `Application.app_dir` instead of `Path.expand` for priv paths

### Commit 2: DualKeyAccess (52 fixes)

Remove defensive dual atom/string key access. For maps from ReqLLM (usage, metadata, tool calls) which are always atom-keyed, remove the string fallback. For strategy params that may receive string keys from external dispatch, normalize at the `process_instruction` entry point.

## Testing

- [x] Tests pass (`mix test`)
- [x] Compiles without warnings (`mix compile --warnings-as-errors`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format