### PR TITLE
fix: forward agent signal routes

### DIFF
--- a/guides/developer/configuration_reference.md
+++ b/guides/developer/configuration_reference.md
@@ -30,6 +30,7 @@ Package defaults are built into `Jido.AI`; `model_aliases` is merged on top for 
   - `req_http_options`: `[]`
   - `llm_opts`: `[]`
   - `request_transformer`: `nil`
+  - `signal_routes`: `[]` (agent-level routes merged with ReAct strategy routes)
 
 - CoT (`Jido.AI.CoTAgent`)
   - `model`: `:fast` (resolved at runtime via `Jido.AI.resolve_model/1`)

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -51,6 +51,8 @@ defmodule Jido.AI.Agent do
     Runtime reserves `:state` (core Jido-compatible) for tool execution snapshots.
     User-provided values for that key are overwritten per request.
   - `:skills` - Additional skills to attach to the agent (TaskSupervisorSkill is auto-included)
+  - `:signal_routes` - Additional agent-level signal routes forwarded to `Jido.Agent`.
+    ReAct routes are still provided by the default strategy.
 
   ## Generated Functions
 
@@ -373,6 +375,7 @@ defmodule Jido.AI.Agent do
     # Don't extract tool_context here - it contains AST with module aliases
     # that need to be evaluated in the calling module's context
     plugins = Keyword.get(opts, :plugins, [])
+    signal_routes_ast = Keyword.get(opts, :signal_routes, [])
 
     default_plugins =
       opts
@@ -479,6 +482,7 @@ defmodule Jido.AI.Agent do
         description: unquote(description),
         tags: unquote(tags),
         plugins: unquote(ai_plugins) ++ unquote(plugins),
+        signal_routes: unquote(signal_routes_ast),
         default_plugins: unquote(Macro.escape(default_plugins)),
         strategy: {Jido.AI.Reasoning.ReAct.Strategy, unquote(strategy_opts_ast)},
         schema: unquote(base_schema_ast)

--- a/test/jido_ai/agent_test.exs
+++ b/test/jido_ai/agent_test.exs
@@ -43,6 +43,14 @@ defmodule Jido.AI.AgentTest do
     def run(%{query: query}, _ctx), do: {:ok, %{results: ["Found: #{query}"]}}
   end
 
+  defmodule TestSignalAction do
+    use Jido.Action,
+      name: "signal_action",
+      description: "Handles custom agent signals"
+
+    def run(params, _ctx), do: {:ok, params}
+  end
+
   defmodule TestRequestTransformer do
     def transform_request(request, _state, _config, _context), do: {:ok, request}
   end
@@ -174,6 +182,33 @@ defmodule Jido.AI.AgentTest do
       name: "agent_with_nil_prompt",
       tools: [TestCalculator],
       system_prompt: nil
+  end
+
+  defmodule AgentWithSignalRoutes do
+    use Jido.AI.Agent,
+      name: "agent_with_signal_routes",
+      tools: [TestCalculator],
+      signal_routes: [
+        {"custom.state.patch", TestSignalAction}
+      ]
+  end
+
+  defmodule AgentWithSignalRouteStaticParams do
+    use Jido.AI.Agent,
+      name: "agent_with_signal_route_static_params",
+      tools: [TestCalculator],
+      signal_routes: [
+        {"custom.static", {TestSignalAction, %{mode: :patch}}}
+      ]
+  end
+
+  defmodule AgentWithSignalRoutesFromAttribute do
+    @signal_routes [{"custom.attr.patch", TestSignalAction}]
+
+    use Jido.AI.Agent,
+      name: "agent_with_signal_routes_from_attribute",
+      tools: [TestCalculator],
+      signal_routes: @signal_routes
   end
 
   defmodule AgentWithoutDefaultMemory do
@@ -400,6 +435,48 @@ defmodule Jido.AI.AgentTest do
       config = StratState.get(AgentWithNilSystemPrompt.new(), %{})[:config]
 
       assert config.system_prompt == default_config.system_prompt
+    end
+
+    test "signal_routes option is forwarded to the base agent" do
+      expected_routes = [{"custom.state.patch", TestSignalAction}]
+
+      assert AgentWithSignalRoutes.signal_routes() == expected_routes
+      assert AgentWithSignalRoutes.signal_routes(%{agent_module: AgentWithSignalRoutes}) == expected_routes
+    end
+
+    test "signal_routes option supports static params route format" do
+      assert [{"custom.static", {TestSignalAction, %{mode: :patch}}}] =
+               AgentWithSignalRouteStaticParams.signal_routes()
+    end
+
+    test "signal_routes option supports module attributes" do
+      assert AgentWithSignalRoutesFromAttribute.signal_routes() == [
+               {"custom.attr.patch", TestSignalAction}
+             ]
+    end
+
+    test "signal_routes option is used by AgentServer routing" do
+      suffix = System.unique_integer([:positive, :monotonic])
+      registry = Module.concat(__MODULE__, :"SignalRouteRegistry#{suffix}")
+      start_supervised!({Registry, keys: :unique, name: registry})
+
+      {:ok, pid} =
+        Jido.AgentServer.start_link(
+          agent: AgentWithSignalRoutes,
+          id: "signal-route-agent-#{suffix}",
+          registry: registry
+        )
+
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      signal =
+        Jido.Signal.new!("custom.state.patch", %{patched_by_signal: true}, source: "/jido_ai/agent_test")
+
+      assert {:ok, agent} = Jido.AgentServer.call(pid, signal)
+      assert agent.state.patched_by_signal == true
+
+      assert {:ok, server_state} = Jido.AgentServer.state(pid)
+      assert server_state.agent.state.patched_by_signal == true
     end
 
     test "raises when module attribute system_prompt does not resolve to a binary" do


### PR DESCRIPTION
## Summary
- forward Jido.AI.Agent signal_routes into the wrapped Jido.Agent macro
- add regression coverage for simple, static-param, and module-attribute route tables
- verify custom routes are used by AgentServer routing and can mutate agent state
- document the ReAct macro signal_routes default

Closes #280

## Tests
- mix test test/jido_ai/agent_test.exs
- mix test.fast