### PR TITLE
fix: expose completed ReAct tool results

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ end
 - `tools:` replaces the tool registry for one request.
 - `request_transformer:` lets you reshape each LLM turn, including dynamic tool gating and structured-output schemas.
 
+After a ReAct run, `snapshot.result` is the final assistant answer. Completed
+tool outputs are available separately through
+`snapshot.details[:tool_results]`, so callers do not need to parse conversation
+messages or request traces to recover structured tool data.
+
 For retrieval or classification flows, prefer having tools write `StateOp.SetState` updates and let a `request_transformer` read `context[:state]` to constrain the next turn. That keeps tool exposure, runtime state, and output schemas aligned without scraping message history. See [Standalone ReAct Runtime](guides/user/standalone_react_runtime.md) for the pattern.
 
 Need one-shot text generation without an agent process?

--- a/guides/user/first_react_agent.md
+++ b/guides/user/first_react_agent.md
@@ -143,6 +143,33 @@ signal = Jido.Signal.new!(
 {:ok, _agent} = Jido.AI.set_system_prompt(pid, "You are a concise support specialist.")
 ```
 
+## Final Answer Vs Tool Outputs
+
+`ask_sync/3` and `snapshot.result` return the final assistant answer. Tool
+Actions may also return structured data that you want to inspect directly. For
+that, read `snapshot.details[:tool_results]` instead of parsing conversation
+messages or internal request traces.
+
+| Surface | Contains | Use for |
+|---|---|---|
+| `snapshot.result` | Final assistant answer | What to show the user |
+| `snapshot.details[:tool_results]` | Completed tool outputs for the current or most recent ReAct run | URLs, IDs, records, and other structured tool data |
+| `snapshot.details[:conversation]` | Projected LLM messages, including serialized tool messages | Restoring conversation context |
+
+```elixir
+{:ok, status} = Jido.AgentServer.status(pid)
+
+image_results =
+  status.snapshot.details[:tool_results]
+  |> List.wrap()
+  |> Enum.filter(&(&1.name == "generate_image"))
+  |> Enum.map(fn %{result: {:ok, output, _effects}} -> output end)
+```
+
+Use this for run inspection. If a tool produces domain data that must survive
+process restarts or serve as the system of record, persist it from the tool or
+return an allowed state effect.
+
 ## Optional: Restore Conversation Context
 
 If you persist the conversation history (e.g. from `snapshot.details.conversation`),

--- a/guides/user/request_lifecycle_and_concurrency.md
+++ b/guides/user/request_lifecycle_and_concurrency.md
@@ -162,6 +162,20 @@ get_in(status.raw_state, [:requests, request_id, :meta])
 # %{usage: %{...}, reasoning_details: [...], ...}
 ```
 
+The status snapshot separates the final assistant answer from completed tool
+outputs:
+
+```elixir
+{:ok, status} = Jido.AgentServer.status(pid)
+
+answer = status.snapshot.result
+tool_results = status.snapshot.details[:tool_results] || []
+```
+
+`tool_results` is scoped to the current or most recent ReAct run and is meant
+for inspection. Persist durable business data from the tool itself, or return an
+allowed state effect when later turns need to read it.
+
 ## Failure Mode: Timeouts Under Load
 
 Symptom:

--- a/guides/user/thread_context_and_message_projection.md
+++ b/guides/user/thread_context_and_message_projection.md
@@ -72,6 +72,11 @@ context =
   |> Context.append_messages(conversation_messages)
 ```
 
+Use `snapshot.details.conversation` for message restore/import workflows. Tool
+messages in that conversation are serialized for LLM projection, so do not parse
+them to recover structured tool payloads. For completed ReAct tool outputs, use
+`snapshot.details[:tool_results]`.
+
 ## ReAct Context Operations
 
 Canonical strategy signal for context lifecycle:

--- a/guides/user/turn_and_tool_results.md
+++ b/guides/user/turn_and_tool_results.md
@@ -198,6 +198,33 @@ Tool execution envelopes are canonical triples:
 Legacy 2-tuples (`{:ok, result}` / `{:error, reason}`) are normalized at runtime boundaries.
 Use triple pattern-matching in new code.
 
+## ReAct Agent Tool Results
+
+`Jido.AI.Turn.tool_results` is the low-level surface used when you build a
+custom tool loop yourself. When `Jido.AI.Agent` manages the ReAct loop for you,
+inspect completed tool outputs through the agent snapshot:
+
+```elixir
+{:ok, status} = Jido.AgentServer.status(pid)
+
+tool_results = status.snapshot.details[:tool_results] || []
+```
+
+`status.snapshot.result` remains the final assistant answer. Tool result
+entries keep the normalized action envelope under `:result`:
+
+```elixir
+%{
+  id: "call_abc",
+  name: "multiply",
+  arguments: %{"a" => 6, "b" => 7},
+  result: {:ok, %{product: 42}, []}
+}
+```
+
+Use `snapshot.details[:conversation]` for restoring message history, not for
+recovering structured tool payloads.
+
 ## Effect Policy And Ordering
 
 - `Turn.execute/4` and `Turn.execute_module/4` filter tool-emitted effects through `context[:effect_policy]` when provided.

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -398,6 +398,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       output: state[:output],
       duration_ms: calculate_duration(state[:started_at]),
       tool_calls: format_tool_calls(state[:pending_tool_calls] || []),
+      tool_results: state[:tool_results] || [],
       current_llm_call_id: state[:current_llm_call_id],
       active_request_id: state[:active_request_id],
       checkpoint_token: state[:checkpoint_token],
@@ -434,13 +435,55 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
 
   defp format_tool_calls(pending_tool_calls) do
     Enum.map(pending_tool_calls, fn tc ->
+      result = fetch_map_value(tc, :result)
+
       %{
-        id: tc.id,
-        name: tc.name,
-        arguments: tc.arguments,
-        status: if(tc.result == nil, do: :running, else: :completed),
-        result: tc.result
+        id: fetch_map_value(tc, :id),
+        name: fetch_map_value(tc, :name),
+        arguments: fetch_map_value(tc, :arguments) || %{},
+        status: if(result == nil, do: :running, else: :completed),
+        result: result
       }
+    end)
+  end
+
+  defp completed_tool_result_entry(state, tool_call_id, tool_name, tool_result) do
+    %{
+      id: tool_call_id,
+      name: tool_name,
+      arguments: pending_tool_arguments(state, tool_call_id),
+      result: tool_result
+    }
+  end
+
+  defp put_completed_tool_result(state, tool_result_entry) do
+    existing =
+      case Map.get(state, :tool_results, []) do
+        results when is_list(results) -> results
+        _ -> []
+      end
+
+    updated =
+      case Enum.split_while(existing, &(fetch_map_value(&1, :id) != tool_result_entry[:id])) do
+        {_before, []} ->
+          existing ++ [tool_result_entry]
+
+        {before, [_old | after_results]} ->
+          before ++ [tool_result_entry | after_results]
+      end
+
+    Map.put(state, :tool_results, updated)
+  end
+
+  defp pending_tool_arguments(state, tool_call_id) do
+    state
+    |> Map.get(:pending_tool_calls, [])
+    |> Enum.find_value(%{}, fn call ->
+      if fetch_map_value(call, :id) == tool_call_id do
+        fetch_map_value(call, :arguments) || %{}
+      else
+        false
+      end
     end)
   end
 
@@ -460,6 +503,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
         run_context: nil,
         active_context_ref: active_context_ref,
         pending_tool_calls: [],
+        tool_results: [],
         final_answer: nil,
         result: nil,
         current_llm_call_id: nil,
@@ -675,6 +719,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           |> Map.put(:streaming_text, "")
           |> Map.put(:streaming_thinking, "")
           |> Map.put(:pending_tool_calls, [])
+          |> Map.put(:tool_results, [])
           |> Map.put(:cancel_reason, nil)
           |> Map.put(:checkpoint_token, nil)
           |> Map.put(:run_context, run_context)
@@ -1524,6 +1569,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           |> Map.put(:started_at, event_field(event, :at_ms, System.monotonic_time(:millisecond)))
           |> Map.put(:streaming_text, "")
           |> Map.put(:streaming_thinking, "")
+          |> Map.put(:tool_results, [])
           |> ensure_request_trace(request_id)
 
         signal =
@@ -1659,6 +1705,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
         tool_call_id = event_field(data, :tool_call_id, event_field(event, :tool_call_id, ""))
         tool_name = event_field(data, :tool_name, event_field(event, :tool_name, ""))
         tool_result = normalize_tool_result(event_field(data, :result, {:error, :unknown, []}))
+        tool_result_entry = completed_tool_result_entry(base_state, tool_call_id, tool_name, tool_result)
 
         refs = runtime_event_refs(event, request_id)
 
@@ -1669,6 +1716,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
               if tc.id == tool_call_id, do: %{tc | result: tool_result}, else: tc
             end)
           end)
+          |> put_completed_tool_result(tool_result_entry)
           |> append_tool_result_to_run_context(tool_call_id, tool_name, tool_result, refs)
 
         signal =

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -884,6 +884,128 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
              ]
     end
 
+    test "snapshot formats pending tool calls with string keys" do
+      agent = create_agent(tools: [TestCalculator])
+
+      state =
+        agent
+        |> StratState.get(%{})
+        |> Map.put(:status, :awaiting_tool)
+        |> Map.put(:pending_tool_calls, [
+          %{
+            "id" => "call_string",
+            "name" => "calculator",
+            "arguments" => %{"operation" => "add", "a" => 2, "b" => 3},
+            "result" => nil
+          }
+        ])
+
+      agent = StratState.put(agent, state)
+
+      assert ReAct.snapshot(agent, %{}).details.tool_calls == [
+               %{
+                 id: "call_string",
+                 name: "calculator",
+                 arguments: %{"operation" => "add", "a" => 2, "b" => 3},
+                 status: :running,
+                 result: nil
+               }
+             ]
+    end
+
+    test "snapshot exposes completed tool results after final answer" do
+      agent = create_agent(tools: [TestCalculator, TestSearch])
+
+      {agent, [_spawn]} =
+        ReAct.cmd(agent, [instruction(ReAct.start_action(), %{query: "Use tools", request_id: "req_tools"})], %{})
+
+      replayed_tool_result =
+        runtime_event(:tool_completed, "req_tools", 3, %{
+          tool_call_id: "call_calc",
+          tool_name: "calculator",
+          result: {:ok, %{result: 5}, []}
+        })
+
+      events = [
+        runtime_event(:request_started, "req_tools", 1, %{query: "Use tools"}),
+        runtime_event(:llm_completed, "req_tools", 2, %{
+          turn_type: :tool_calls,
+          text: "",
+          thinking_content: nil,
+          tool_calls: [
+            %{
+              id: "call_calc",
+              name: "calculator",
+              arguments: %{"operation" => "add", "a" => 2, "b" => 3}
+            },
+            %{
+              id: "call_search",
+              name: "search",
+              arguments: %{"query" => "jido"}
+            }
+          ],
+          usage: %{}
+        }),
+        replayed_tool_result,
+        replayed_tool_result,
+        runtime_event(:tool_completed, "req_tools", 4, %{
+          tool_call_id: "call_search",
+          tool_name: "search",
+          result: {:error, %{type: :timeout, message: "search timed out"}, []}
+        }),
+        runtime_event(:llm_completed, "req_tools", 5, %{
+          turn_type: :final_answer,
+          text: "The tools finished.",
+          thinking_content: nil,
+          tool_calls: [],
+          usage: %{}
+        }),
+        runtime_event(:request_completed, "req_tools", 6, %{
+          result: "The tools finished.",
+          termination_reason: :final_answer,
+          usage: %{}
+        })
+      ]
+
+      {agent, []} =
+        Enum.reduce(events, {agent, []}, fn event, {acc, _} ->
+          ReAct.cmd(acc, [instruction(:ai_react_worker_event, %{request_id: "req_tools", event: event})], %{})
+        end)
+
+      snapshot = ReAct.snapshot(agent, %{})
+
+      assert snapshot.result == "The tools finished."
+
+      assert snapshot.details.tool_results == [
+               %{
+                 id: "call_calc",
+                 name: "calculator",
+                 arguments: %{"operation" => "add", "a" => 2, "b" => 3},
+                 result: {:ok, %{result: 5}, []}
+               },
+               %{
+                 id: "call_search",
+                 name: "search",
+                 arguments: %{"query" => "jido"},
+                 result:
+                   {:error,
+                    %{
+                      type: :timeout,
+                      message: "search timed out",
+                      details: %{},
+                      retryable?: true
+                    }, []}
+               }
+             ]
+
+      refute Map.has_key?(snapshot.details, :tool_calls)
+
+      {agent, [_spawn]} =
+        ReAct.cmd(agent, [instruction(ReAct.start_action(), %{query: "Next run", request_id: "req_next"})], %{})
+
+      refute Map.has_key?(ReAct.snapshot(agent, %{}).details, :tool_results)
+    end
+
     test "request completion clears ephemeral req_http_options" do
       agent = create_agent(tools: [TestCalculator])
 


### PR DESCRIPTION
## Summary
- track completed ReAct tool results separately from pending tool calls
- expose completed tool outputs via snapshot.details.tool_results
- upsert completed tool results by call id so replayed completion events do not duplicate snapshot output
- make snapshot tool-call formatting tolerate atom-keyed structs/maps and string-keyed maps
- document final answer vs tool output vs conversation projection across README and user guides
- clarify that durable domain data should be persisted by tools or state effects, not parsed from conversation history

## Tests
- mix test test/jido_ai/strategy/react_test.exs
- mix test.fast
- mix test