### PR TITLE
feat(agent): support uploaded file references

### DIFF
--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -470,7 +470,7 @@ defmodule Jido.AI.Agent do
           requests: Zoi.map() |> Zoi.default(%{}),
           last_request_id: Zoi.string() |> Zoi.optional(),
           # Backward compatibility fields (convenience pointers to most recent)
-          last_query: Zoi.string() |> Zoi.default(""),
+          last_query: Jido.AI.Query.schema() |> Zoi.default(""),
           last_answer: Zoi.string() |> Zoi.default(""),
           completed: Zoi.boolean() |> Zoi.default(false)
         })
@@ -509,6 +509,8 @@ defmodule Jido.AI.Agent do
         `:stream_receive_timeout_ms` is accepted as a compatibility alias.
       - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
       - `:llm_opts` - Per-request ReqLLM generation options forwarded to ReAct runtime
+      - `:file_id` / `:file_ids` / `:file_references` - Uploaded file references appended
+        to the user query as ReqLLM content parts when supported by the ReqLLM version
       - `:output` - `:raw` to bypass structured output or a request-scoped output config
       - `:stream_to` - Optional request-scoped runtime event sink, currently `{:pid, pid}`
       - `:timeout` - Timeout for the underlying cast (default: no timeout)
@@ -609,6 +611,8 @@ defmodule Jido.AI.Agent do
         `:stream_receive_timeout_ms` is accepted as a compatibility alias.
       - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
       - `:llm_opts` - Per-request ReqLLM generation options forwarded to ReAct runtime
+      - `:file_id` / `:file_ids` / `:file_references` - Uploaded file references appended
+        to the user query as ReqLLM content parts when supported by the ReqLLM version
       - `:output` - `:raw` to bypass structured output or a request-scoped output config
       - `:timeout` - How long to wait in milliseconds (default: 30_000)
 

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -509,8 +509,8 @@ defmodule Jido.AI.Agent do
         `:stream_receive_timeout_ms` is accepted as a compatibility alias.
       - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
       - `:llm_opts` - Per-request ReqLLM generation options forwarded to ReAct runtime
-      - `:file_id` / `:file_ids` / `:file_references` - Uploaded file references appended
-        to the user query as ReqLLM content parts when supported by the ReqLLM version
+      - `:file_id` / `:file_ids` / `:file_reference` / `:file_references` - Uploaded
+        file references appended to the user query as ReqLLM content parts when supported by the ReqLLM version
       - `:output` - `:raw` to bypass structured output or a request-scoped output config
       - `:stream_to` - Optional request-scoped runtime event sink, currently `{:pid, pid}`
       - `:timeout` - Timeout for the underlying cast (default: no timeout)
@@ -611,8 +611,8 @@ defmodule Jido.AI.Agent do
         `:stream_receive_timeout_ms` is accepted as a compatibility alias.
       - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
       - `:llm_opts` - Per-request ReqLLM generation options forwarded to ReAct runtime
-      - `:file_id` / `:file_ids` / `:file_references` - Uploaded file references appended
-        to the user query as ReqLLM content parts when supported by the ReqLLM version
+      - `:file_id` / `:file_ids` / `:file_reference` / `:file_references` - Uploaded
+        file references appended to the user query as ReqLLM content parts when supported by the ReqLLM version
       - `:output` - `:raw` to bypass structured output or a request-scoped output config
       - `:timeout` - How long to wait in milliseconds (default: 30_000)
 

--- a/lib/jido_ai/query.ex
+++ b/lib/jido_ai/query.ex
@@ -215,11 +215,12 @@ defmodule Jido.AI.Query do
 
   defp normalize_file_reference(%{} = reference) do
     file_id = Map.get(reference, :file_id) || Map.get(reference, "file_id")
-    source = Map.get(reference, :source) || Map.get(reference, "source")
+    source = reference_source(reference)
 
     file_id =
       file_id ||
