### PR TITLE
feat(react): allow request_transformer to swap model per turn

### DIFF
--- a/guides/user/standalone_react_runtime.md
+++ b/guides/user/standalone_react_runtime.md
@@ -148,6 +148,24 @@ Typical pattern:
 
 This keeps the LLM-visible tool list, the executable tool registry, and the structured-output contract aligned inside one run.
 
+The overrides map also accepts `model:` to swap which provider handles the next turn. The runtime re-validates any `llm_opts.provider_options` overrides against the override model's provider schema, so a transformer can route between providers and add provider-specific options on the matching turns without breaking validation on the other ones:
+
+```elixir
+def transform_request(_request, _state, _config, _runtime_context) do
+  case current_review_model() do
+    %{provider: :xai} = model ->
+      {:ok,
+       %{
+         model: model,
+         llm_opts: [provider_options: [xai_api: :responses]]
+       }}
+
+    model ->
+      {:ok, %{model: model}}
+  end
+end
+```
+
 ## Run To Completion
 
 `run/3` streams internally and returns the aggregated result map. Simplest path when you do not need the event stream.

--- a/lib/jido_ai/reasoning/react/config.ex
+++ b/lib/jido_ai/reasoning/react/config.ex
@@ -245,12 +245,22 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
 
   @doc """
   Merge request-scoped LLM option overrides into an existing normalized option list.
+
+  The 3-arg form validates `provider_options` overrides against the compile-time
+  `config.model`'s schema. The 4-arg form takes an explicit `model_override` so
+  per-turn provider swaps (via a `request_transformer` returning `:model`) can
+  validate against the *runtime* provider's schema instead.
   """
   @spec merge_llm_opts(t(), keyword(), keyword() | map() | nil) :: keyword()
-  def merge_llm_opts(%__MODULE__{} = _config, base_opts, nil) when is_list(base_opts), do: base_opts
+  def merge_llm_opts(%__MODULE__{} = config, base_opts, overrides) when is_list(base_opts),
+    do: merge_llm_opts(config, base_opts, overrides, nil)
 
-  def merge_llm_opts(%__MODULE__{} = config, base_opts, overrides) when is_list(base_opts) do
-    provider_opt_keys_by_string = provider_opt_keys_by_string(config.model)
+  @spec merge_llm_opts(t(), keyword(), keyword() | map() | nil, term() | nil) :: keyword()
+  def merge_llm_opts(%__MODULE__{} = _config, base_opts, nil, _model) when is_list(base_opts), do: base_opts
+
+  def merge_llm_opts(%__MODULE__{} = config, base_opts, overrides, model_override) when is_list(base_opts) do
+    model = model_override || config.model
+    provider_opt_keys_by_string = provider_opt_keys_by_string(model)
     normalized_overrides = normalize_llm_opts(overrides, provider_opt_keys_by_string)
     maybe_merge_llm_opts(base_opts, normalized_overrides)
   end

--- a/lib/jido_ai/reasoning/react/request_transformer.ex
+++ b/lib/jido_ai/reasoning/react/request_transformer.ex
@@ -11,6 +11,11 @@ defmodule Jido.AI.Reasoning.ReAct.RequestTransformer do
   - dynamic structured-output schemas
   - provider-specific `llm_opts` based on tool results
   - custom message projection beyond the default context rendering
+  - **per-turn model selection** — returning `model:` in the overrides swaps
+    which provider handles the next LLM turn. `llm_opts.provider_options`
+    overrides are re-validated against the selected model's provider schema,
+    so xAI-only keys (e.g. `xai_api`) can be added on xAI turns without
+    breaking Fireworks turns on the same agent.
 
   The runtime always regenerates `llm_opts[:tools]` from the returned `tools`
   field so the exposed LLM tools and execution registry stay aligned.
