### PR TITLE
fix(reasoning): merge nested usage metadata safely

### DIFF
--- a/lib/jido_ai/actions/tool_calling/call_with_tools.ex
+++ b/lib/jido_ai/actions/tool_calling/call_with_tools.ex
@@ -62,7 +62,7 @@ defmodule Jido.AI.Actions.ToolCalling.CallWithTools do
           |> Zoi.default(10)
       })
 
-  alias Jido.AI.{ToolAdapter, Turn, Validation}
+  alias Jido.AI.{ToolAdapter, Turn, Usage, Validation}
   alias ReqLLM.Context
 
   @doc """
@@ -303,27 +303,9 @@ defmodule Jido.AI.Actions.ToolCalling.CallWithTools do
   defp maybe_put_message_attr(map, key, value), do: Map.put(map, key, value)
 
   defp merge_usage(first, second) do
-    first_usage = normalize_usage(first)
-    second_usage = normalize_usage(second)
-
-    input_tokens = first_usage.input_tokens + second_usage.input_tokens
-    output_tokens = first_usage.output_tokens + second_usage.output_tokens
-
-    %{
-      input_tokens: input_tokens,
-      output_tokens: output_tokens,
-      total_tokens: input_tokens + output_tokens
-    }
-  end
-
-  defp normalize_usage(nil), do: %{input_tokens: 0, output_tokens: 0, total_tokens: 0}
-
-  defp normalize_usage(%{} = usage) do
-    input_tokens = Map.get(usage, :input_tokens, 0)
-    output_tokens = Map.get(usage, :output_tokens, 0)
-    total_tokens = Map.get(usage, :total_tokens, input_tokens + output_tokens)
-
-    %{input_tokens: input_tokens, output_tokens: output_tokens, total_tokens: total_tokens}
+    first
+    |> Usage.merge(second)
+    |> Usage.ensure_total_tokens()
   end
 
   defp apply_context_defaults(params, context) when is_map(params) do

--- a/lib/jido_ai/reasoning/chain_of_thought/strategy.ex
+++ b/lib/jido_ai/reasoning/chain_of_thought/strategy.ex
@@ -583,7 +583,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Strategy do
   end
 
   defp merge_usage(existing, incoming) do
-    Map.merge(existing || %{}, incoming || %{}, fn _k, left, right -> (left || 0) + (right || 0) end)
+    Jido.AI.Usage.merge(existing, incoming)
   end
 
   defp event_kind(event) do

--- a/lib/jido_ai/reasoning/react/state.ex
+++ b/lib/jido_ai/reasoning/react/state.ex
@@ -249,12 +249,7 @@ defmodule Jido.AI.Reasoning.ReAct.State do
   def merge_usage(%__MODULE__{} = state, nil), do: state
 
   def merge_usage(%__MODULE__{} = state, usage) when is_map(usage) do
-    merged =
-      Map.merge(state.usage, usage, fn _k, old, new ->
-        normalize_numeric(old) + normalize_numeric(new)
-      end)
-
-    %{state | usage: merged, updated_at_ms: now_ms()}
+    %{state | usage: Jido.AI.Usage.merge(state.usage, usage), updated_at_ms: now_ms()}
   end
 
   def merge_usage(%__MODULE__{} = state, _), do: state
@@ -323,18 +318,6 @@ defmodule Jido.AI.Reasoning.ReAct.State do
   end
 
   defp normalize_status(_), do: :error
-
-  defp normalize_numeric(value) when is_integer(value), do: value
-  defp normalize_numeric(value) when is_float(value), do: trunc(value)
-
-  defp normalize_numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {int, ""} -> int
-      _ -> 0
-    end
-  end
-
-  defp normalize_numeric(_), do: 0
 
   defp now_ms, do: System.system_time(:millisecond)
 end

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -1856,9 +1856,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   end
 
   defp merge_usage(existing, incoming) do
-    Map.merge(existing || %{}, incoming || %{}, fn _k, left, right ->
-      (left || 0) + (right || 0)
-    end)
+    Jido.AI.Usage.merge(existing, incoming)
   end
 
   defp event_kind(event) do

--- a/lib/jido_ai/turn.ex
+++ b/lib/jido_ai/turn.ex
@@ -12,7 +12,7 @@ defmodule Jido.AI.Turn do
   - Optional executed tool results
   """
 
