### PR TITLE
[codex] Add request-scoped ReAct max iterations

### DIFF
--- a/guides/developer/configuration_reference.md
+++ b/guides/developer/configuration_reference.md
@@ -73,7 +73,7 @@ Package defaults are built into `Jido.AI`; `model_aliases` is merged on top for 
 
 - await timeout: `30_000ms`
 - max retained requests per agent state: `100`
-- request-scoped ReAct overrides: `tools`, `allowed_tools`, `request_transformer`, `tool_context`, `req_http_options`, `llm_opts`
+- request-scoped ReAct overrides: `tools`, `allowed_tools`, `request_transformer`, `max_iterations`, `tool_context`, `req_http_options`, `llm_opts`
 
 ## Security Defaults
 

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -504,6 +504,7 @@ defmodule Jido.AI.Agent do
       - `:tools` - Request-scoped tool registry override for this run only
       - `:allowed_tools` - Request-scoped allowlist of tool names
       - `:request_transformer` - Module implementing per-turn ReAct request shaping
+      - `:max_iterations` - Request-scoped maximum reasoning iterations
       - `:stream_timeout_ms` - Request-scoped runtime inactivity timeout.
         `:stream_receive_timeout_ms` is accepted as a compatibility alias.
       - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
@@ -599,6 +600,7 @@ defmodule Jido.AI.Agent do
       - `:tools` - Request-scoped tool registry override for this run only
       - `:allowed_tools` - Request-scoped allowlist of tool names
       - `:request_transformer` - Module implementing per-turn ReAct request shaping
+      - `:max_iterations` - Request-scoped maximum reasoning iterations
       - `:stream_timeout_ms` - Request-scoped runtime inactivity timeout.
         `:stream_receive_timeout_ms` is accepted as a compatibility alias.
       - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime

--- a/lib/jido_ai/directive/emit_tool_error.ex
+++ b/lib/jido_ai/directive/emit_tool_error.ex
@@ -65,7 +65,8 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.EmitToolError do
         tool_name: tool_name,
         result:
           {:error,
-           SignalHelpers.normalize_error(error, :execution_error, "Tool execution failed", %{tool_name: tool_name}), []},
+           SignalHelpers.normalize_error(error, :execution_error, "Tool execution failed", %{tool_name: tool_name}),
+           []},
         metadata: metadata
       })
 

--- a/lib/jido_ai/directive/emit_tool_error.ex
+++ b/lib/jido_ai/directive/emit_tool_error.ex
@@ -58,15 +58,15 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.EmitToolError do
     agent_pid = self()
     metadata = Map.get(directive, :metadata, %{})
 
+    normalized_error =
+      SignalHelpers.normalize_error(error, :execution_error, "Tool execution failed", %{tool_name: tool_name})
+
     # Emit the error result synchronously (no task needed)
     signal =
       Signal.ToolResult.new!(%{
         call_id: call_id,
         tool_name: tool_name,
-        result:
-          {:error,
-           SignalHelpers.normalize_error(error, :execution_error, "Tool execution failed", %{tool_name: tool_name}),
-           []},
+        result: {:error, normalized_error, []},
         metadata: metadata
       })
 

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -193,6 +193,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           stream_timeout_ms: Zoi.integer() |> Zoi.optional(),
           req_http_options: Zoi.list(Zoi.any()) |> Zoi.optional(),
           llm_opts: Zoi.any() |> Zoi.optional(),
+          max_iterations: Zoi.integer() |> Zoi.optional(),
           output: Zoi.any() |> Zoi.optional(),
           extra_refs: Zoi.map() |> Zoi.optional()
         }),
@@ -614,6 +615,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
             tools: effective_tools,
             stream_receive_timeout_ms: Map.get(params, :stream_receive_timeout_ms),
             stream_timeout_ms: Map.get(params, :stream_timeout_ms),
+            max_iterations: Map.get(params, :max_iterations),
             request_transformer: request_transformer,
             output: output,
             pending_input_server: pending_input_server
@@ -1873,6 +1875,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     tools = Keyword.get(opts, :tools, config[:actions_by_name] || %{})
     request_transformer = Keyword.get(opts, :request_transformer, config[:request_transformer])
     output = Keyword.get(opts, :output, config[:output])
