### PR TITLE
fix: ignore ReAct stream cancel exits

### DIFF
--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -1472,10 +1472,13 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   defp invoke_stream_cancel(%{stream_cancelled?: true} = state), do: state
 
   defp invoke_stream_cancel(%{stream_cancel: cancel_fun} = state) when is_function(cancel_fun, 0) do
-    _ = cancel_fun.()
+    try do
+      _ = cancel_fun.()
+    catch
+      _, _ -> :ok
+    end
+
     %{state | stream_cancelled?: true}
-  catch
-    _, _ -> %{state | stream_cancelled?: true}
   end
 
   defp invoke_stream_cancel(state), do: state

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -887,6 +887,31 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     assert_receive :idle_stream_cancelled, 200
   end
 
+  test "successful stream cleanup ignores dead cancel process exits" do
+    {:ok, dead_pid} = Agent.start_link(fn -> :ok end)
+    dead_ref = Process.monitor(dead_pid)
+    Agent.stop(dead_pid)
+
+    assert_receive {:DOWN, ^dead_ref, :process, ^dead_pid, :normal}, 200
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      {:ok,
+       responses_stream_response(
+         [ReqLLM.StreamChunk.text("Hello")],
+         %{finish_reason: :stop, usage: %{input_tokens: 1, output_tokens: 1}},
+         model,
+         cancel: fn -> GenServer.call(dead_pid, :cancel, 5_000) end
+       )}
+    end)
+
+    config = Config.new(%{model: :capable, tools: %{}})
+
+    events = ReAct.stream("Say hello", config) |> Enum.to_list()
+
+    request_completed = Enum.find(events, &(&1.kind == :request_completed))
+    assert request_completed.data.result == "Hello"
+  end
+
   test "preserves reasoning_details across tool turns" do
     parent = self()
 


### PR DESCRIPTION
## Summary
- make ReAct stream cancel cleanup use explicit `try`/`catch` so exits from a dead ReqLLM cancel process do not crash callers
- add regression coverage using `GenServer.call/3` against a dead process after successful stream consumption

Closes #287

## Verification
- `mix test test/jido_ai/react/runtime_runner_test.exs:890`
- `mix test test/jido_ai/react/runtime_runner_test.exs`
- `mix test.fast`
- `mix precommit`