-  alias Jido.AI.{Effects, Observe, ToolAdapter}
+  alias Jido.AI.{Effects, Observe, ToolAdapter, Usage}
   alias Jido.AI.Signal.Helpers, as: SignalHelpers
   alias Jido.Action.Error.TimeoutError
   alias Jido.Action.Tool, as: ActionTool
@@ -530,54 +530,10 @@ defmodule Jido.AI.Turn do
     }
   end
 
-  defp normalize_usage(nil), do: nil
-
-  defp normalize_usage(usage) when is_map(usage) do
-    usage
-    |> Enum.map(fn {key, value} -> {normalize_usage_key(key), normalize_usage_value(value)} end)
-    |> Map.new()
-  end
-
-  defp normalize_usage(_), do: nil
+  defp normalize_usage(usage), do: Usage.normalize(usage)
 
   defp normalize_metadata(%{} = metadata), do: metadata
   defp normalize_metadata(_), do: %{}
-
-  defp normalize_usage_key("input_tokens"), do: :input_tokens
-  defp normalize_usage_key("output_tokens"), do: :output_tokens
-  defp normalize_usage_key("total_tokens"), do: :total_tokens
-  defp normalize_usage_key("cache_creation_input_tokens"), do: :cache_creation_input_tokens
-  defp normalize_usage_key("cache_read_input_tokens"), do: :cache_read_input_tokens
-  defp normalize_usage_key(key) when is_binary(key), do: key
-  defp normalize_usage_key(key), do: key
-
-  defp normalize_usage_value(value) when is_integer(value), do: value
-  defp normalize_usage_value(value) when is_float(value), do: value
-  defp normalize_usage_value(value) when is_boolean(value), do: value
-  defp normalize_usage_value(nil), do: nil
-
-  defp normalize_usage_value(value) when is_map(value), do: normalize_usage(value)
-
-  defp normalize_usage_value(value) when is_list(value) do
-    Enum.map(value, &normalize_usage_value/1)
-  end
-
-  defp normalize_usage_value(value) when is_binary(value) do
-    trimmed = String.trim(value)
-
-    case Integer.parse(trimmed) do
-      {int, ""} ->
-        int
-
-      _ ->
-        case Float.parse(trimmed) do
-          {float, ""} -> float
-          _ -> value
-        end
-    end
-  end
-
-  defp normalize_usage_value(value), do: value
 
   defp execute_internal(module, tool_name, params, context, timeout, exec_opts) do
     schema = module.schema()

--- a/lib/jido_ai/turn.ex
+++ b/lib/jido_ai/turn.ex
@@ -553,21 +553,31 @@ defmodule Jido.AI.Turn do
 
   defp normalize_usage_value(value) when is_integer(value), do: value
   defp normalize_usage_value(value) when is_float(value), do: value
+  defp normalize_usage_value(value) when is_boolean(value), do: value
+  defp normalize_usage_value(nil), do: nil
+
+  defp normalize_usage_value(value) when is_map(value), do: normalize_usage(value)
+
+  defp normalize_usage_value(value) when is_list(value) do
+    Enum.map(value, &normalize_usage_value/1)
+  end
 
   defp normalize_usage_value(value) when is_binary(value) do
-    case Integer.parse(value) do
+    trimmed = String.trim(value)
+
+    case Integer.parse(trimmed) do
       {int, ""} ->
         int
 
       _ ->
-        case Float.parse(value) do
-          {float, _} -> float
-          :error -> 0
+        case Float.parse(trimmed) do
+          {float, ""} -> float
+          _ -> value
         end
     end
   end
 