+    max_iterations = resolve_max_iterations_opt(opts, config[:max_iterations])
 
     stream_timeout_ms =
       resolve_stream_timeout_ms_opt(
@@ -1885,7 +1888,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       system_prompt: config[:system_prompt],
       tools: tools,
       request_transformer: request_transformer,
-      max_iterations: config[:max_iterations],
+      max_iterations: max_iterations,
       max_tokens: config[:max_tokens],
       streaming: config[:streaming],
       stream_timeout_ms: stream_timeout_ms,
@@ -2332,6 +2335,13 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           _ ->
             default
         end
+    end
+  end
+
+  defp resolve_max_iterations_opt(opts, default) when is_list(opts) do
+    case Keyword.fetch(opts, :max_iterations) do
+      {:ok, value} when is_integer(value) and value > 0 -> value
+      _ -> default
     end
   end
 

--- a/lib/jido_ai/request.ex
+++ b/lib/jido_ai/request.ex
@@ -157,6 +157,7 @@ defmodule Jido.AI.Request do
   - `:tools` - ReAct-only request-scoped tool registry override for this run
   - `:allowed_tools` - ReAct-only request-scoped allowlist of tool names
   - `:request_transformer` - ReAct-only module implementing per-turn request shaping
+  - `:max_iterations` - ReAct-only request-scoped maximum reasoning iterations
   - `:stream_timeout_ms` - ReAct-only request-scoped runtime inactivity timeout.
     `:stream_receive_timeout_ms` is accepted as a compatibility alias.
   - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
@@ -189,6 +190,7 @@ defmodule Jido.AI.Request do
     tools = Keyword.get(opts, :tools)
     allowed_tools = Keyword.get(opts, :allowed_tools)
     request_transformer = Keyword.get(opts, :request_transformer)
+    max_iterations = Keyword.get(opts, :max_iterations)
     stream_timeout_ms = Keyword.get(opts, :stream_timeout_ms, Keyword.get(opts, :stream_receive_timeout_ms))
     req_http_options = Keyword.get(opts, :req_http_options, [])
     llm_opts = Keyword.get(opts, :llm_opts, [])
@@ -207,6 +209,7 @@ defmodule Jido.AI.Request do
         |> maybe_add_tools(tools)
         |> maybe_add_allowed_tools(allowed_tools)
         |> maybe_add_request_transformer(request_transformer)
+        |> maybe_add_max_iterations(max_iterations)
         |> maybe_add_stream_timeout_ms(stream_timeout_ms)
         |> maybe_add_req_http_options(req_http_options)
         |> maybe_add_llm_opts(llm_opts)
@@ -560,6 +563,13 @@ defmodule Jido.AI.Request do
   end
 
   defp maybe_add_stream_timeout_ms(payload, _), do: payload
+
+  defp maybe_add_max_iterations(payload, max_iterations)
+       when is_integer(max_iterations) and max_iterations > 0 do
+    Map.put(payload, :max_iterations, max_iterations)
+  end
+
+  defp maybe_add_max_iterations(payload, _), do: payload
 
   defp maybe_add_stream_to(payload, nil), do: payload
   defp maybe_add_stream_to(payload, stream_to), do: Map.put(payload, :stream_to, stream_to)

--- a/test/jido_ai/request_test.exs
+++ b/test/jido_ai/request_test.exs
@@ -407,6 +407,7 @@ defmodule JidoTest.AI.RequestTest do
                  tools: [:tool_override],
                  allowed_tools: ["calculator"],
                  request_transformer: TestRequestTransformer,
+                 max_iterations: 3,
                  stream_timeout_ms: 4_321,
                  stream_to: {:pid, self()},
                  req_http_options: [plug: {Req.Test, []}],
@@ -429,6 +430,7 @@ defmodule JidoTest.AI.RequestTest do
       assert signal.data.tools == [:tool_override]
       assert signal.data.allowed_tools == ["calculator"]
       assert signal.data.request_transformer == TestRequestTransformer
+      assert signal.data.max_iterations == 3
       assert signal.data.stream_timeout_ms == 4_321
       assert signal.data.stream_to == {:pid, self()}
       assert signal.data.req_http_options == [plug: {Req.Test, []}]

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -200,6 +200,48 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
       assert state.pending_worker_start.config.llm.max_tokens == 4_096
     end
 
+    test "start preserves configured max_iterations when request omits override" do
+      agent = create_agent(tools: [TestCalculator], max_iterations: 4)
+
+      start_instruction = instruction(ReAct.start_action(), %{query: "What is 2 + 2?", request_id: "req_1"})
+      {agent, [_spawn]} = ReAct.cmd(agent, [start_instruction], %{})
+
+      state = StratState.get(agent, %{})
+      assert state.pending_worker_start.config.max_iterations == 4
+    end
+
+    test "start applies request-scoped max_iterations override to runtime config" do
+      agent = create_agent(tools: [TestCalculator], max_iterations: 4)
+
+      start_instruction =
+        instruction(ReAct.start_action(), %{
+          query: "What is 2 + 2?",
+          request_id: "req_1",
+          max_iterations: 2
+        })
+
+      {agent, [_spawn]} = ReAct.cmd(agent, [start_instruction], %{})
+
+      state = StratState.get(agent, %{})
+      assert state.pending_worker_start.config.max_iterations == 2
+    end
+
+    test "start ignores invalid request-scoped max_iterations override" do
+      agent = create_agent(tools: [TestCalculator], max_iterations: 4)
+
+      start_instruction =
+        instruction(ReAct.start_action(), %{
+          query: "What is 2 + 2?",
+          request_id: "req_1",
+          max_iterations: 0
+        })
+
+      {agent, [_spawn]} = ReAct.cmd(agent, [start_instruction], %{})
+
+      state = StratState.get(agent, %{})
+      assert state.pending_worker_start.config.max_iterations == 4
+    end
+
     test "start propagates stream_timeout_ms option into runtime config" do
       agent = create_agent(tools: [TestCalculator], stream_timeout_ms: 123_456)
 

--- a/test/jido_ai/turn_test.exs
+++ b/test/jido_ai/turn_test.exs
@@ -423,7 +423,9 @@ defmodule Jido.AI.TurnTest do
           handler_id,
           [:jido, :ai, :tool, :execute, :stop],
           fn _event, _measurements, metadata, _config ->
-            send(test_pid, {:stop_metadata, metadata})
+            if metadata[:tool_call_id] == "tc_run_tools_1" do
+              send(test_pid, {:stop_metadata, metadata})
+            end
           end,
           nil
         )