-        if(is_map(source), do: Map.get(source, :file_id) || Map.get(source, "file_id"))
+        Map.get(source, :file_id) ||
+        Map.get(source, "file_id")
 
     with {:ok, file_id} <- normalize_file_id(file_id) do
       {:ok,
@@ -243,10 +244,19 @@ defmodule Jido.AI.Query do
 
   defp normalize_file_id(_file_id), do: {:error, {:invalid_file_reference, :missing_file_id}}
 
+  defp reference_source(reference) do
+    case Map.get(reference, :source) || Map.get(reference, "source") do
+      %{} = source -> source
+      source when is_list(source) -> if(Keyword.keyword?(source), do: Map.new(source), else: %{})
+      _source -> %{}
+    end
+  end
+
   defp reference_value(reference, source, key) do
     Map.get(reference, key) ||
       Map.get(reference, Atom.to_string(key)) ||
-      if(is_map(source), do: Map.get(source, key) || Map.get(source, Atom.to_string(key)))
+      Map.get(source, key) ||
+      Map.get(source, Atom.to_string(key))
   end
 
   defp reference_metadata(reference) do

--- a/lib/jido_ai/query.ex
+++ b/lib/jido_ai/query.ex
@@ -3,7 +3,10 @@ defmodule Jido.AI.Query do
 
   alias ReqLLM.Message.ContentPart
 
-  @type t :: String.t() | [ContentPart.t()]
+  @type t :: String.t() | [ContentPart.t() | map()]
+  @typedoc "Uploaded file reference accepted by generated request helpers."
+  @type file_reference :: String.t() | keyword() | map()
+  @file_metadata_keys [:title, :context, :citations]
 
   @doc "Returns a Zoi schema that accepts text or a non-empty list of ReqLLM content parts."
   @spec schema(keyword()) :: Zoi.schema()
@@ -37,9 +40,37 @@ defmodule Jido.AI.Query do
   @spec content_part?(term()) :: boolean()
   def content_part?(%ContentPart{}), do: true
 
-  def content_part?(%{type: type}) when type in [:text, :image, :image_url, :thinking], do: true
-  def content_part?(%{"type" => type}) when type in ["text", "image", "image_url", "thinking"], do: true
+  def content_part?(%{type: type}) when type in [:text, :image, :image_url, :video_url, :file, :thinking], do: true
+
+  def content_part?(%{"type" => type}) when type in ["text", "image", "image_url", "video_url", "file", "thinking"],
+    do: true
+
   def content_part?(_part), do: false
+
+  @doc """
+  Appends uploaded file references from request options to a text or content-part query.
+
+  Supports `:file_id`, `:file_ids`, and `:file_references`. File references can be
+  strings, keyword lists, or maps with `:file_id`/`"file_id"` plus optional
+  `:media_type`, `:filename`, `:metadata`, `:title`, `:context`, or `:citations`.
+
+  Returns an explicit unsupported error when the active ReqLLM version does not
+  expose `ReqLLM.Message.ContentPart.file_id/3`.
+  """
+  @spec attach_file_references(t(), keyword()) :: {:ok, t()} | {:error, term()}
+  def attach_file_references(query, opts) when is_list(opts) do
+    case file_references_from_opts(opts) do
+      [] ->
+        {:ok, query}
+
+      references ->
+        with {:ok, references} <- normalize_file_references(references),
+             :ok <- ensure_file_reference_support() do
+          file_parts = build_file_reference_parts(references)
+          {:ok, query_to_parts(query) ++ file_parts}
+        end
+    end
+  end
 
   @doc "Builds a text summary for event metadata without discarding the original query."
   @spec summarize(t()) :: String.t()
@@ -49,11 +80,167 @@ defmodule Jido.AI.Query do
     Enum.map_join(parts, "\n", fn
       %ContentPart{type: :text, text: text} when is_binary(text) -> text
       %ContentPart{type: type} when type in [:image, :image_url] -> "[Image]"
+      %ContentPart{type: :file, filename: filename} when is_binary(filename) -> "[File: #{filename}]"
+      %ContentPart{type: :file} -> "[File]"
       %{type: type, text: text} when type in [:text, "text"] and is_binary(text) -> text
       %{type: type} when type in [:image, :image_url, "image", "image_url"] -> "[Image]"
+      %{type: type, filename: filename} when type in [:file, "file"] and is_binary(filename) -> "[File: #{filename}]"
+      %{type: type} when type in [:file, "file"] -> "[File]"
       %{"type" => type, "text" => text} when type == "text" and is_binary(text) -> text
       %{"type" => type} when type in ["image", "image_url"] -> "[Image]"
+      %{"type" => "file", "filename" => filename} when is_binary(filename) -> "[File: #{filename}]"
+      %{"type" => "file"} -> "[File]"
       part -> inspect(part)
     end)
   end
+
+  defp file_references_from_opts(opts) do
+    []
+    |> maybe_add_reference(Keyword.get(opts, :file_id))
+    |> maybe_add_references(Keyword.get(opts, :file_ids))
+    |> maybe_add_references(Keyword.get(opts, :file_references))
+  end
+
+  defp maybe_add_reference(acc, nil), do: acc
+  defp maybe_add_reference(acc, ""), do: acc
+  defp maybe_add_reference(acc, reference), do: acc ++ [reference]
+
+  defp maybe_add_references(acc, nil), do: acc
+  defp maybe_add_references(acc, []), do: acc
+
+  defp maybe_add_references(acc, references) when is_list(references) do
+    if keyword_reference?(references) do
+      acc ++ [references]
+    else
+      acc ++ references
+    end
+  end
+
+  defp maybe_add_references(acc, reference), do: maybe_add_reference(acc, reference)
+
+  defp keyword_reference?(value) when is_list(value) do
+    Keyword.keyword?(value) and
+      Enum.any?(
+        [:file_id, :source, :media_type, :metadata, :filename, :title, :context, :citations],
+        &Keyword.has_key?(value, &1)
+      )
+  end
+
+  defp keyword_reference?(_value), do: false
+
+  defp ensure_file_reference_support do
+    if function_exported?(ContentPart, :file_id, 3) do
+      :ok
+    else
+      {:error, {:unsupported_content_part_file_id, "ReqLLM.Message.ContentPart.file_id/3 is required"}}
+    end
+  end
+
+  defp build_file_reference_parts(references) do
+    Enum.map(references, &build_file_reference_part/1)
+  end
+
+  defp build_file_reference_part(attrs) do
+    file_id = attrs.file_id
+    media_type = attrs.media_type || "application/pdf"
+    metadata = attrs.metadata || %{}
+
+    part = apply(ContentPart, :file_id, [file_id, media_type, metadata])
+
+    maybe_put_filename(part, attrs.filename)
+  end
+
+  defp normalize_file_references(references) do
+    references
+    |> Enum.reduce_while({:ok, []}, fn reference, {:ok, acc} ->
+      case normalize_file_reference(reference) do
+        {:ok, reference} -> {:cont, {:ok, [reference | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, references} -> {:ok, Enum.reverse(references)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp normalize_file_reference(file_id) when is_binary(file_id) do
+    case String.trim(file_id) do
+      "" -> {:error, {:invalid_file_reference, :missing_file_id}}
+      file_id -> {:ok, %{file_id: file_id, media_type: nil, metadata: %{}, filename: nil}}
+    end
+  end
+
+  defp normalize_file_reference(reference) when is_list(reference) do
+    if Keyword.keyword?(reference) do
+      reference
+      |> Map.new()
+      |> normalize_file_reference()
+    else
+      {:error, {:invalid_file_reference, :missing_file_id}}
+    end
+  end
+
+  defp normalize_file_reference(%{} = reference) do
+    file_id = Map.get(reference, :file_id) || Map.get(reference, "file_id")
+    source = Map.get(reference, :source) || Map.get(reference, "source")
+
+    file_id =
+      file_id ||
+        if(is_map(source), do: Map.get(source, :file_id) || Map.get(source, "file_id"))
+
+    with {:ok, file_id} <- normalize_file_id(file_id) do
+      {:ok,
+       %{
+         file_id: file_id,
+         media_type: reference_value(reference, source, :media_type),
+         metadata: reference_metadata(reference),
+         filename: reference_value(reference, source, :filename)
+       }}
+    end
+  end
+
+  defp normalize_file_reference(_reference), do: {:error, {:invalid_file_reference, :missing_file_id}}
+
+  defp normalize_file_id(file_id) when is_binary(file_id) do
+    case String.trim(file_id) do
+      "" -> {:error, {:invalid_file_reference, :missing_file_id}}
+      file_id -> {:ok, file_id}
+    end
+  end
+
+  defp normalize_file_id(_file_id), do: {:error, {:invalid_file_reference, :missing_file_id}}
+
+  defp reference_value(reference, source, key) do
+    Map.get(reference, key) ||
+      Map.get(reference, Atom.to_string(key)) ||
+      if(is_map(source), do: Map.get(source, key) || Map.get(source, Atom.to_string(key)))
+  end
+
+  defp reference_metadata(reference) do
+    metadata =
+      case Map.get(reference, :metadata) || Map.get(reference, "metadata") do
+        metadata when is_map(metadata) -> metadata
+        _metadata -> %{}
+      end
+
+    Enum.reduce(@file_metadata_keys, metadata, fn key, acc ->
+      value = Map.get(reference, key) || Map.get(reference, Atom.to_string(key))
+
+      if is_nil(value) do
+        acc
+      else
+        Map.put_new(acc, key, value)
+      end
+    end)
+  end
+
+  defp query_to_parts(query) when is_binary(query), do: [ContentPart.text(query)]
+  defp query_to_parts(query) when is_list(query), do: query
+
+  defp maybe_put_filename(part, filename) when is_binary(filename) and filename != "" do
+    %{part | filename: filename}
+  end
+
+  defp maybe_put_filename(part, _filename), do: part
 end

--- a/lib/jido_ai/query.ex
+++ b/lib/jido_ai/query.ex
@@ -6,6 +6,12 @@ defmodule Jido.AI.Query do
   @type t :: String.t() | [ContentPart.t() | map()]
   @typedoc "Uploaded file reference accepted by generated request helpers."
   @type file_reference :: String.t() | keyword() | map()
+  @content_part_types [:text, :image, :image_url, :video_url, :file, :file_id, :document, :thinking]
+  @content_part_type_strings Enum.map(@content_part_types, &Atom.to_string/1)
+  @content_part_type_values @content_part_types ++ @content_part_type_strings
+  @file_part_types [:file, :file_id, :document]
+  @file_part_type_strings Enum.map(@file_part_types, &Atom.to_string/1)
+  @file_part_type_values @file_part_types ++ @file_part_type_strings
   @file_metadata_keys [:title, :context, :citations]
 
   @doc "Returns a Zoi schema that accepts text or a non-empty list of ReqLLM content parts."
@@ -40,19 +46,19 @@ defmodule Jido.AI.Query do
   @spec content_part?(term()) :: boolean()
   def content_part?(%ContentPart{}), do: true
 
-  def content_part?(%{type: type}) when type in [:text, :image, :image_url, :video_url, :file, :thinking], do: true
+  def content_part?(%{type: type}) when type in @content_part_type_values, do: true
 
-  def content_part?(%{"type" => type}) when type in ["text", "image", "image_url", "video_url", "file", "thinking"],
-    do: true
+  def content_part?(%{"type" => type}) when type in @content_part_type_strings, do: true
 
   def content_part?(_part), do: false
 
   @doc """
   Appends uploaded file references from request options to a text or content-part query.
 
-  Supports `:file_id`, `:file_ids`, and `:file_references`. File references can be
-  strings, keyword lists, or maps with `:file_id`/`"file_id"` plus optional
-  `:media_type`, `:filename`, `:metadata`, `:title`, `:context`, or `:citations`.
+  Supports `:file_id`, `:file_ids`, `:file_reference`, and `:file_references`.
+  File references can be strings, keyword lists, or maps with `:file_id`/`"file_id"`
+  plus optional `:media_type`, `:filename`, `:metadata`, `:title`, `:context`, or
+  `:citations`.
 
   Returns an explicit unsupported error when the active ReqLLM version does not
   expose `ReqLLM.Message.ContentPart.file_id/3`.
@@ -78,19 +84,44 @@ defmodule Jido.AI.Query do
 
   def summarize(parts) when is_list(parts) do
     Enum.map_join(parts, "\n", fn
-      %ContentPart{type: :text, text: text} when is_binary(text) -> text
-      %ContentPart{type: type} when type in [:image, :image_url] -> "[Image]"
-      %ContentPart{type: :file, filename: filename} when is_binary(filename) -> "[File: #{filename}]"
-      %ContentPart{type: :file} -> "[File]"
-      %{type: type, text: text} when type in [:text, "text"] and is_binary(text) -> text
-      %{type: type} when type in [:image, :image_url, "image", "image_url"] -> "[Image]"
-      %{type: type, filename: filename} when type in [:file, "file"] and is_binary(filename) -> "[File: #{filename}]"
-      %{type: type} when type in [:file, "file"] -> "[File]"
-      %{"type" => type, "text" => text} when type == "text" and is_binary(text) -> text
-      %{"type" => type} when type in ["image", "image_url"] -> "[Image]"
-      %{"type" => "file", "filename" => filename} when is_binary(filename) -> "[File: #{filename}]"
-      %{"type" => "file"} -> "[File]"
-      part -> inspect(part)
+      %ContentPart{type: :text, text: text} when is_binary(text) ->
+        text
+
+      %ContentPart{type: type} when type in [:image, :image_url] ->
+        "[Image]"
+
+      %ContentPart{type: :file, filename: filename} when is_binary(filename) ->
+        "[File: #{filename}]"
+
+      %ContentPart{type: :file} ->
+        "[File]"
+
+      %{type: type, text: text} when type in [:text, "text"] and is_binary(text) ->
+        text
+
+      %{type: type} when type in [:image, :image_url, "image", "image_url"] ->
+        "[Image]"
+
+      %{type: type, filename: filename} when type in @file_part_type_values and is_binary(filename) ->
+        "[File: #{filename}]"
+
+      %{type: type} when type in @file_part_type_values ->
+        "[File]"
+
+      %{"type" => type, "text" => text} when type == "text" and is_binary(text) ->
+        text
+
+      %{"type" => type} when type in ["image", "image_url"] ->
+        "[Image]"
+
+      %{"type" => type, "filename" => filename} when type in @file_part_type_strings and is_binary(filename) ->
+        "[File: #{filename}]"
+
+      %{"type" => type} when type in @file_part_type_strings ->
+        "[File]"
+
+      part ->
+        inspect(part)
     end)
   end
 
@@ -98,6 +129,7 @@ defmodule Jido.AI.Query do
     []
     |> maybe_add_reference(Keyword.get(opts, :file_id))
     |> maybe_add_references(Keyword.get(opts, :file_ids))
+    |> maybe_add_reference(Keyword.get(opts, :file_reference))
     |> maybe_add_references(Keyword.get(opts, :file_references))
   end
 
@@ -193,9 +225,9 @@ defmodule Jido.AI.Query do
       {:ok,
        %{
          file_id: file_id,
-         media_type: reference_value(reference, source, :media_type),
+         media_type: normalize_optional_binary(reference_value(reference, source, :media_type)),
          metadata: reference_metadata(reference),
-         filename: reference_value(reference, source, :filename)
+         filename: normalize_optional_binary(reference_value(reference, source, :filename))
        }}
     end
   end
@@ -221,6 +253,7 @@ defmodule Jido.AI.Query do
     metadata =
       case Map.get(reference, :metadata) || Map.get(reference, "metadata") do
         metadata when is_map(metadata) -> metadata
+        metadata when is_list(metadata) -> if(Keyword.keyword?(metadata), do: Map.new(metadata), else: %{})
         _metadata -> %{}
       end
 
@@ -234,6 +267,15 @@ defmodule Jido.AI.Query do
       end
     end)
   end
+
+  defp normalize_optional_binary(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      value -> value
+    end
+  end
+
+  defp normalize_optional_binary(_value), do: nil
 
   defp query_to_parts(query) when is_binary(query), do: [ContentPart.text(query)]
   defp query_to_parts(query) when is_list(query), do: query

--- a/lib/jido_ai/request.ex
+++ b/lib/jido_ai/request.ex
@@ -163,8 +163,8 @@ defmodule Jido.AI.Request do
     `:stream_receive_timeout_ms` is accepted as a compatibility alias.
   - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
   - `:llm_opts` - Per-request ReqLLM generation options forwarded to ReAct runtime
-  - `:file_id` / `:file_ids` / `:file_references` - Uploaded file references appended
-    to the user query as ReqLLM content parts when supported by the ReqLLM version
+  - `:file_id` / `:file_ids` / `:file_reference` / `:file_references` - Uploaded
+    file references appended to the user query as ReqLLM content parts when supported by the ReqLLM version
   - `:output` - `:raw` to bypass agent-level structured output for this request,
     or a request-scoped structured output config
   - `:extra_refs` - Map of additional refs to attach to the user message thread entry

--- a/lib/jido_ai/request.ex
+++ b/lib/jido_ai/request.ex
@@ -115,7 +115,7 @@ defmodule Jido.AI.Request do
     @doc """
     Creates a new Handle struct.
     """
-    @spec new(String.t(), server(), String.t()) :: t()
+    @spec new(String.t(), server(), Query.t()) :: t()
     def new(id, server, query) do
       %__MODULE__{
         id: id,
@@ -163,6 +163,8 @@ defmodule Jido.AI.Request do
     `:stream_receive_timeout_ms` is accepted as a compatibility alias.
   - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
   - `:llm_opts` - Per-request ReqLLM generation options forwarded to ReAct runtime
+  - `:file_id` / `:file_ids` / `:file_references` - Uploaded file references appended
+    to the user query as ReqLLM content parts when supported by the ReqLLM version
   - `:output` - `:raw` to bypass agent-level structured output for this request,
     or a request-scoped structured output config
   - `:extra_refs` - Map of additional refs to attach to the user message thread entry
@@ -182,7 +184,7 @@ defmodule Jido.AI.Request do
         source: "/ai/react/agent"
       )
   """
-  @spec create_and_send(server(), String.t() | [ReqLLM.Message.ContentPart.t()], keyword()) ::
+  @spec create_and_send(server(), Query.t(), keyword()) ::
           {:ok, Handle.t()} | {:error, term()}
   def create_and_send(server, query, opts) when is_binary(query) or is_list(query) do
     signal_type = Keyword.fetch!(opts, :signal_type)
@@ -199,7 +201,8 @@ defmodule Jido.AI.Request do
     request_id = Keyword.get_lazy(opts, :request_id, &generate_id/0)
     stream_to = Keyword.get(opts, :stream_to)
 
-    with {:ok, stream_to} <- RequestStream.normalize_sink(stream_to) do
+    with {:ok, query} <- Query.attach_file_references(query, opts),
+         {:ok, stream_to} <- RequestStream.normalize_sink(stream_to) do
       # Build payload with request_id for correlation.
       # Keep both query and prompt keys so all strategy start schemas can consume it.
       extra_refs = Keyword.get(opts, :extra_refs, %{})
@@ -249,7 +252,7 @@ defmodule Jido.AI.Request do
         source: "/ai/react/agent"
       )
   """
-  @spec send_and_await(server(), String.t() | [ReqLLM.Message.ContentPart.t()], keyword()) ::
+  @spec send_and_await(server(), Query.t(), keyword()) ::
           {:ok, any()} | {:error, term()}
   def send_and_await(server, query, opts) when is_binary(query) or is_list(query) do
     timeout = Keyword.get(opts, :timeout, @default_timeout)
@@ -372,8 +375,9 @@ defmodule Jido.AI.Request do
         {:ok, agent, action}
       end
   """
-  @spec start_request(struct(), String.t(), String.t(), keyword()) :: struct()
-  def start_request(agent, request_id, query, opts \\ []) when is_binary(request_id) and is_binary(query) do
+  @spec start_request(struct(), String.t(), Query.t(), keyword()) :: struct()
+  def start_request(agent, request_id, query, opts \\ [])
+      when is_binary(request_id) and (is_binary(query) or is_list(query)) do
     stream_to = Keyword.get(opts, :stream_to)
 
     request =
@@ -538,7 +542,7 @@ defmodule Jido.AI.Request do
       requests: quote(do: Zoi.map() |> Zoi.default(%{})),
       last_request_id: quote(do: Zoi.string() |> Zoi.optional()),
       # Backward compat fields
-      last_query: quote(do: Zoi.string() |> Zoi.default("")),
+      last_query: quote(do: Jido.AI.Query.schema() |> Zoi.default("")),
       last_answer: quote(do: Zoi.string() |> Zoi.default("")),
       completed: quote(do: Zoi.boolean() |> Zoi.default(false))
     }

--- a/test/jido_ai/agent_test.exs
+++ b/test/jido_ai/agent_test.exs
@@ -11,6 +11,7 @@ defmodule Jido.AI.AgentTest do
   alias Jido.AI.Agent
   alias Jido.AI.Reasoning.ReAct.Event
   alias Jido.AI.Reasoning.ReAct.Strategy, as: ReAct
+  alias ReqLLM.Message.ContentPart
 
   # ============================================================================
   # Test Action Modules (simulating external modules like ash_jido)
@@ -549,6 +550,19 @@ defmodule Jido.AI.AgentTest do
 
     test "ask_stream/3 exists as stream wrapper" do
       assert :erlang.fun_info(&BasicAgent.ask_stream/3, :arity) == {:arity, 3}
+    end
+
+    test "generated request helpers surface unsupported file reference options before dispatch" do
+      unless function_exported?(ContentPart, :file_id, 3) do
+        assert {:error, {:unsupported_content_part_file_id, _message}} =
+                 BasicAgent.ask(self(), "Summarize this.", file_id: "file_123")
+
+        assert {:error, {:unsupported_content_part_file_id, _message}} =
+                 BasicAgent.ask_stream(self(), "Summarize this.", file_id: "file_123")
+
+        assert {:error, {:unsupported_content_part_file_id, _message}} =
+                 BasicAgent.ask_sync(self(), "Summarize this.", file_id: "file_123", timeout: 1)
+      end
     end
   end
 

--- a/test/jido_ai/query_test.exs
+++ b/test/jido_ai/query_test.exs
@@ -7,9 +7,12 @@ defmodule Jido.AI.QueryTest do
   describe "content_part?/1" do
     test "accepts compatible file and video content maps" do
       assert Query.content_part?(%{type: :file, file_id: "file_123"})
+      assert Query.content_part?(%{type: "file", file_id: "file_123"})
       assert Query.content_part?(%{"type" => "file", "file_id" => "file_123"})
       assert Query.content_part?(%{type: :video_url, url: "https://example.com/video.mp4"})
       assert Query.content_part?(%{"type" => "video_url", "url" => "https://example.com/video.mp4"})
+      assert Query.content_part?(%{type: :document, source: %{file_id: "file_123"}})
+      assert Query.content_part?(%{"type" => "file_id", "file_id" => "file_123"})
     end
   end
 
@@ -47,6 +50,31 @@ defmodule Jido.AI.QueryTest do
         assert file_part.file_id == "file_123"
         assert file_part.media_type == "application/pdf"
         assert file_part.metadata.title == "Quarterly report"
+      else
+        assert {:error, {:unsupported_content_part_file_id, message}} = result
+        assert message =~ "ReqLLM.Message.ContentPart.file_id/3"
+      end
+    end
+
+    test "accepts singular file_reference and normalizes optional metadata" do
+      result =
+        Query.attach_file_references("Summarize this.",
+          file_reference: [
+            file_id: "file_123",
+            media_type: " ",
+            filename: " report.pdf ",
+            metadata: [custom: true],
+            context: "Uploaded through the Files API"
+          ]
+        )
+
+      if file_reference_supported?() do
+        assert {:ok, [_text_part, file_part]} = result
+
+        file_part = Map.from_struct(file_part)
+        assert file_part.media_type == "application/pdf"
+        assert file_part.filename == "report.pdf"
+        assert file_part.metadata == %{custom: true, context: "Uploaded through the Files API"}
       else
         assert {:error, {:unsupported_content_part_file_id, message}} = result
         assert message =~ "ReqLLM.Message.ContentPart.file_id/3"
@@ -95,10 +123,13 @@ defmodule Jido.AI.QueryTest do
           ContentPart.text("Review this file."),
           ContentPart.file("PDF", "report.pdf", "application/pdf"),
           %{"type" => "file", "filename" => "appendix.pdf"},
-          %{type: :file}
+          %{"type" => "document", "filename" => "source.pdf"},
+          %{type: :file_id},
+          %{type: "file", filename: "notes.txt"}
         ])
 
-      assert summary == "Review this file.\n[File: report.pdf]\n[File: appendix.pdf]\n[File]"
+      assert summary ==
+               "Review this file.\n[File: report.pdf]\n[File: appendix.pdf]\n[File: source.pdf]\n[File]\n[File: notes.txt]"
     end
   end
 

--- a/test/jido_ai/query_test.exs
+++ b/test/jido_ai/query_test.exs
@@ -1,0 +1,108 @@
+defmodule Jido.AI.QueryTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.AI.Query
+  alias ReqLLM.Message.ContentPart
+
+  describe "content_part?/1" do
+    test "accepts compatible file and video content maps" do
+      assert Query.content_part?(%{type: :file, file_id: "file_123"})
+      assert Query.content_part?(%{"type" => "file", "file_id" => "file_123"})
+      assert Query.content_part?(%{type: :video_url, url: "https://example.com/video.mp4"})
+      assert Query.content_part?(%{"type" => "video_url", "url" => "https://example.com/video.mp4"})
+    end
+  end
+
+  describe "attach_file_references/2" do
+    test "returns the original query when no file reference options are provided" do
+      assert {:ok, "Summarize this."} = Query.attach_file_references("Summarize this.", [])
+    end
+
+    test "validates missing file ids before checking ReqLLM support" do
+      assert {:error, {:invalid_file_reference, :missing_file_id}} =
+               Query.attach_file_references("Summarize this.", file_id: " ")
+    end
+
+    test "returns a structured error for malformed list-shaped references" do
+      assert {:error, {:invalid_file_reference, :missing_file_id}} =
+               Query.attach_file_references("Summarize this.", file_id: ["file_123"])
+    end
+
+    test "treats a keyword file reference as a single reference" do
+      result =
+        Query.attach_file_references("Summarize this.",
+          file_references: [
+            file_id: "file_123",
+            media_type: "application/pdf",
+            title: "Quarterly report"
+          ]
+        )
+
+      if file_reference_supported?() do
+        assert {:ok, [text_part, file_part]} = result
+        assert %ContentPart{type: :text, text: "Summarize this."} = text_part
+
+        file_part = Map.from_struct(file_part)
+        assert file_part.type == :file
+        assert file_part.file_id == "file_123"
+        assert file_part.media_type == "application/pdf"
+        assert file_part.metadata.title == "Quarterly report"
+      else
+        assert {:error, {:unsupported_content_part_file_id, message}} = result
+        assert message =~ "ReqLLM.Message.ContentPart.file_id/3"
+      end
+    end
+
+    test "appends normalized file reference content parts when ReqLLM supports them" do
+      result =
+        Query.attach_file_references("Compare these files.",
+          file_id: "file_document",
+          file_references: [
+            %{
+              "source" => %{"file_id" => "file_image", "media_type" => "image/png"},
+              "filename" => "chart.png",
+              "metadata" => %{"custom" => true}
+            }
+          ]
+        )
+
+      if file_reference_supported?() do
+        assert {:ok, [text_part, document_part, image_part]} = result
+        assert %ContentPart{type: :text, text: "Compare these files."} = text_part
+
+        document_part = Map.from_struct(document_part)
+        assert document_part.type == :file
+        assert document_part.file_id == "file_document"
+        assert document_part.media_type == "application/pdf"
+
+        image_part = Map.from_struct(image_part)
+        assert image_part.type == :file
+        assert image_part.file_id == "file_image"
+        assert image_part.media_type == "image/png"
+        assert image_part.filename == "chart.png"
+        assert image_part.metadata == %{"custom" => true}
+      else
+        assert {:error, {:unsupported_content_part_file_id, message}} = result
+        assert message =~ "ReqLLM.Message.ContentPart.file_id/3"
+      end
+    end
+  end
+
+  describe "summarize/1" do
+    test "renders file content parts without exposing raw payloads" do
+      summary =
+        Query.summarize([
+          ContentPart.text("Review this file."),
+          ContentPart.file("PDF", "report.pdf", "application/pdf"),
+          %{"type" => "file", "filename" => "appendix.pdf"},
+          %{type: :file}
+        ])
+
+      assert summary == "Review this file.\n[File: report.pdf]\n[File: appendix.pdf]\n[File]"
+    end
+  end
+
+  defp file_reference_supported? do
+    function_exported?(ContentPart, :file_id, 3)
+  end
+end

--- a/test/jido_ai/query_test.exs
+++ b/test/jido_ai/query_test.exs
@@ -81,6 +81,31 @@ defmodule Jido.AI.QueryTest do
       end
     end
 
+    test "accepts nested source options as keyword lists" do
+      result =
+        Query.attach_file_references("Summarize this.",
+          file_reference: [
+            source: [
+              file_id: " file_123 ",
+              media_type: " application/pdf "
+            ],
+            filename: " report.pdf "
+          ]
+        )
+
+      if file_reference_supported?() do
+        assert {:ok, [_text_part, file_part]} = result
+
+        file_part = Map.from_struct(file_part)
+        assert file_part.file_id == "file_123"
+        assert file_part.media_type == "application/pdf"
+        assert file_part.filename == "report.pdf"
+      else
+        assert {:error, {:unsupported_content_part_file_id, message}} = result
+        assert message =~ "ReqLLM.Message.ContentPart.file_id/3"
+      end
+    end
+
     test "appends normalized file reference content parts when ReqLLM supports them" do
       result =
         Query.attach_file_references("Compare these files.",

--- a/test/jido_ai/request_test.exs
+++ b/test/jido_ai/request_test.exs
@@ -4,6 +4,7 @@ defmodule JidoTest.AI.RequestTest do
   alias Jido.AI.Request
   alias Jido.AI.Request.Handle
   alias Jido.AI.Reasoning.ReAct.Event
+  alias ReqLLM.Message.ContentPart
 
   defmodule TestRequestTransformer do
     def transform_request(request, _state, _config, _context), do: {:ok, request}
@@ -155,6 +156,19 @@ defmodule JidoTest.AI.RequestTest do
       agent = Request.start_request(agent, "req-1", "What is 2+2?", stream_to: {:pid, self()})
 
       assert agent.state.requests["req-1"].stream_to == {:pid, self()}
+    end
+
+    test "start_request/4 tracks multimodal queries" do
+      query = [
+        ContentPart.text("Review this."),
+        ContentPart.file("PDF", "report.pdf", "application/pdf")
+      ]
+
+      agent = %MockAgent{state: Request.init_state(%{})}
+      agent = Request.start_request(agent, "req-1", query)
+
+      assert agent.state.requests["req-1"].query == query
+      assert agent.state.last_query == query
     end
 
     test "complete_request/3 updates request with result" do
@@ -447,6 +461,44 @@ defmodule JidoTest.AI.RequestTest do
                  source: "/ai/test",
                  stream_to: :bad_sink
                )
+    end
+
+    test "create_and_send/3 appends uploaded file references when supported by ReqLLM" do
+      server = start_runtime_server([])
+
+      result =
+        Request.create_and_send(server, "Summarize this document.",
+          signal_type: "ai.test.query",
+          source: "/ai/test",
+          request_id: "req_file",
+          file_references: [
+            %{
+              file_id: "file_123",
+              media_type: "application/pdf",
+              title: "Quarterly report"
+            }
+          ]
+        )
+
+      if function_exported?(ContentPart, :file_id, 3) do
+        assert {:ok, handle} = result
+        signal = FakeRuntimeServer.last_signal(server)
+
+        assert [text_part, file_part] = signal.data.query
+        assert signal.data.prompt == signal.data.query
+        assert handle.query == signal.data.query
+        assert %ContentPart{type: :text, text: "Summarize this document."} = text_part
+
+        file_part = Map.from_struct(file_part)
+        assert file_part.type == :file
+        assert file_part.file_id == "file_123"
+        assert file_part.media_type == "application/pdf"
+        assert file_part.metadata.title == "Quarterly report"
+      else
+        assert {:error, {:unsupported_content_part_file_id, message}} = result
+        assert message =~ "ReqLLM.Message.ContentPart.file_id/3"
+        assert FakeRuntimeServer.last_signal(server) == nil
+      end
     end
 
     test "await/2 returns successful result for completed request payload" do


### PR DESCRIPTION
## Summary
- Add request-level `:file_id`, `:file_ids`, and `:file_references` options for generated `use Jido.AI.Agent` ask helpers.
- Normalize file reference strings, keyword lists, and maps into ReqLLM `ContentPart.file_id/3` content parts, preserving media type, filename, and document metadata.
- Keep current Hex ReqLLM 1.11.0 safe by returning an explicit unsupported error until the already-merged ReqLLM file-reference API is available.
- Allow request tracking state to retain multimodal query lists instead of assuming query text is always a binary.

Closes #292

## Validation
- `mix test test/jido_ai/query_test.exs test/jido_ai/request_test.exs test/jido_ai/agent_test.exs`
- `mix precommit`
- `mix test`