-  defp normalize_usage_value(_), do: 0
+  defp normalize_usage_value(value), do: value
 
   defp execute_internal(module, tool_name, params, context, timeout, exec_opts) do
     schema = module.schema()

--- a/lib/jido_ai/usage.ex
+++ b/lib/jido_ai/usage.ex
@@ -1,0 +1,21 @@
+defmodule Jido.AI.Usage do
+  @moduledoc """
+  Helpers for merging provider usage metadata.
+  """
+
+  @doc """
+  Merges two usage maps while summing numeric counters and preserving provider metadata.
+  """
+  @spec merge(map() | nil, map() | nil) :: map()
+  def merge(existing, incoming) do
+    Map.merge(existing || %{}, incoming || %{}, fn _key, left, right ->
+      merge_value(left, right)
+    end)
+  end
+
+  defp merge_value(left, right) when is_number(left) and is_number(right), do: left + right
+  defp merge_value(left, right) when is_map(left) and is_map(right), do: merge(left, right)
+  defp merge_value(nil, right), do: right
+  defp merge_value(left, nil), do: left
+  defp merge_value(_left, right), do: right
+end

--- a/lib/jido_ai/usage.ex
+++ b/lib/jido_ai/usage.ex
@@ -6,16 +6,92 @@ defmodule Jido.AI.Usage do
   @doc """
   Merges two usage maps while summing numeric counters and preserving provider metadata.
   """
-  @spec merge(map() | nil, map() | nil) :: map()
+  @spec merge(term(), term()) :: map()
   def merge(existing, incoming) do