@@ -468,8 +470,10 @@ defmodule Jido.AI.TurnTest do
         :telemetry.attach(
           handler_id,
           [:jido, :ai, :tool, :execute, :stop],
-          fn _event, measurements, _metadata, _config ->
-            send(test_pid, {:stop_measurements, measurements})
+          fn _event, measurements, metadata, _config ->
+            if metadata[:tool_call_id] == "tc_duration_1" do
+              send(test_pid, {:stop_measurements, measurements})
+            end
           end,
           nil
         )
@@ -480,7 +484,7 @@ defmodule Jido.AI.TurnTest do
                Turn.execute_module(
                  Calculator,
                  %{operation: "add", a: 1, b: 2},
-                 %{observability: %{emit_telemetry?: true}}
+                 %{observability: %{emit_telemetry?: true}, call_id: "tc_duration_1"}
                )
 
       assert_receive {:stop_measurements, measurements}
@@ -498,7 +502,9 @@ defmodule Jido.AI.TurnTest do
           stop_handler_id,
           [:jido, :ai, :tool, :execute, :stop],
           fn _event, _measurements, metadata, _config ->
-            send(test_pid, {:stop_metadata, metadata})
+            if metadata[:tool_call_id] == "tc_meta_1" do
+              send(test_pid, {:stop_metadata, metadata})
+            end
           end,
           nil
         )
@@ -530,7 +536,9 @@ defmodule Jido.AI.TurnTest do
           start_handler_id,
           [:jido, :ai, :tool, :execute, :start],
           fn _event, _measurements, metadata, _config ->
-            send(test_pid, {:start_metadata, metadata})
+            if metadata[:tool_call_id] == "tc_ctx_1" do
+              send(test_pid, {:start_metadata, metadata})
+            end
           end,
           nil
         )
@@ -540,7 +548,9 @@ defmodule Jido.AI.TurnTest do
           stop_handler_id,
           [:jido, :ai, :tool, :execute, :stop],
           fn _event, _measurements, metadata, _config ->
-            send(test_pid, {:stop_metadata, metadata})
+            if metadata[:tool_call_id] == "tc_ctx_1" do
+              send(test_pid, {:stop_metadata, metadata})
+            end
           end,
           nil
         )
@@ -572,7 +582,9 @@ defmodule Jido.AI.TurnTest do
           stop_handler_id,
           [:jido, :ai, :tool, :execute, :stop],
           fn _event, _measurements, metadata, _config ->
-            send(test_pid, {:stop_metadata, metadata})
+            if metadata[:tool_call_id] == "tc_legacy_1" do
+              send(test_pid, {:stop_metadata, metadata})
+            end
           end,
           nil
         )


### PR DESCRIPTION
## Summary

Adds a request-scoped `max_iterations` override for delegated ReAct runs while preserving configured strategy defaults when the request omits or provides an invalid override.

## Details

- Extends the ReAct start schema with optional `max_iterations`.
- Threads positive per-request overrides into runtime config construction.
- Keeps configured `max_iterations` intact when no valid request override is present, avoiding the nil override regression from the vendored patch.
- Forwards `max_iterations` through `Jido.AI.Request.create_and_send/3` and documents it on generated agent request APIs.
- Fixes an existing formatter-only tuple wrapping issue in `EmitToolError`.

## Validation

- `mix test test/jido_ai/strategy/react_test.exs test/jido_ai/request_test.exs`
- `mix test.fast`
- `mix precommit`