@@ -21,13 +26,15 @@ defmodule Jido.AI.Reasoning.ReAct.RequestTransformer do
   @type request :: %{
           required(:messages) => [map()],
           required(:llm_opts) => keyword(),
-          required(:tools) => ToolSelection.tools_input()
+          required(:tools) => ToolSelection.tools_input(),
+          required(:model) => term()
         }
 
   @type overrides :: %{
           optional(:messages) => [map()],
           optional(:llm_opts) => keyword() | map(),
-          optional(:tools) => ToolSelection.tools_input()
+          optional(:tools) => ToolSelection.tools_input(),
+          optional(:model) => term()
         }
 
   @doc """

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -263,7 +263,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     with {:ok, request} <- build_turn_request(state, config, runtime_context) do
       state = %{state | active_tools: request.tools}
 
-      case request_turn(state, owner, ref, config, request.messages, request.llm_opts) do
+      case request_turn(state, owner, ref, config, request.messages, request.llm_opts, request.model) do
         {:ok, state, turn, response_id} ->
           state =
             state
@@ -335,7 +335,8 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     base_request = %{
       messages: AIContext.to_messages(state.context),
       llm_opts: config |> Config.llm_opts() |> maybe_put_previous_response_id(state.llm_response_id),
-      tools: config.tools
+      tools: config.tools,
+      model: config.model
     }
 
     with {:ok, request} <- maybe_transform_request(base_request, state, config, runtime_context),
@@ -343,7 +344,13 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
          {:ok, messages} <- normalize_request_messages(request),
          {:ok, tools} <- normalize_request_tools(request),
          llm_opts <- sync_tools_in_llm_opts(config, request.llm_opts, tools) do
-      {:ok, %{messages: messages, llm_opts: maybe_put_openai_websocket_session(config, llm_opts), tools: tools}}
+      {:ok,
+       %{
+         messages: messages,
+         llm_opts: maybe_put_openai_websocket_session(config, llm_opts),
+         tools: tools,
+         model: Map.get(request, :model, config.model)
+       }}
     end
   end
 
@@ -368,6 +375,12 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   end
 
   defp apply_request_overrides(request, overrides, %Config{} = config) when is_map(request) and is_map(overrides) do
+    # Resolve `:model` first so any per-turn provider swap is in place before
+    # we re-validate llm_opts overrides — `provider_options` keys differ per
+    # provider, so xAI-only keys (e.g. `xai_api`) must validate against xAI's
+    # schema, not the compile-time provider's schema.
+    request = maybe_put_request_model(request, Map.get(overrides, :model, Map.get(overrides, "model")))
+
     request
     |> maybe_put_request_field(:messages, Map.get(overrides, :messages, Map.get(overrides, "messages")))
     |> maybe_put_request_field(:tools, Map.get(overrides, :tools, Map.get(overrides, "tools")))
@@ -377,11 +390,22 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   defp maybe_put_request_field(request, _field, nil), do: request
   defp maybe_put_request_field(request, field, value), do: Map.put(request, field, value)
 
+  defp maybe_put_request_model(request, nil), do: request
+
+  defp maybe_put_request_model(request, model_override) do
+    Map.put(request, :model, Jido.AI.resolve_model(model_override))
+  end
+
   defp maybe_merge_request_llm_opts(request, _config, nil), do: request
 
   defp maybe_merge_request_llm_opts(request, %Config{} = config, llm_opts_override) do
+    # If a per-turn `:model` override was applied earlier in apply_request_overrides,
+    # validate the llm_opts overrides against THAT provider's schema. Otherwise
+    # fall back to the compile-time `config.model` schema (existing behavior).
+    effective_model = Map.get(request, :model, config.model)
+
     Map.update!(request, :llm_opts, fn base_opts ->
-      Config.merge_llm_opts(config, base_opts, llm_opts_override)
+      Config.merge_llm_opts(config, base_opts, llm_opts_override, effective_model)
     end)
   end
 
@@ -411,18 +435,18 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     |> Keyword.put(:tools, reqllm_tools)
   end
 
-  defp request_turn(%State{} = state, owner, ref, %Config{} = config, messages, llm_opts) do
+  defp request_turn(%State{} = state, owner, ref, %Config{} = config, messages, llm_opts, model) do
     case config.streaming do
       false ->
-        request_turn_generate(state, config, messages, llm_opts)
+        request_turn_generate(state, config, messages, llm_opts, model)
 
       _ ->
-        request_turn_stream(state, owner, ref, config, messages, llm_opts)
+        request_turn_stream(state, owner, ref, config, messages, llm_opts, model)
     end
   end
 
-  defp request_turn_stream(%State{} = state, owner, ref, %Config{} = config, messages, llm_opts) do
-    case ReqLLM.Generation.stream_text(config.model, messages, llm_opts) do
+  defp request_turn_stream(%State{} = state, owner, ref, %Config{} = config, messages, llm_opts, model) do
+    case ReqLLM.Generation.stream_text(model, messages, llm_opts) do
       {:ok, stream_response} ->
         announce_stream_control(owner, ref, stream_response)
 
@@ -436,8 +460,8 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     end
   end
 
-  defp request_turn_generate(%State{} = state, %Config{} = config, messages, llm_opts) do
-    case ReqLLM.Generation.generate_text(config.model, messages, llm_opts) do
+  defp request_turn_generate(%State{} = state, %Config{} = config, messages, llm_opts, model) do
+    case ReqLLM.Generation.generate_text(model, messages, llm_opts) do
       {:ok, response} ->
         consume_generate(state, config, response)
 

--- a/test/jido_ai/reasoning/react/config_runtime_model_test.exs
+++ b/test/jido_ai/reasoning/react/config_runtime_model_test.exs
@@ -1,0 +1,57 @@
+defmodule Jido.AI.Reasoning.ReAct.ConfigRuntimeModelTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.AI.Reasoning.ReAct.Config
+
+  describe "merge_llm_opts/4 with model override" do
+    test "3-arg form validates provider_options against config.model" do
+      config = Config.new(model: "openai:gpt-4.1")
+
+      merged =
+        Config.merge_llm_opts(
+          config,
+          [],
+          provider_options: [verbosity: :medium]
+        )
+
+      assert get_in(merged, [:provider_options]) == [verbosity: :medium]
+    end
+
+    test "4-arg form validates provider_options against the override model" do
+      # Boot config uses OpenAI; override to anthropic for this turn.
+      config = Config.new(model: "openai:gpt-4.1")
+
+      merged =
+        Config.merge_llm_opts(
+          config,
+          [],
+          [provider_options: [reasoning_token_budget: 8192]],
+          "anthropic:claude-sonnet-4-5"
+        )
+
+      assert get_in(merged, [:provider_options]) == [reasoning_token_budget: 8192]
+    end
+
+    test "4-arg form with nil model_override falls back to config.model" do
+      config = Config.new(model: "openai:gpt-4.1")
+
+      merged =
+        Config.merge_llm_opts(
+          config,
+          [],
+          [provider_options: [verbosity: :medium]],
+          nil
+        )
+
+      assert get_in(merged, [:provider_options]) == [verbosity: :medium]
+    end
+
+    test "nil overrides return base_opts unchanged for both 3- and 4-arg forms" do
+      config = Config.new(model: "openai:gpt-4.1")
+      base = [max_tokens: 1024]
+
+      assert Config.merge_llm_opts(config, base, nil) == base
+      assert Config.merge_llm_opts(config, base, nil, "anthropic:claude-sonnet-4-5") == base
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Jido.AI.Reasoning.ReAct.RequestTransformer` can now return `:model` in its overrides. The runner resolves it via `Jido.AI.resolve_model/1`, uses it for that turn's LLM call instead of `config.model`, and re-validates any `provider_options` overrides against the runtime provider's schema.

## Why

Agents that swap providers at runtime (e.g. a settings-driven dropdown between Fireworks and xAI) currently can't add provider-specific keys like `xai_api: :responses` to `llm_opts.provider_options`. The compile-time `use Jido.AI.Agent, model: …` decides which provider schema validates every turn, so a key valid for one provider crashes the other's validation. Per-turn override fixes this.

## Changes

- `RequestTransformer.overrides` gains optional `:model`; `request` gains required `:model` (seeded from `config.model`).
- `apply_request_overrides` resolves `:model` before merging `llm_opts` so validation uses the runtime provider's schema.
- `request_turn` / `request_turn_stream` / `request_turn_generate` take `model` explicitly and pass it through to `ReqLLM.Generation`.
- `Config.merge_llm_opts/4` accepts an optional `model_override`; the 3-arg form delegates with `nil` (backwards compatible).
- `guides/user/standalone_react_runtime.md` updated with an example.

## Tests

4 new tests for `merge_llm_opts/4`; 86 pre-existing ReAct tests stay green. `mix format`, `mix compile --warnings-as-errors`, `mix credo --strict` (no new warnings vs `main`), `mix dialyzer`, `mix doctor --summary --raise`, `mix test.fast` all pass.