-    Map.merge(existing || %{}, incoming || %{}, fn _key, left, right ->
+    Map.merge(usage_map(existing), usage_map(incoming), fn _key, left, right ->
       merge_value(left, right)
     end)
   end
 
-  defp merge_value(left, right) when is_number(left) and is_number(right), do: left + right
-  defp merge_value(left, right) when is_map(left) and is_map(right), do: merge(left, right)
-  defp merge_value(nil, right), do: right
-  defp merge_value(left, nil), do: left
-  defp merge_value(_left, right), do: right
+  @doc """
+  Adds `:total_tokens` when input and output token counters are available.
+  """
+  @spec ensure_total_tokens(map()) :: map()
+  def ensure_total_tokens(%{} = usage) do
+    total_tokens = Map.get(usage, :total_tokens)
+
+    with false <- is_number(total_tokens),
+         {:ok, input_tokens} <- numeric_value(Map.get(usage, :input_tokens)),
+         {:ok, output_tokens} <- numeric_value(Map.get(usage, :output_tokens)) do
+      Map.put(usage, :total_tokens, input_tokens + output_tokens)
+    else
+      _ -> usage
+    end
+  end
+
+  defp usage_map(%{} = usage), do: normalize_usage_values(usage)
+  defp usage_map(_usage), do: %{}
+
+  defp merge_value(left, right) do
+    case {numeric_value(left), numeric_value(right)} do
+      {{:ok, left}, {:ok, right}} ->
+        left + right
+
+      _ ->
+        merge_metadata_value(left, right)
+    end
+  end
+
+  defp merge_metadata_value(left, right) when is_map(left) and is_map(right), do: merge(left, right)
+  defp merge_metadata_value(nil, right), do: right
+  defp merge_metadata_value(left, nil), do: left
+  defp merge_metadata_value(_left, right), do: right
+
+  defp normalize_usage_values(usage) do
+    Map.new(usage, fn {key, value} -> {key, normalize_usage_value(value)} end)
+  end
+
+  defp normalize_usage_value(value) when is_map(value), do: normalize_usage_values(value)
+
+  defp normalize_usage_value(value) when is_list(value) do
+    Enum.map(value, &normalize_usage_value/1)
+  end
+
+  defp normalize_usage_value(value) do
+    case numeric_value(value) do
+      {:ok, number} -> number
+      :error -> value
+    end
+  end
+
+  defp numeric_value(value) when is_integer(value) or is_float(value), do: {:ok, value}
+
+  defp numeric_value(value) when is_binary(value) do
+    value = String.trim(value)
+
+    case parse_integer(value) do
+      {:ok, _int} = parsed -> parsed
+      :error -> parse_float(value)
+    end
+  end
+
+  defp numeric_value(_value), do: :error
+
+  defp parse_integer(""), do: :error
+
+  defp parse_integer(value) do
+    case Integer.parse(value) do
+      {int, ""} -> {:ok, int}
+      _ -> :error
+    end
+  end
+
+  defp parse_float(""), do: :error
+
+  defp parse_float(value) do
+    case Float.parse(value) do
+      {float, ""} -> {:ok, float}
+      _ -> :error
+    end
+  end
 end

--- a/lib/jido_ai/usage.ex
+++ b/lib/jido_ai/usage.ex
@@ -3,13 +3,63 @@ defmodule Jido.AI.Usage do
   Helpers for merging provider usage metadata.
   """
 
+  @numeric_usage_keys MapSet.new([
+                        "accepted_prediction_tokens",
+                        "attempts",
+                        "audio_tokens",
+                        "cache_creation_input_tokens",
+                        "cache_read_input_tokens",
+                        "cached_input_tokens",
+                        "calls",
+                        "completion_tokens",
+                        "cost",
+                        "duration_ms",
+                        "images",
+                        "input_audio_tokens",
+                        "input_cost",
+                        "input_tokens",
+                        "output_audio_tokens",
+                        "output_cost",
+                        "output_tokens",
+                        "prompt_tokens",
+                        "reasoning_tokens",
+                        "rejected_prediction_tokens",
+                        "requests",
+                        "retries",
+                        "total",
+                        "total_cost",
+                        "total_tokens"
+                      ])
+
+  @numeric_usage_suffixes [
+    "_cost",
+    "_count",
+    "_duration_ms",
+    "_tokens"
+  ]
+
+  @doc """
+  Normalizes common usage counter keys and numeric counter values.
+  """
+  @spec normalize(term()) :: map() | nil
+  def normalize(nil), do: nil
+
+  def normalize(%{} = usage) do
+    Map.new(usage, fn {key, value} ->
+      key = normalize_usage_key(key)
+      {key, normalize_usage_value(key, value)}
+    end)
+  end
+
+  def normalize(_usage), do: nil
+
   @doc """
   Merges two usage maps while summing numeric counters and preserving provider metadata.
   """
   @spec merge(term(), term()) :: map()
   def merge(existing, incoming) do
-    Map.merge(usage_map(existing), usage_map(incoming), fn _key, left, right ->
-      merge_value(left, right)
+    Map.merge(usage_map(existing), usage_map(incoming), fn key, left, right ->
+      merge_value(key, left, right)
     end)
   end
 
@@ -29,16 +79,19 @@ defmodule Jido.AI.Usage do
     end
   end
 
-  defp usage_map(%{} = usage), do: normalize_usage_values(usage)
-  defp usage_map(_usage), do: %{}
+  defp usage_map(usage), do: normalize(usage) || %{}
 
-  defp merge_value(left, right) do
-    case {numeric_value(left), numeric_value(right)} do
-      {{:ok, left}, {:ok, right}} ->
-        left + right
+  defp merge_value(key, left, right) do
+    if numeric_usage_key?(key) do
+      case {numeric_value(left), numeric_value(right)} do
+        {{:ok, left}, {:ok, right}} ->
+          left + right
 
-      _ ->
-        merge_metadata_value(left, right)
+        _ ->
+          merge_metadata_value(left, right)
+      end
+    else
+      merge_metadata_value(left, right)
     end
   end
 
@@ -47,22 +100,41 @@ defmodule Jido.AI.Usage do
   defp merge_metadata_value(left, nil), do: left
   defp merge_metadata_value(_left, right), do: right
 
-  defp normalize_usage_values(usage) do
-    Map.new(usage, fn {key, value} -> {key, normalize_usage_value(value)} end)
+  defp normalize_usage_key("input_tokens"), do: :input_tokens
+  defp normalize_usage_key("output_tokens"), do: :output_tokens
+  defp normalize_usage_key("total_tokens"), do: :total_tokens
+  defp normalize_usage_key("cache_creation_input_tokens"), do: :cache_creation_input_tokens
+  defp normalize_usage_key("cache_read_input_tokens"), do: :cache_read_input_tokens
+  defp normalize_usage_key(key), do: key
+
+  defp normalize_usage_value(_key, value) when is_map(value), do: normalize(value)
+
+  defp normalize_usage_value(_key, value) when is_list(value) do
+    Enum.map(value, fn
+      %{} = item -> normalize(item)
+      item -> item
+    end)
   end
 
-  defp normalize_usage_value(value) when is_map(value), do: normalize_usage_values(value)
-
-  defp normalize_usage_value(value) when is_list(value) do
-    Enum.map(value, &normalize_usage_value/1)
-  end
-
-  defp normalize_usage_value(value) do
-    case numeric_value(value) do
-      {:ok, number} -> number
-      :error -> value
+  defp normalize_usage_value(key, value) do
+    if numeric_usage_key?(key) do
+      case numeric_value(value) do
+        {:ok, number} -> number
+        :error -> value
+      end
+    else
+      value
     end
   end
+
+  defp numeric_usage_key?(key) when is_atom(key), do: key |> Atom.to_string() |> numeric_usage_key?()
+
+  defp numeric_usage_key?(key) when is_binary(key) do
+    MapSet.member?(@numeric_usage_keys, key) or
+      Enum.any?(@numeric_usage_suffixes, &String.ends_with?(key, &1))
+  end
+
+  defp numeric_usage_key?(_key), do: false
 
   defp numeric_value(value) when is_integer(value) or is_float(value), do: {:ok, value}
 

--- a/test/jido_ai/skills/tool_calling/actions/call_with_tools_test.exs
+++ b/test/jido_ai/skills/tool_calling/actions/call_with_tools_test.exs
@@ -216,6 +216,75 @@ defmodule Jido.AI.Actions.ToolCalling.CallWithToolsTest do
       assert result.usage.total_tokens > 0
     end
 
+    test "merges nested provider usage across auto_execute turns" do
+      call_key = {__MODULE__, :nested_usage_call_count, self()}
+      on_exit(fn -> :persistent_term.erase(call_key) end)
+
+      Mimic.stub(ReqLLM.Generation, :generate_text, fn model, _messages, _opts ->
+        count = :persistent_term.get(call_key, 0) + 1
+        :persistent_term.put(call_key, count)
+
+        case count do
+          1 ->
+            {:ok,
+             %{
+               message: %{
+                 content: "",
+                 tool_calls: [
+                   %{
+                     id: "tc_1",
+                     name: "calculator",
+                     arguments: %{"operation" => "add", "a" => 5, "b" => 3}
+                   }
+                 ]
+               },
+               finish_reason: :tool_calls,
+               usage: %{
+                 input_tokens: 10,
+                 output_tokens: 8,
+                 total_cost: 0.001,
+                 cost: %{total: 0.001, line_items: [%{id: "first"}]}
+               },
+               model: model
+             }}
+
+          2 ->
+            {:ok,
+             %{
+               message: %{content: "Tool execution complete: 8", tool_calls: nil},
+               finish_reason: :stop,
+               usage: %{
+                 input_tokens: 12,
+                 output_tokens: 6,
+                 total_cost: 0.002,
+                 cost: %{total: 0.002, line_items: [%{id: "second"}]}
+               },
+               model: model
+             }}
+        end
+      end)
+
+      params = %{
+        prompt: "Calculate 5 + 3",
+        tools: ["calculator"],
+        auto_execute: true
+      }
+
+      context = %{
+        tools: %{TestCalculator.name() => TestCalculator}
+      }
+
+      assert {:ok, result} = CallWithTools.run(params, context)
+
+      assert result.usage == %{
+               input_tokens: 22,
+               output_tokens: 14,
+               total_tokens: 36,
+               total_cost: 0.003,
+               cost: %{total: 0.003, line_items: [%{id: "second"}]}
+             }
+    end
+
     test "preserves OpenAI Responses response_id across auto_execute turns" do
       test_pid = self()
 

--- a/test/jido_ai/strategy/chain_of_thought_test.exs
+++ b/test/jido_ai/strategy/chain_of_thought_test.exs
@@ -200,6 +200,58 @@ defmodule Jido.AI.Reasoning.ChainOfThought.StrategyTest do
       assert state[:cot_worker_status] == :ready
     end
 
+    test "llm_completed worker events merge nested provider usage without crashing" do
+      agent = create_agent()
+
+      usage_1 = %{
+        input_tokens: 10,
+        output_tokens: 5,
+        total_cost: 0.001,
+        add_reasoning_to_cost: false,
+        cost: %{total: 0.001, input_cost: 0.0008, line_items: [%{id: "first"}]},
+        tool_usage: %{calls: 1}
+      }
+
+      usage_2 = %{
+        input_tokens: 7,
+        output_tokens: 3,
+        total_cost: 0.002,
+        add_reasoning_to_cost: true,
+        cost: %{total: 0.002, input_cost: 0.0015, line_items: [%{id: "second"}]},
+        tool_usage: %{calls: 2}
+      }
+
+      events = [
+        worker_event(:request_started, "req_cot_usage", 1, %{query: "Compute"}),
+        worker_event(:llm_completed, "req_cot_usage", 2, %{
+          call_id: "cot_call_req_cot_usage_1",
+          text: "Draft 1",
+          usage: usage_1
+        }),
+        worker_event(:llm_completed, "req_cot_usage", 3, %{
+          call_id: "cot_call_req_cot_usage_2",
+          text: "Draft 2",
+          usage: usage_2
+        })
+      ]
+
+      {agent, []} =
+        Enum.reduce(events, {agent, []}, fn event, {acc, _} ->
+          ChainOfThought.cmd(acc, [instruction(:cot_worker_event, %{request_id: "req_cot_usage", event: event})], %{})
+        end)
+
+      state = StratState.get(agent, %{})
+
+      assert state[:usage] == %{
+               input_tokens: 17,
+               output_tokens: 8,
+               total_cost: 0.003,
+               add_reasoning_to_cost: true,
+               cost: %{total: 0.003, input_cost: 0.0023, line_items: [%{id: "second"}]},
+               tool_usage: %{calls: 3}
+             }
+    end
+
     test "propagates runtime ordering metadata to LLMDelta signals" do
       agent = create_agent()
       request_id = "req_cot_delta_meta"

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -792,6 +792,70 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
       assert state.pending_input_server == nil
     end
 
+    test "llm_completed events merge nested provider usage without crashing" do
+      agent = create_agent(tools: [TestCalculator])
+
+      {agent, [_spawn]} =
+        ReAct.cmd(
+          agent,
+          [instruction(ReAct.start_action(), %{query: "q", request_id: "req_usage"})],
+          %{}
+        )
+
+      usage_1 = %{
+        input_tokens: 10,
+        output_tokens: 5,
+        total_cost: 0.001,
+        input_includes_cached: false,
+        cost: %{total: 0.001, input_cost: 0.0008, line_items: [%{id: "first"}]},
+        image_usage: %{images: 1}
+      }
+
+      usage_2 = %{
+        input_tokens: 7,
+        output_tokens: 3,
+        total_cost: 0.002,
+        input_includes_cached: true,
+        cost: %{total: 0.002, input_cost: 0.0015, line_items: [%{id: "second"}]},
+        image_usage: %{images: 2}
+      }
+
+      events = [
+        runtime_event(:llm_completed, "req_usage", 1, %{
+          turn_type: :final_answer,
+          text: "draft one",
+          thinking_content: nil,
+          reasoning_details: [],
+          tool_calls: [],
+          usage: usage_1
+        }),
+        runtime_event(:llm_completed, "req_usage", 2, %{
+          turn_type: :final_answer,
+          text: "draft two",
+          thinking_content: nil,
+          reasoning_details: [],
+          tool_calls: [],
+          usage: usage_2
+        })
+      ]
+
+      {agent, []} =
+        Enum.reduce(events, {agent, []}, fn event, {acc, _} ->
+          ReAct.cmd(acc, [instruction(:ai_react_worker_event, %{request_id: "req_usage", event: event})], %{})
+        end)
+
+      state = StratState.get(agent, %{})
+
+      assert state.usage == %{
+               input_tokens: 17,
+               output_tokens: 8,
+               total_cost: 0.003,
+               input_includes_cached: true,
+               cost: %{total: 0.003, input_cost: 0.0023, line_items: [%{id: "second"}]},
+               image_usage: %{images: 3}
+             }
+    end
+
     test "completed request history is reused for the next turn" do
       agent = create_agent(tools: [TestCalculator])
       reasoning_details = [%{signature: "sig_123", provider: :openai}]

--- a/test/jido_ai/turn_test.exs
+++ b/test/jido_ai/turn_test.exs
@@ -90,6 +90,36 @@ defmodule Jido.AI.TurnTest do
       assert Turn.needs_tools?(turn)
     end
 
+    test "preserves nested provider usage metadata" do
+      response = %{
+        message: %{content: "hello", tool_calls: nil},
+        finish_reason: :stop,
+        usage: %{
+          input_tokens: "10",
+          output_tokens: "5",
+          input_includes_cached: false,
+          cost: %{
+            total: "0.003",
+            currency: "USD",
+            line_items: [%{id: "prompt", cost: "0.001"}]
+          }
+        }
+      }
+
+      turn = Turn.from_response(response)
+
+      assert turn.usage == %{
+               input_tokens: 10,
+               output_tokens: 5,
+               input_includes_cached: false,
+               cost: %{
+                 total: 0.003,
+                 currency: "USD",
+                 line_items: [%{id: "prompt", cost: 0.001}]
+               }
+             }
+    end
+
     test "uses ReqLLM.Response classification for canonical responses" do
       reasoning_details = [
         %ReqLLM.Message.ReasoningDetails{

--- a/test/jido_ai/turn_test.exs
+++ b/test/jido_ai/turn_test.exs
@@ -101,7 +101,7 @@ defmodule Jido.AI.TurnTest do
           cost: %{
             total: "0.003",
             currency: "USD",
-            line_items: [%{id: "prompt", cost: "0.001"}]
+            line_items: [%{id: "001", cost: "0.001"}]
           }
         }
       }
@@ -115,7 +115,7 @@ defmodule Jido.AI.TurnTest do
                cost: %{
                  total: 0.003,
                  currency: "USD",
-                 line_items: [%{id: "prompt", cost: 0.001}]
+                 line_items: [%{id: "001", cost: 0.001}]
                }
              }
     end

--- a/test/jido_ai/usage_test.exs
+++ b/test/jido_ai/usage_test.exs
@@ -1,0 +1,46 @@
+defmodule Jido.AI.UsageTest do
+  use ExUnit.Case, async: true
+
+  describe "merge/2" do
+    test "adds numeric usage and preserves nested non-numeric provider metadata" do
+      first = %{
+        input_tokens: 10,
+        output_tokens: 5,
+        total_cost: 0.001,
+        add_reasoning_to_cost: false,
+        cost: %{
+          total: 0.001,
+          input_cost: 0.0008,
+          line_items: [%{id: "first"}]
+        },
+        tool_usage: %{calls: 1}
+      }
+
+      second = %{
+        input_tokens: 7,
+        output_tokens: 3,
+        total_cost: 0.002,
+        add_reasoning_to_cost: true,
+        cost: %{
+          total: 0.002,
+          input_cost: 0.0015,
+          line_items: [%{id: "second"}]
+        },
+        tool_usage: %{calls: 2}
+      }
+
+      assert Jido.AI.Usage.merge(first, second) == %{
+               input_tokens: 17,
+               output_tokens: 8,
+               total_cost: 0.003,
+               add_reasoning_to_cost: true,
+               cost: %{
+                 total: 0.003,
+                 input_cost: 0.0023,
+                 line_items: [%{id: "second"}]
+               },
+               tool_usage: %{calls: 3}
+             }
+    end
+  end
+end

--- a/test/jido_ai/usage_test.exs
+++ b/test/jido_ai/usage_test.exs
@@ -58,6 +58,22 @@ defmodule Jido.AI.UsageTest do
       assert Jido.AI.Usage.merge(%{input_tokens: 3}, :bad_usage) == %{input_tokens: 3}
     end
 
+    test "does not coerce numeric-looking provider metadata identifiers" do
+      assert Jido.AI.Usage.merge(
+               %{
+                 cost: %{line_items: [%{id: "001", cost: "0.001"}]},
+                 provider_meta: %{request_id: "001", shard: "03"}
+               },
+               %{
+                 cost: %{line_items: [%{id: "002", cost: "0.002"}]},
+                 provider_meta: %{request_id: "002"}
+               }
+             ) == %{
+               cost: %{line_items: [%{id: "002", cost: 0.002}]},
+               provider_meta: %{request_id: "002", shard: "03"}
+             }
+    end
+
     test "derives total tokens when input and output counters are present" do
       assert Jido.AI.Usage.ensure_total_tokens(%{input_tokens: 2, output_tokens: "3"}) == %{
                input_tokens: 2,

--- a/test/jido_ai/usage_test.exs
+++ b/test/jido_ai/usage_test.exs
@@ -42,5 +42,34 @@ defmodule Jido.AI.UsageTest do
                tool_usage: %{calls: 3}
              }
     end
+
+    test "sums numeric strings and ignores malformed top-level usage inputs" do
+      assert Jido.AI.Usage.merge(%{input_tokens: "10", cost: %{total: "0.001"}}, %{
+               input_tokens: 7,
+               cost: %{total: "0.002"},
+               provider: "anthropic"
+             }) == %{
+               input_tokens: 17,
+               cost: %{total: 0.003},
+               provider: "anthropic"
+             }
+
+      assert Jido.AI.Usage.merge(:bad_usage, %{input_tokens: "3"}) == %{input_tokens: 3}
+      assert Jido.AI.Usage.merge(%{input_tokens: 3}, :bad_usage) == %{input_tokens: 3}
+    end
+
+    test "derives total tokens when input and output counters are present" do
+      assert Jido.AI.Usage.ensure_total_tokens(%{input_tokens: 2, output_tokens: "3"}) == %{
+               input_tokens: 2,
+               output_tokens: "3",
+               total_tokens: 5
+             }
+
+      assert Jido.AI.Usage.ensure_total_tokens(%{input_tokens: 2, output_tokens: 3, total_tokens: 99}) == %{
+               input_tokens: 2,
+               output_tokens: 3,
+               total_tokens: 99
+             }
+    end
   end
 end


### PR DESCRIPTION
## Summary
- add a shared usage merge helper that sums numeric counters and preserves provider metadata
- use it for CoT/CoD worker usage accumulation and ReAct usage accumulation
- add regressions for nested ReqLLM cost maps, booleans, and nested usage maps

Closes #294

## Validation
- `mix test test/jido_ai/usage_test.exs test/jido_ai/strategy/chain_of_thought_test.exs test/jido_ai/strategy/react_test.exs test/jido_ai/react/public_api_test.exs`
- `mix precommit`