### PR TITLE
refactor(error): centralize runtime error contract

### DIFF
--- a/guides/developer/error_model_and_recovery.md
+++ b/guides/developer/error_model_and_recovery.md
@@ -28,6 +28,10 @@ After this guide, you can classify failures and pick the right recovery path.
 `jido_ai` owns the AI runtime error envelope used in signals, tool results, and
 telemetry-facing payloads.
 
+Use `Jido.AI.Error.normalize/4` to adapt arbitrary runtime errors into the
+canonical envelope, `Jido.AI.Error.normalize_result/3` for result tuples, and
+`Jido.AI.Error.retryable?/1` for retry policy decisions.
+
 Upstream packages such as `jido_action` should stay generic. They can expose
 error type/message/details and retryability, but they should not define
 AI-specific contracts.

--- a/guides/developer/error_model_and_recovery.md
+++ b/guides/developer/error_model_and_recovery.md
@@ -36,6 +36,11 @@ Upstream packages such as `jido_action` should stay generic. They can expose
 error type/message/details and retryability, but they should not define
 AI-specific contracts.
 
+`Jido.AI.Error.normalize/4` adapts upstream `Jido.Action.Error`,
+`Jido.Signal.Error`, and `Jido.Error` structs through the generic `Jido.Error`
+map contract. Plain Elixir exceptions use the caller-provided fallback type
+while preserving the exception message and sanitized struct fields.
+
 At this boundary, envelope `details` are normalized to JSON-safe values. Raw
 runtime terms (for example tuples, pids, refs) are stringified so signal and
 telemetry payload encoding stays reliable.

--- a/guides/developer/error_model_and_recovery.md
+++ b/guides/developer/error_model_and_recovery.md
@@ -45,6 +45,10 @@ At this boundary, envelope `details` are normalized to JSON-safe values. Raw
 runtime terms (for example tuples, pids, refs) are stringified so signal and
 telemetry payload encoding stays reliable.
 
+Already-decoded maps with string keys are accepted when their type/code atom
+already exists, so JSON round-trips do not silently lose known error types or
+retry hints.
+
 ## Example: Sanitized User Message + Full Log
 
 ```elixir

--- a/lib/jido_ai/directive/emit_tool_error.ex
+++ b/lib/jido_ai/directive/emit_tool_error.ex
@@ -45,8 +45,8 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.EmitToolError do
   receives a tool_result signal for every pending tool call, preventing deadlock.
   """
 
+  alias Jido.AI.Error
   alias Jido.AI.Signal
-  alias Jido.AI.Signal.Helpers, as: SignalHelpers
 
   def exec(directive, _input_signal, state) do
     %{
@@ -59,7 +59,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.EmitToolError do
     metadata = Map.get(directive, :metadata, %{})
 
     normalized_error =
-      SignalHelpers.normalize_error(error, :execution_error, "Tool execution failed", %{tool_name: tool_name})
+      Error.normalize(error, :execution_error, "Tool execution failed", %{tool_name: tool_name})
 
     # Emit the error result synchronously (no task needed)
     signal =

--- a/lib/jido_ai/directive/llm_generate.ex
+++ b/lib/jido_ai/directive/llm_generate.ex
@@ -78,9 +78,8 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.LLMGenerate do
   when an agent is created.
   """
 
-  alias Jido.AI.{Observe, Signal, Turn}
+  alias Jido.AI.{Error, Observe, Signal, Turn}
   alias Jido.AI.Directive.Helpers
-  alias Jido.AI.Signal.Helpers, as: SignalHelpers
 
   def exec(directive, _input_signal, state) do
     %{
@@ -174,7 +173,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.LLMGenerate do
            signal =
              Signal.LLMResponse.new!(%{
                call_id: call_id,
-               result: SignalHelpers.normalize_result(result, :llm_error, "LLM request failed"),
+               result: Error.normalize_result(result, :llm_error, "LLM request failed"),
                metadata: signal_metadata(event_meta)
              })
 
@@ -189,7 +188,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.LLMGenerate do
             call_id: call_id,
             result:
               {:error,
-               SignalHelpers.error_envelope(
+               Error.error_envelope(
                  :supervisor,
                  "Failed to start LLM task",
                  %{reason: inspect(reason)},

--- a/lib/jido_ai/directive/llm_stream.ex
+++ b/lib/jido_ai/directive/llm_stream.ex
@@ -89,9 +89,8 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.LLMStream do
   when an agent is created.
   """
 
-  alias Jido.AI.{Observe, Signal, Turn}
+  alias Jido.AI.{Error, Observe, Signal, Turn}
   alias Jido.AI.Directive.Helpers
-  alias Jido.AI.Signal.Helpers, as: SignalHelpers
   alias Jido.Tracing.Context, as: TraceContext
 
   def exec(directive, _input_signal, state) do
@@ -197,7 +196,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.LLMStream do
            signal =
              Signal.LLMResponse.new!(%{
                call_id: call_id,
-               result: SignalHelpers.normalize_result(result, :llm_error, "LLM request failed"),
+               result: Error.normalize_result(result, :llm_error, "LLM request failed"),
                metadata: signal_metadata(event_meta)
              })
 
@@ -212,7 +211,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.LLMStream do
             call_id: call_id,
             result:
               {:error,
-               SignalHelpers.error_envelope(
+               Error.error_envelope(
                  :supervisor,
                  "Failed to start LLM stream task",
                  %{reason: inspect(reason)},

--- a/lib/jido_ai/directive/tool_exec.ex
+++ b/lib/jido_ai/directive/tool_exec.ex
@@ -95,9 +95,9 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
   This prevents the Machine from deadlocking in `awaiting_tool` state.
   """
 
+  alias Jido.AI.Error
   alias Jido.AI.Observe
   alias Jido.AI.Signal
-  alias Jido.AI.Signal.Helpers, as: SignalHelpers
   alias Jido.AI.Turn
   alias Jido.Tracing.Context, as: TraceContext
 
@@ -255,7 +255,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
           call_id,
           tool_name,
           {:error,
-           SignalHelpers.error_envelope(
+           Error.error_envelope(
              :supervisor,
              "Failed to start tool execution task",
              %{tool_name: tool_name, reason: inspect(reason)},
@@ -282,8 +282,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
          obs_cfg
        ) do
     0..max_retries
-    |> Enum.reduce_while({{:error, SignalHelpers.error_envelope(:executor, "uninitialized error"), []}, 0}, fn attempt,
-                                                                                                               _acc ->
+    |> Enum.reduce_while({{:error, Error.error_envelope(:executor, "uninitialized error"), []}, 0}, fn attempt, _acc ->
       if attempt > 0 do
         maybe_emit(obs_cfg, Observe.tool(:retry), %{duration_ms: 0, retry_count: attempt}, event_meta)
 
@@ -307,7 +306,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
           {:halt, {ok, attempt}}
 
         {:error, error, _effects} ->
-          retryable? = SignalHelpers.retryable?(error)
+          retryable? = Error.retryable?(error)
 
           if retryable? and attempt < max_retries do
             {:cont, {result, attempt}}
@@ -340,12 +339,10 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
             normalize_result(result, tool_name)
 
           {:exit, _reason} ->
-            {:error,
-             SignalHelpers.error_envelope(:timeout, "Tool execution timed out", %{timeout_ms: timeout_ms}, true), []}
+            {:error, Error.error_envelope(:timeout, "Tool execution timed out", %{timeout_ms: timeout_ms}, true), []}
 
           nil ->
-            {:error,
-             SignalHelpers.error_envelope(:timeout, "Tool execution timed out", %{timeout_ms: timeout_ms}, true), []}
+            {:error, Error.error_envelope(:timeout, "Tool execution timed out", %{timeout_ms: timeout_ms}, true), []}
         end
       after
         Process.demonitor(task.ref, [:flush])
@@ -370,7 +367,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
     rescue
       e ->
         {:error,
-         SignalHelpers.error_envelope(
+         Error.error_envelope(
            :exception,
            Exception.message(e),
            %{tool_name: tool_name, exception_type: inspect(e.__struct__)},
@@ -379,7 +376,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
     catch
       kind, reason ->
         {:error,
-         SignalHelpers.error_envelope(
+         Error.error_envelope(
            :exception,
            "Caught #{kind}: #{inspect(reason)}",
            %{tool_name: tool_name, kind: kind},
@@ -397,18 +394,17 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
   defp normalize_result({:ok, result}, _tool_name), do: {:ok, result, []}
 
   defp normalize_result({:error, reason, effects}, tool_name) do
-    {:error, SignalHelpers.normalize_error(reason, :execution_error, "Tool execution failed", %{tool_name: tool_name}),
+    {:error, Error.normalize(reason, :execution_error, "Tool execution failed", %{tool_name: tool_name}),
      List.wrap(effects)}
   end
 
   defp normalize_result({:error, reason}, tool_name) do
-    {:error, SignalHelpers.normalize_error(reason, :execution_error, "Tool execution failed", %{tool_name: tool_name}),
-     []}
+    {:error, Error.normalize(reason, :execution_error, "Tool execution failed", %{tool_name: tool_name}), []}
   end
 
   defp normalize_result(other, tool_name) do
     {:error,
-     SignalHelpers.error_envelope(
+     Error.error_envelope(
        :executor,
        "Unexpected tool execution result: #{inspect(other)}",
        %{tool_name: tool_name, result: inspect(other)},
@@ -454,7 +450,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
           tool_name: tool_name || "unknown",
           result:
             {:error,
-             SignalHelpers.error_envelope(
+             Error.error_envelope(
                :internal_error,
                "Signal construction failed: #{Exception.message(e)}",
                %{tool_name: tool_name || "unknown"},

--- a/lib/jido_ai/error.ex
+++ b/lib/jido_ai/error.ex
@@ -56,7 +56,7 @@ defmodule Jido.AI.Error do
     error_envelope(
       type,
       normalize_message(message),
-      merge_error_details(Map.get(error, :details, %{}), extra_details),
+      merge_error_details(error_details(error), extra_details),
       normalize_retryable(error, type)
     )
   end
@@ -66,7 +66,31 @@ defmodule Jido.AI.Error do
     error_envelope(
       type,
       normalize_message(message),
-      merge_error_details(Map.get(error, :details, %{}), extra_details),
+      merge_error_details(error_details(error), extra_details),
+      normalize_retryable(error, type)
+    )
+  end
+
+  def normalize(%{"type" => type, "message" => message} = error, fallback_type, _fallback_message, extra_details)
+      when is_binary(type) and is_map(extra_details) do
+    type = normalize_type(type, fallback_type)
+
+    error_envelope(
+      type,
+      normalize_message(message),
+      merge_error_details(error_details(error), extra_details),
+      normalize_retryable(error, type)
+    )
+  end
+
+  def normalize(%{"code" => type, "message" => message} = error, fallback_type, _fallback_message, extra_details)
+      when is_binary(type) and is_map(extra_details) do
+    type = normalize_type(type, fallback_type)
+
+    error_envelope(
+      type,
+      normalize_message(message),
+      merge_error_details(error_details(error), extra_details),
       normalize_retryable(error, type)
     )
   end
@@ -94,7 +118,7 @@ defmodule Jido.AI.Error do
       when not is_nil(message) and is_map(extra_details) do
     details =
       error
-      |> Map.drop([:message, :retryable, :retryable?])
+      |> Map.drop([:message, :retryable, :retryable?, "message", "retryable", "retryable?"])
       |> merge_error_details(extra_details)
 
     error_envelope(fallback_type, normalize_message(message), details, normalize_retryable(error, fallback_type))
@@ -191,8 +215,12 @@ defmodule Jido.AI.Error do
   def retryable?({:error, reason}), do: retryable?(reason)
   def retryable?(%{retryable?: value}) when is_boolean(value), do: value
   def retryable?(%{retryable: value}) when is_boolean(value), do: value
+  def retryable?(%{"retryable?" => value}) when is_boolean(value), do: value
+  def retryable?(%{"retryable" => value}) when is_boolean(value), do: value
   def retryable?(%{type: type} = error) when is_atom(type), do: retryable_hint(error, retryable_type?(type))
   def retryable?(%{code: type} = error) when is_atom(type), do: retryable_hint(error, retryable_type?(type))
+  def retryable?(%{"type" => type} = error) when is_binary(type), do: retryable_from_string_type(error, type)
+  def retryable?(%{"code" => type} = error) when is_binary(type), do: retryable_from_string_type(error, type)
   def retryable?(reason) when is_atom(reason), do: retryable_type?(reason)
   def retryable?(_reason), do: false
 
@@ -230,7 +258,11 @@ defmodule Jido.AI.Error do
   defp normalize_json_safe_value(value) when is_atom(value), do: value
 
   defp normalize_json_safe_value(value) when is_list(value) do
-    Enum.map(value, &normalize_json_safe_value/1)
+    if proper_list?(value) do
+      Enum.map(value, &normalize_json_safe_value/1)
+    else
+      inspect(value)
+    end
   end
 
   defp normalize_json_safe_value(%_{} = struct) do
@@ -248,10 +280,24 @@ defmodule Jido.AI.Error do
   defp normalize_retryable(error, type) do
     cond do
       is_boolean(Map.get(error, :retryable?)) -> Map.get(error, :retryable?)
+      is_boolean(Map.get(error, "retryable?")) -> Map.get(error, "retryable?")
       is_boolean(Map.get(error, :retryable)) -> Map.get(error, :retryable)
+      is_boolean(Map.get(error, "retryable")) -> Map.get(error, "retryable")
       true -> retryable_hint(error, retryable_type?(type))
     end
   end
+
+  defp error_details(error), do: Map.get(error, :details, Map.get(error, "details", %{}))
+
+  defp normalize_type(type, _fallback) when is_atom(type), do: type
+
+  defp normalize_type(type, fallback) when is_binary(type) do
+    String.to_existing_atom(type)
+  rescue
+    ArgumentError -> fallback
+  end
+
+  defp normalize_type(_type, fallback), do: fallback
 
   defp normalize_message(message) when is_binary(message), do: message
   defp normalize_message(message) when is_atom(message), do: Atom.to_string(message)
@@ -290,14 +336,39 @@ defmodule Jido.AI.Error do
     String.starts_with?(module_name, @upstream_jido_error_prefixes)
   end
 
-  defp retryable_hint(term, default) do
-    case extract_retry_hint(term) do
-      nil -> default
-      value -> value != false
+  defp retryable_from_string_type(error, type) do
+    case normalize_type(type, nil) do
+      nil -> retryable_hint(error, false)
+      type -> retryable_hint(error, retryable_type?(type))
     end
   end
 
+  defp retryable_hint(term, default) do
+    case extract_retry_hint(term) do
+      nil -> default
+      value -> retry_hint_truthy?(value)
+    end
+  end
+
+  defp retry_hint_truthy?(false), do: false
+  defp retry_hint_truthy?("false"), do: false
+  defp retry_hint_truthy?("0"), do: false
+  defp retry_hint_truthy?(_), do: true
+
   defp extract_retry_hint(%{details: details} = error) do
+    case extract_retry_value(details) do
+      nil ->
+        details
+        |> extract_nested_reason()
+        |> Kernel.||(extract_nested_reason(error))
+        |> extract_retry_hint()
+
+      value ->
+        value
+    end
+  end
+
+  defp extract_retry_hint(%{"details" => details} = error) do
     case extract_retry_value(details) do
       nil ->
         details
@@ -319,11 +390,14 @@ defmodule Jido.AI.Error do
 
   defp extract_retry_hint(nil), do: nil
   defp extract_retry_hint(reason) when is_atom(reason), do: retryable_type?(reason)
+  defp extract_retry_hint(reason) when is_binary(reason), do: retryable_type_from_string(reason)
   defp extract_retry_hint(_), do: nil
 
   defp extract_nested_reason(%{} = map) do
     map[:reason] ||
-      if(is_atom(map[:message]), do: map[:message], else: nil)
+      map["reason"] ||
+      retry_hint_message(map[:message]) ||
+      retry_hint_message(map["message"])
   end
 
   defp extract_nested_reason(_), do: nil
@@ -331,6 +405,11 @@ defmodule Jido.AI.Error do
   defp extract_retry_value(%{} = map) do
     cond do
       Map.has_key?(map, :retry) -> map[:retry]
+      Map.has_key?(map, "retry") -> map["retry"]
+      Map.has_key?(map, :retryable?) -> map[:retryable?]
+      Map.has_key?(map, "retryable?") -> map["retryable?"]
+      Map.has_key?(map, :retryable) -> map[:retryable]
+      Map.has_key?(map, "retryable") -> map["retryable"]
       true -> nil
     end
   end
@@ -340,6 +419,21 @@ defmodule Jido.AI.Error do
   end
 
   defp extract_retry_value(_), do: nil
+
+  defp retry_hint_message(message) when is_atom(message), do: message
+  defp retry_hint_message(message) when is_binary(message), do: normalize_type(message, nil)
+  defp retry_hint_message(_), do: nil
+
+  defp retryable_type_from_string(type) do
+    case normalize_type(type, nil) do
+      nil -> nil
+      type -> retryable_type?(type)
+    end
+  end
+
+  defp proper_list?([]), do: true
+  defp proper_list?([_head | tail]), do: proper_list?(tail)
+  defp proper_list?(_), do: false
 
   defp retryable_type?(type) when type in [:timeout, :transient, :transient_error, :rate_limited], do: true
   defp retryable_type?(_type), do: false

--- a/lib/jido_ai/error.ex
+++ b/lib/jido_ai/error.ex
@@ -289,15 +289,11 @@ defmodule Jido.AI.Error do
 
   defp error_details(error), do: Map.get(error, :details, Map.get(error, "details", %{}))
 
-  defp normalize_type(type, _fallback) when is_atom(type), do: type
-
-  defp normalize_type(type, fallback) when is_binary(type) do
+  defp normalize_type(type, fallback) do
     String.to_existing_atom(type)
   rescue
     ArgumentError -> fallback
   end
-
-  defp normalize_type(_type, fallback), do: fallback
 
   defp normalize_message(message) when is_binary(message), do: message
   defp normalize_message(message) when is_atom(message), do: Atom.to_string(message)

--- a/lib/jido_ai/error.ex
+++ b/lib/jido_ai/error.ex
@@ -15,6 +15,12 @@ defmodule Jido.AI.Error do
     ],
     unknown_error: Jido.AI.Error.Unknown
 
+  @upstream_jido_error_prefixes [
+    "Elixir.Jido.Action.Error.",
+    "Elixir.Jido.Error.",
+    "Elixir.Jido.Signal.Error."
+  ]
+
   @type error_envelope :: %{
           type: atom(),
           message: String.t(),
@@ -68,20 +74,11 @@ defmodule Jido.AI.Error do
   def normalize(%module{} = reason, fallback_type, fallback_message, extra_details)
       when is_map(extra_details) do
     cond do
-      jido_error_struct?(module) and Code.ensure_loaded?(Jido.Error) and function_exported?(Jido.Error, :to_map, 1) and
-          function_exported?(module, :message, 1) ->
-        reason
-        |> Jido.Error.to_map()
-        |> Map.drop([:stacktrace])
-        |> normalize(fallback_type, fallback_message, extra_details)
+      upstream_jido_error_struct?(module) ->
+        normalize_upstream_jido_error(reason, fallback_type, fallback_message, extra_details)
 
       is_exception(reason) ->
-        error_envelope(
-          fallback_type,
-          Exception.message(reason),
-          merge_error_details(Map.from_struct(reason), extra_details),
-          false
-        )
+        normalize_exception(reason, fallback_type, extra_details)
 
       true ->
         error_envelope(
@@ -204,6 +201,17 @@ defmodule Jido.AI.Error do
     |> normalize_json_safe_map()
   end
 
+  defp merge_error_details(details, extra_details) when is_map(extra_details) do
+    details
+    |> normalize_error_details()
+    |> Map.merge(extra_details)
+    |> normalize_json_safe_map()
+  end
+
+  defp normalize_error_details(nil), do: %{}
+  defp normalize_error_details(details) when is_map(details), do: details
+  defp normalize_error_details(details), do: %{details: details}
+
   defp normalize_json_safe_map(map) when is_map(map) do
     Map.new(map, fn {key, value} ->
       {normalize_json_safe_key(key), normalize_json_safe_value(value)}
@@ -250,13 +258,36 @@ defmodule Jido.AI.Error do
   defp normalize_message(nil), do: "Execution failed"
   defp normalize_message(message), do: inspect(message)
 
-  defp jido_error_struct?(module) do
+  defp normalize_upstream_jido_error(reason, fallback_type, fallback_message, extra_details) do
+    reason
+    |> Jido.Error.to_map()
+    |> Map.drop([:stacktrace])
+    |> normalize(fallback_type, fallback_message, extra_details)
+  end
+
+  defp normalize_exception(reason, fallback_type, extra_details) do
+    error_envelope(
+      fallback_type,
+      Exception.message(reason),
+      merge_error_details(Map.from_struct(reason), extra_details),
+      false
+    )
+  end
+
+  defp upstream_jido_error_struct?(module) do
+    jido_error_adapter_available?() and exception_struct?(module) and jido_error_namespace?(module)
+  end
+
+  defp jido_error_adapter_available? do
+    Code.ensure_loaded?(Jido.Error) and function_exported?(Jido.Error, :to_map, 1)
+  end
+
+  defp exception_struct?(module), do: function_exported?(module, :message, 1)
+
+  defp jido_error_namespace?(module) do
     module_name = Atom.to_string(module)
 
-    String.starts_with?(module_name, [
-      "Elixir.Jido.Action.Error.",
-      "Elixir.Jido.Error."
-    ])
+    String.starts_with?(module_name, @upstream_jido_error_prefixes)
   end
 
   defp retryable_hint(term, default) do

--- a/lib/jido_ai/error.ex
+++ b/lib/jido_ai/error.ex
@@ -5,6 +5,7 @@ defmodule Jido.AI.Error do
   Provides structured error types for AI operations including:
   - API errors (rate limits, authentication, transient failures)
   - Validation errors
+  - Runtime error envelope normalization and retryability policy
   """
 
   use Splode,
@@ -13,6 +14,304 @@ defmodule Jido.AI.Error do
       validation: Jido.AI.Error.Validation
     ],
     unknown_error: Jido.AI.Error.Unknown
+
+  @type error_envelope :: %{
+          type: atom(),
+          message: String.t(),
+          details: map(),
+          retryable?: boolean()
+        }
+
+  @doc """
+  Builds a normalized AI runtime error envelope.
+
+  The envelope is the package-owned caller-visible contract used by tool,
+  LLM, directive, and signal result paths.
+  """
+  @spec error_envelope(atom(), String.t(), map(), boolean()) :: error_envelope()
+  def error_envelope(type, message, details \\ %{}, retryable? \\ false)
+      when is_atom(type) and is_binary(message) and is_map(details) and is_boolean(retryable?) do
+    %{
+      type: type,
+      message: message,
+      details: normalize_json_safe_map(details),
+      retryable?: retryable?
+    }
+  end
+
+  @doc """
+  Normalizes arbitrary runtime error values into the canonical AI error envelope.
+  """
+  @spec normalize(term(), atom(), String.t(), map()) :: error_envelope()
+  def normalize(reason, fallback_type \\ :execution_error, fallback_message \\ "Execution failed", extra_details \\ %{})
+
+  def normalize(%{type: type, message: message} = error, _fallback_type, _fallback_message, extra_details)
+      when is_atom(type) and is_map(extra_details) do
+    error_envelope(
+      type,
+      normalize_message(message),
+      merge_error_details(Map.get(error, :details, %{}), extra_details),
+      normalize_retryable(error, type)
+    )
+  end
+
+  def normalize(%{code: type, message: message} = error, _fallback_type, _fallback_message, extra_details)
+      when is_atom(type) and is_map(extra_details) do
+    error_envelope(
+      type,
+      normalize_message(message),
+      merge_error_details(Map.get(error, :details, %{}), extra_details),
+      normalize_retryable(error, type)
+    )
+  end
+
+  def normalize(%module{} = reason, fallback_type, fallback_message, extra_details)
+      when is_map(extra_details) do
+    cond do
+      jido_error_struct?(module) and Code.ensure_loaded?(Jido.Error) and function_exported?(Jido.Error, :to_map, 1) and
+          function_exported?(module, :message, 1) ->
+        reason
+        |> Jido.Error.to_map()
+        |> Map.drop([:stacktrace])
+        |> normalize(fallback_type, fallback_message, extra_details)
+
+      is_exception(reason) ->
+        error_envelope(
+          fallback_type,
+          Exception.message(reason),
+          merge_error_details(Map.from_struct(reason), extra_details),
+          false
+        )
+
+      true ->
+        error_envelope(
+          fallback_type,
+          fallback_message,
+          merge_error_details(%{reason: inspect(reason)}, extra_details),
+          false
+        )
+    end
+  end
+
+  def normalize(%{message: message} = error, fallback_type, _fallback_message, extra_details)
+      when not is_nil(message) and is_map(extra_details) do
+    details =
+      error
+      |> Map.drop([:message, :retryable, :retryable?])
+      |> merge_error_details(extra_details)
+
+    error_envelope(fallback_type, normalize_message(message), details, normalize_retryable(error, fallback_type))
+  end
+
+  def normalize({type, message}, _fallback_type, _fallback_message, extra_details)
+      when is_atom(type) and is_binary(message) and is_map(extra_details) do
+    error_envelope(type, message, extra_details, retryable_type?(type))
+  end
+
+  def normalize({:error, reason}, fallback_type, fallback_message, extra_details)
+      when is_map(extra_details) do
+    normalize(reason, fallback_type, fallback_message, extra_details)
+  end
+
+  def normalize({:unknown_tool, message}, _fallback_type, _fallback_message, extra_details)
+      when is_binary(message) and is_map(extra_details) do
+    error_envelope(:unknown_tool, message, extra_details, false)
+  end
+
+  def normalize({:validation, details}, _fallback_type, _fallback_message, extra_details)
+      when is_map(extra_details) do
+    error_envelope(
+      :validation,
+      "Tool validation failed",
+      merge_error_details(%{details: details}, extra_details),
+      false
+    )
+  end
+
+  def normalize({:timeout, details}, _fallback_type, _fallback_message, extra_details)
+      when is_map(details) and is_map(extra_details) do
+    error_envelope(:timeout, "Tool execution timed out", merge_error_details(details, extra_details), true)
+  end
+
+  def normalize(:timeout, _fallback_type, _fallback_message, extra_details) when is_map(extra_details) do
+    error_envelope(:timeout, "Tool execution timed out", extra_details, true)
+  end
+
+  def normalize(reason, fallback_type, _fallback_message, extra_details)
+      when is_atom(reason) and is_map(extra_details) do
+    error_envelope(
+      fallback_type,
+      Atom.to_string(reason),
+      merge_error_details(%{reason: reason}, extra_details),
+      retryable_type?(reason)
+    )
+  end
+
+  def normalize(reason, fallback_type, fallback_message, extra_details) when is_map(extra_details) do
+    error_envelope(
+      fallback_type,
+      fallback_message,
+      merge_error_details(%{reason: inspect(reason)}, extra_details),
+      retryable_type?(fallback_type)
+    )
+  end
+
+  @doc """
+  Serializes a runtime error term as the canonical AI runtime error map.
+  """
+  @spec to_map(term()) :: error_envelope()
+  def to_map(reason), do: normalize(reason)
+
+  @doc """
+  Ensures result payloads use `{:ok, term, effects}` or `{:error, reason, effects}` tuples.
+  """
+  @spec normalize_result(term(), atom(), String.t()) ::
+          {:ok, term(), [term()]} | {:error, error_envelope(), [term()]}
+  def normalize_result(result, fallback_type \\ :invalid_result, fallback_message \\ "Invalid result envelope")
+
+  def normalize_result({:ok, value, effects}, _fallback_type, _fallback_message),
+    do: {:ok, value, List.wrap(effects)}
+
+  def normalize_result({:ok, value}, _fallback_type, _fallback_message), do: {:ok, value, []}
+
+  def normalize_result({:error, reason, effects}, fallback_type, fallback_message),
+    do: {:error, normalize(reason, fallback_type, fallback_message), List.wrap(effects)}
+
+  def normalize_result({:error, reason}, fallback_type, fallback_message),
+    do: {:error, normalize(reason, fallback_type, fallback_message), []}
+
+  def normalize_result(result, fallback_type, fallback_message) do
+    {:error, error_envelope(fallback_type, fallback_message, %{result: inspect(result)}), []}
+  end
+
+  @doc """
+  Returns whether a result or error should be treated as retryable by runtime policy.
+  """
+  @spec retryable?(term()) :: boolean()
+  def retryable?({:ok, _, _}), do: false
+  def retryable?({:ok, _}), do: false
+  def retryable?({:error, reason, _effects}), do: retryable?(reason)
+  def retryable?({:error, reason}), do: retryable?(reason)
+  def retryable?(%{retryable?: value}) when is_boolean(value), do: value
+  def retryable?(%{retryable: value}) when is_boolean(value), do: value
+  def retryable?(%{type: type} = error) when is_atom(type), do: retryable_hint(error, retryable_type?(type))
+  def retryable?(%{code: type} = error) when is_atom(type), do: retryable_hint(error, retryable_type?(type))
+  def retryable?(reason) when is_atom(reason), do: retryable_type?(reason)
+  def retryable?(_reason), do: false
+
+  defp merge_error_details(details, extra_details) when is_map(details) and is_map(extra_details) do
+    Map.merge(details, extra_details)
+    |> normalize_json_safe_map()
+  end
+
+  defp normalize_json_safe_map(map) when is_map(map) do
+    Map.new(map, fn {key, value} ->
+      {normalize_json_safe_key(key), normalize_json_safe_value(value)}
+    end)
+  end
+
+  defp normalize_json_safe_key(key) when is_binary(key), do: key
+  defp normalize_json_safe_key(key) when is_atom(key), do: key
+  defp normalize_json_safe_key(key), do: inspect(key)
+
+  defp normalize_json_safe_value(value) when is_nil(value), do: nil
+  defp normalize_json_safe_value(value) when is_boolean(value), do: value
+  defp normalize_json_safe_value(value) when is_integer(value), do: value
+  defp normalize_json_safe_value(value) when is_float(value), do: value
+  defp normalize_json_safe_value(value) when is_binary(value), do: value
+  defp normalize_json_safe_value(value) when is_atom(value), do: value
+
+  defp normalize_json_safe_value(value) when is_list(value) do
+    Enum.map(value, &normalize_json_safe_value/1)
+  end
+
+  defp normalize_json_safe_value(%_{} = struct) do
+    struct
+    |> Map.from_struct()
+    |> normalize_json_safe_map()
+  end
+
+  defp normalize_json_safe_value(value) when is_map(value) do
+    normalize_json_safe_map(value)
+  end
+
+  defp normalize_json_safe_value(value), do: inspect(value)
+
+  defp normalize_retryable(error, type) do
+    cond do
+      is_boolean(Map.get(error, :retryable?)) -> Map.get(error, :retryable?)
+      is_boolean(Map.get(error, :retryable)) -> Map.get(error, :retryable)
+      true -> retryable_hint(error, retryable_type?(type))
+    end
+  end
+
+  defp normalize_message(message) when is_binary(message), do: message
+  defp normalize_message(message) when is_atom(message), do: Atom.to_string(message)
+  defp normalize_message(nil), do: "Execution failed"
+  defp normalize_message(message), do: inspect(message)
+
+  defp jido_error_struct?(module) do
+    module_name = Atom.to_string(module)
+
+    String.starts_with?(module_name, [
+      "Elixir.Jido.Action.Error.",
+      "Elixir.Jido.Error."
+    ])
+  end
+
+  defp retryable_hint(term, default) do
+    case extract_retry_hint(term) do
+      nil -> default
+      value -> value != false
+    end
+  end
+
+  defp extract_retry_hint(%{details: details} = error) do
+    case extract_retry_value(details) do
+      nil ->
+        details
+        |> extract_nested_reason()
+        |> Kernel.||(extract_nested_reason(error))
+        |> extract_retry_hint()
+
+      value ->
+        value
+    end
+  end
+
+  defp extract_retry_hint(%{} = map) do
+    case extract_retry_value(map) do
+      nil -> map |> extract_nested_reason() |> extract_retry_hint()
+      value -> value
+    end
+  end
+
+  defp extract_retry_hint(nil), do: nil
+  defp extract_retry_hint(reason) when is_atom(reason), do: retryable_type?(reason)
+  defp extract_retry_hint(_), do: nil
+
+  defp extract_nested_reason(%{} = map) do
+    map[:reason] ||
+      if(is_atom(map[:message]), do: map[:message], else: nil)
+  end
+
+  defp extract_nested_reason(_), do: nil
+
+  defp extract_retry_value(%{} = map) do
+    cond do
+      Map.has_key?(map, :retry) -> map[:retry]
+      true -> nil
+    end
+  end
+
+  defp extract_retry_value(keyword) when is_list(keyword) do
+    if Keyword.keyword?(keyword), do: Keyword.get(keyword, :retry), else: nil
+  end
+
+  defp extract_retry_value(_), do: nil
+
+  defp retryable_type?(type) when type in [:timeout, :transient, :transient_error, :rate_limited], do: true
+  defp retryable_type?(_type), do: false
 end
 
 defmodule Jido.AI.Error.API do

--- a/lib/jido_ai/error.ex
+++ b/lib/jido_ai/error.ex
@@ -61,8 +61,32 @@ defmodule Jido.AI.Error do
     )
   end
 
+  def normalize(%{type: type, message: message} = error, fallback_type, _fallback_message, extra_details)
+      when is_binary(type) and is_map(extra_details) do
+    type = normalize_type(type, fallback_type)
+
+    error_envelope(
+      type,
+      normalize_message(message),
+      merge_error_details(error_details(error), extra_details),
+      normalize_retryable(error, type)
+    )
+  end
+
   def normalize(%{code: type, message: message} = error, _fallback_type, _fallback_message, extra_details)
       when is_atom(type) and is_map(extra_details) do
+    error_envelope(
+      type,
+      normalize_message(message),
+      merge_error_details(error_details(error), extra_details),
+      normalize_retryable(error, type)
+    )
+  end
+
+  def normalize(%{code: type, message: message} = error, fallback_type, _fallback_message, extra_details)
+      when is_binary(type) and is_map(extra_details) do
+    type = normalize_type(type, fallback_type)
+
     error_envelope(
       type,
       normalize_message(message),
@@ -219,6 +243,8 @@ defmodule Jido.AI.Error do
   def retryable?(%{"retryable" => value}) when is_boolean(value), do: value
   def retryable?(%{type: type} = error) when is_atom(type), do: retryable_hint(error, retryable_type?(type))
   def retryable?(%{code: type} = error) when is_atom(type), do: retryable_hint(error, retryable_type?(type))
+  def retryable?(%{type: type} = error) when is_binary(type), do: retryable_from_string_type(error, type)
+  def retryable?(%{code: type} = error) when is_binary(type), do: retryable_from_string_type(error, type)
   def retryable?(%{"type" => type} = error) when is_binary(type), do: retryable_from_string_type(error, type)
   def retryable?(%{"code" => type} = error) when is_binary(type), do: retryable_from_string_type(error, type)
   def retryable?(reason) when is_atom(reason), do: retryable_type?(reason)
@@ -347,8 +373,15 @@ defmodule Jido.AI.Error do
   end
 
   defp retry_hint_truthy?(false), do: false
-  defp retry_hint_truthy?("false"), do: false
-  defp retry_hint_truthy?("0"), do: false
+  defp retry_hint_truthy?(0), do: false
+
+  defp retry_hint_truthy?(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.downcase()
+    |> then(&(&1 not in ["", "0", "false", "no", "off"]))
+  end
+
   defp retry_hint_truthy?(_), do: true
 
   defp extract_retry_hint(%{details: details} = error) do

--- a/lib/jido_ai/plugins/policy.ex
+++ b/lib/jido_ai/plugins/policy.ex
@@ -41,6 +41,7 @@ defmodule Jido.AI.Plugins.Policy do
     vsn: "1.0.0"
 
   alias Jido.AI.Signal
+  alias Jido.AI.Error
   alias Jido.AI.Signal.Helpers, as: SignalHelpers
   alias Jido.AI.Validation
   alias Jido.Signal, as: BaseSignal
@@ -153,7 +154,7 @@ defmodule Jido.AI.Plugins.Policy do
     normalized =
       data
       |> Map.get(:result, Map.get(data, "result"))
-      |> SignalHelpers.normalize_result(:malformed_result, "Malformed result envelope")
+      |> Error.normalize_result(:malformed_result, "Malformed result envelope")
 
     put_signal_data(signal, Map.put(data, :result, normalized))
   end

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -12,7 +12,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   alias Jido.AI.Reasoning.ReAct.{Config, Event, PendingToolCall, State, Token, ToolSelection}
   alias Jido.AI.Effects
   alias Jido.AI.Context, as: AIContext
-  alias Jido.AI.Signal.Helpers, as: SignalHelpers
+  alias Jido.AI.Error
   alias Jido.AI.Turn
   alias Jido.Agent.State, as: AgentState
 
@@ -906,7 +906,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     max_retries = normalize_retry_count(config.tool_exec[:max_retries])
     backoff_ms = normalize_backoff(config.tool_exec[:retry_backoff_ms])
 
-    case SignalHelpers.retryable?(result) and attempt <= max_retries do
+    case Error.retryable?(result) and attempt <= max_retries do
       true ->
         case backoff_ms > 0 do
           true -> Process.sleep(backoff_ms)

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -48,7 +48,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   alias Jido.AI.Reasoning.ReAct.Config, as: ReActRuntimeConfig
   alias Jido.AI.Reasoning.ReAct.ToolSelection
   alias Jido.AI.Signal
-  alias Jido.AI.Signal.Helpers, as: SignalHelpers
+  alias Jido.AI.Error
   alias Jido.AI.Reasoning.Helpers
   alias Jido.AI.Context, as: AIContext
   alias Jido.AI.ToolAdapter
@@ -2409,7 +2409,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     |> Map.get(:effect_policy, Effects.default_policy())
   end
 
-  defp normalize_tool_result(result), do: SignalHelpers.normalize_result(result, :tool_error, "Tool execution failed")
+  defp normalize_tool_result(result), do: Error.normalize_result(result, :tool_error, "Tool execution failed")
 
   defp request_stream_to(agent, request_id) when is_binary(request_id) do
     get_in(agent.state, [:requests, request_id, :stream_to])

--- a/lib/jido_ai/reasoning/tree_of_thoughts/strategy.ex
+++ b/lib/jido_ai/reasoning/tree_of_thoughts/strategy.ex
@@ -73,7 +73,7 @@ defmodule Jido.AI.Reasoning.TreeOfThoughts.Strategy do
   alias Jido.AI.Directive
   alias Jido.AI.Effects
   alias Jido.AI.Reasoning.Helpers
-  alias Jido.AI.Signal.Helpers, as: SignalHelpers
+  alias Jido.AI.Error
   alias Jido.AI.Reasoning.TreeOfThoughts.Machine
   alias Jido.AI.ToolAdapter
   alias Jido.AI.Turn
@@ -918,7 +918,7 @@ defmodule Jido.AI.Reasoning.TreeOfThoughts.Strategy do
   defp normalize_map_opt({:%{}, _meta, pairs}) when is_list(pairs), do: Map.new(pairs)
   defp normalize_map_opt(_), do: %{}
 
-  defp normalize_tool_result(result), do: SignalHelpers.normalize_result(result, :tool_error, "Tool execution failed")
+  defp normalize_tool_result(result), do: Error.normalize_result(result, :tool_error, "Tool execution failed")
 
   defp generate_call_id, do: Machine.generate_call_id()
 

--- a/lib/jido_ai/signals/helpers.ex
+++ b/lib/jido_ai/signals/helpers.ex
@@ -1,193 +1,57 @@
 defmodule Jido.AI.Signal.Helpers do
   @moduledoc """
-  Shared helpers for signal correlation and standardized AI runtime error envelopes.
-
-  The envelope defined here is owned by `jido_ai`. Upstream packages such as
-  `jido_action` should expose only generic error information and retryability;
-  they are adapted to the AI runtime contract at this boundary.
+  Shared helpers for signal correlation and signal-safe payload shaping.
   """
 
+  alias Jido.AI.Error
   alias Jido.Signal
 
-  @type error_envelope :: %{
-          type: atom(),
-          message: String.t(),
-          details: map(),
-          retryable?: boolean()
-        }
+  @type error_envelope :: Error.error_envelope()
 
   @doc """
-  Builds a normalized error envelope for signal payloads.
+  Builds a normalized AI runtime error envelope.
+
+  Prefer `Jido.AI.Error.error_envelope/4` for new runtime code.
   """
+  @deprecated "Use Jido.AI.Error.error_envelope/4"
   @spec error_envelope(atom(), String.t(), map(), boolean()) :: error_envelope()
-  def error_envelope(type, message, details \\ %{}, retryable? \\ false)
-      when is_atom(type) and is_binary(message) and is_map(details) and is_boolean(retryable?) do
-    %{
-      type: type,
-      message: message,
-      details: normalize_json_safe_map(details),
-      retryable?: retryable?
-    }
-  end
+  defdelegate error_envelope(type, message, details \\ %{}, retryable? \\ false), to: Error
 
   @doc """
   Normalizes arbitrary error values into the canonical AI error envelope.
+
+  Prefer `Jido.AI.Error.normalize/4` for new runtime code.
   """
+  @deprecated "Use Jido.AI.Error.normalize/4"
   @spec normalize_error(term(), atom(), String.t(), map()) :: error_envelope()
   def normalize_error(
         reason,
         fallback_type \\ :execution_error,
         fallback_message \\ "Execution failed",
         extra_details \\ %{}
-      )
-
-  def normalize_error(%{type: type, message: message} = error, _fallback_type, _fallback_message, extra_details)
-      when is_atom(type) and is_map(extra_details) do
-    error_envelope(
-      type,
-      normalize_message(message),
-      merge_error_details(Map.get(error, :details, %{}), extra_details),
-      normalize_retryable(error, type)
-    )
-  end
-
-  def normalize_error(%{code: type, message: message} = error, _fallback_type, _fallback_message, extra_details)
-      when is_atom(type) and is_map(extra_details) do
-    error_envelope(
-      type,
-      normalize_message(message),
-      merge_error_details(Map.get(error, :details, %{}), extra_details),
-      normalize_retryable(error, type)
-    )
-  end
-
-  def normalize_error(%module{} = reason, fallback_type, fallback_message, extra_details)
-      when is_map(extra_details) do
-    cond do
-      Code.ensure_loaded?(Jido.Error) and function_exported?(Jido.Error, :to_map, 1) and
-          function_exported?(module, :message, 1) ->
-        reason
-        |> Jido.Error.to_map()
-        |> Map.drop([:stacktrace])
-        |> normalize_error(fallback_type, fallback_message, extra_details)
-
-      is_exception(reason) ->
-        error_envelope(
-          fallback_type,
-          Exception.message(reason),
-          merge_error_details(Map.from_struct(reason), extra_details),
-          false
-        )
-
-      true ->
-        error_envelope(
-          fallback_type,
-          fallback_message,
-          merge_error_details(%{reason: inspect(reason)}, extra_details),
-          false
-        )
-    end
-  end
-
-  def normalize_error(%{message: message} = error, fallback_type, _fallback_message, extra_details)
-      when not is_nil(message) and is_map(extra_details) do
-    details =
-      error
-      |> Map.drop([:message, :retryable, :retryable?])
-      |> merge_error_details(extra_details)
-
-    error_envelope(fallback_type, normalize_message(message), details, normalize_retryable(error, fallback_type))
-  end
-
-  def normalize_error({type, message}, _fallback_type, _fallback_message, extra_details)
-      when is_atom(type) and is_binary(message) and is_map(extra_details) do
-    error_envelope(type, message, extra_details, retryable_type?(type))
-  end
-
-  def normalize_error({:error, reason}, fallback_type, fallback_message, extra_details)
-      when is_map(extra_details) do
-    normalize_error(reason, fallback_type, fallback_message, extra_details)
-  end
-
-  def normalize_error({:unknown_tool, message}, _fallback_type, _fallback_message, extra_details)
-      when is_binary(message) and is_map(extra_details) do
-    error_envelope(:unknown_tool, message, extra_details, false)
-  end
-
-  def normalize_error({:validation, details}, _fallback_type, _fallback_message, extra_details)
-      when is_map(extra_details) do
-    error_envelope(
-      :validation,
-      "Tool validation failed",
-      merge_error_details(%{details: details}, extra_details),
-      false
-    )
-  end
-
-  def normalize_error({:timeout, details}, _fallback_type, _fallback_message, extra_details)
-      when is_map(details) and is_map(extra_details) do
-    error_envelope(:timeout, "Tool execution timed out", merge_error_details(details, extra_details), true)
-  end
-
-  def normalize_error(:timeout, _fallback_type, _fallback_message, extra_details) when is_map(extra_details) do
-    error_envelope(:timeout, "Tool execution timed out", extra_details, true)
-  end
-
-  def normalize_error(reason, fallback_type, _fallback_message, extra_details)
-      when is_atom(reason) and is_map(extra_details) do
-    error_envelope(
-      fallback_type,
-      Atom.to_string(reason),
-      merge_error_details(%{reason: reason}, extra_details),
-      retryable_type?(reason)
-    )
-  end
-
-  def normalize_error(reason, fallback_type, fallback_message, extra_details) when is_map(extra_details) do
-    error_envelope(
-      fallback_type,
-      fallback_message,
-      merge_error_details(%{reason: inspect(reason)}, extra_details),
-      retryable_type?(fallback_type)
-    )
+      ) do
+    Error.normalize(reason, fallback_type, fallback_message, extra_details)
   end
 
   @doc """
   Ensures result payloads use `{:ok, term, effects}` or `{:error, reason, effects}` tuples.
+
+  Prefer `Jido.AI.Error.normalize_result/3` for new runtime code.
   """
+  @deprecated "Use Jido.AI.Error.normalize_result/3"
   @spec normalize_result(term(), atom(), String.t()) ::
           {:ok, term(), [term()]} | {:error, error_envelope(), [term()]}
-  def normalize_result(result, fallback_type \\ :invalid_result, fallback_message \\ "Invalid result envelope")
-
-  def normalize_result({:ok, value, effects}, _fallback_type, _fallback_message),
-    do: {:ok, value, List.wrap(effects)}
-
-  def normalize_result({:ok, value}, _fallback_type, _fallback_message), do: {:ok, value, []}
-
-  def normalize_result({:error, reason, effects}, fallback_type, fallback_message),
-    do: {:error, normalize_error(reason, fallback_type, fallback_message), List.wrap(effects)}
-
-  def normalize_result({:error, reason}, fallback_type, fallback_message),
-    do: {:error, normalize_error(reason, fallback_type, fallback_message), []}
-
-  def normalize_result(result, fallback_type, fallback_message) do
-    {:error, error_envelope(fallback_type, fallback_message, %{result: inspect(result)}), []}
-  end
+  defdelegate normalize_result(result, fallback_type \\ :invalid_result, fallback_message \\ "Invalid result envelope"),
+    to: Error
 
   @doc """
   Returns whether a result or error should be treated as retryable by runtime policy.
+
+  Prefer `Jido.AI.Error.retryable?/1` for new runtime code.
   """
+  @deprecated "Use Jido.AI.Error.retryable?/1"
   @spec retryable?(term()) :: boolean()
-  def retryable?({:ok, _, _}), do: false
-  def retryable?({:ok, _}), do: false
-  def retryable?({:error, reason, _effects}), do: retryable?(reason)
-  def retryable?({:error, reason}), do: retryable?(reason)
-  def retryable?(%{retryable?: value}) when is_boolean(value), do: value
-  def retryable?(%{retryable: value}) when is_boolean(value), do: value
-  def retryable?(%{type: type} = error) when is_atom(type), do: retryable_hint(error, retryable_type?(type))
-  def retryable?(%{code: type} = error) when is_atom(type), do: retryable_hint(error, retryable_type?(type))
-  def retryable?(reason) when is_atom(reason), do: retryable_type?(reason)
-  def retryable?(_reason), do: false
+  defdelegate retryable?(reason), to: Error
 
   @doc """
   Extracts the best available request/call correlation identifier from signal data.
@@ -222,110 +86,4 @@ defmodule Jido.AI.Signal.Helpers do
   end
 
   defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
-
-  defp merge_error_details(details, extra_details) when is_map(details) and is_map(extra_details) do
-    Map.merge(details, extra_details)
-    |> normalize_json_safe_map()
-  end
-
-  defp normalize_json_safe_map(map) when is_map(map) do
-    Map.new(map, fn {key, value} ->
-      {normalize_json_safe_key(key), normalize_json_safe_value(value)}
-    end)
-  end
-
-  defp normalize_json_safe_key(key) when is_binary(key), do: key
-  defp normalize_json_safe_key(key) when is_atom(key), do: key
-  defp normalize_json_safe_key(key), do: inspect(key)
-
-  defp normalize_json_safe_value(value) when is_nil(value), do: nil
-  defp normalize_json_safe_value(value) when is_boolean(value), do: value
-  defp normalize_json_safe_value(value) when is_integer(value), do: value
-  defp normalize_json_safe_value(value) when is_float(value), do: value
-  defp normalize_json_safe_value(value) when is_binary(value), do: value
-
-  defp normalize_json_safe_value(value) when is_atom(value), do: value
-
-  defp normalize_json_safe_value(value) when is_list(value) do
-    Enum.map(value, &normalize_json_safe_value/1)
-  end
-
-  defp normalize_json_safe_value(%_{} = struct) do
-    struct
-    |> Map.from_struct()
-    |> normalize_json_safe_map()
-  end
-
-  defp normalize_json_safe_value(value) when is_map(value) do
-    normalize_json_safe_map(value)
-  end
-
-  defp normalize_json_safe_value(value), do: inspect(value)
-
-  defp normalize_retryable(error, type) do
-    cond do
-      is_boolean(Map.get(error, :retryable?)) -> Map.get(error, :retryable?)
-      is_boolean(Map.get(error, :retryable)) -> Map.get(error, :retryable)
-      true -> retryable_hint(error, retryable_type?(type))
-    end
-  end
-
-  defp normalize_message(message) when is_binary(message), do: message
-  defp normalize_message(message) when is_atom(message), do: Atom.to_string(message)
-  defp normalize_message(nil), do: "Execution failed"
-  defp normalize_message(message), do: inspect(message)
-
-  defp retryable_hint(term, default) do
-    case extract_retry_hint(term) do
-      nil -> default
-      value -> value != false
-    end
-  end
-
-  defp extract_retry_hint(%{details: details} = error) do
-    case extract_retry_value(details) do
-      nil ->
-        details
-        |> extract_nested_reason()
-        |> Kernel.||(extract_nested_reason(error))
-        |> extract_retry_hint()
-
-      value ->
-        value
-    end
-  end
-
-  defp extract_retry_hint(%{} = map) do
-    case extract_retry_value(map) do
-      nil -> map |> extract_nested_reason() |> extract_retry_hint()
-      value -> value
-    end
-  end
-
-  defp extract_retry_hint(nil), do: nil
-  defp extract_retry_hint(reason) when is_atom(reason), do: retryable_type?(reason)
-  defp extract_retry_hint(_), do: nil
-
-  defp extract_nested_reason(%{} = map) do
-    map[:reason] ||
-      if(is_atom(map[:message]), do: map[:message], else: nil)
-  end
-
-  defp extract_nested_reason(_), do: nil
-
-  defp extract_retry_value(%{} = map) do
-    cond do
-      Map.has_key?(map, :retry) -> map[:retry]
-      true -> nil
-    end
-  end
-
-  defp extract_retry_value(keyword) when is_list(keyword) do
-    if Keyword.keyword?(keyword), do: Keyword.get(keyword, :retry), else: nil
-  end
-
-  defp extract_retry_value(_), do: nil
-
-  defp retryable_type?(type) when type in [:timeout, :transient, :transient_error, :rate_limited], do: true
-  defp retryable_type?(_type), do: false
 end

--- a/lib/jido_ai/turn.ex
+++ b/lib/jido_ai/turn.ex
@@ -12,8 +12,7 @@ defmodule Jido.AI.Turn do
   - Optional executed tool results
   """
 
-  alias Jido.AI.{Effects, Observe, ToolAdapter, Usage}
-  alias Jido.AI.Signal.Helpers, as: SignalHelpers
+  alias Jido.AI.{Effects, Error, Observe, ToolAdapter, Usage}
   alias Jido.Action.Error.TimeoutError
   alias Jido.Action.Tool, as: ActionTool
   alias ReqLLM.Context
@@ -197,7 +196,7 @@ defmodule Jido.AI.Turn do
 
         :error ->
           {:error,
-           SignalHelpers.error_envelope(
+           Error.error_envelope(
              :not_found,
              "Tool not found: #{tool_name}",
              %{tool_name: tool_name},
@@ -398,14 +397,14 @@ defmodule Jido.AI.Turn do
   def format_tool_result_content({:error, error}) do
     encode_tool_result_envelope(%{
       ok: false,
-      error: SignalHelpers.normalize_error(error, :execution_error, "Tool execution failed")
+      error: Error.normalize(error, :execution_error, "Tool execution failed")
     })
   end
 
   def format_tool_result_content(other) do
     encode_tool_result_envelope(%{
       ok: false,
-      error: SignalHelpers.error_envelope(:invalid_result, "Invalid tool result envelope", %{result: inspect(other)})
+      error: Error.error_envelope(:invalid_result, "Invalid tool result envelope", %{result: inspect(other)})
     })
   end
 
@@ -573,7 +572,7 @@ defmodule Jido.AI.Turn do
     timeout_ms = reason.timeout || timeout_from_details(reason.details)
     message = Exception.message(reason)
 
-    SignalHelpers.error_envelope(
+    Error.error_envelope(
       :timeout,
       message,
       %{tool_name: tool_name, timeout_ms: timeout_ms}
@@ -583,11 +582,11 @@ defmodule Jido.AI.Turn do
   end
 
   defp format_error(tool_name, reason) when is_exception(reason) do
-    SignalHelpers.normalize_error(reason, :execution_error, Exception.message(reason), %{tool_name: tool_name})
+    Error.normalize(reason, :execution_error, Exception.message(reason), %{tool_name: tool_name})
   end
 
   defp format_error(tool_name, reason) do
-    SignalHelpers.normalize_error(reason, :execution_error, "Tool execution failed", %{tool_name: tool_name})
+    Error.normalize(reason, :execution_error, "Tool execution failed", %{tool_name: tool_name})
   end
 
   defp format_exception(tool_name, exception, stacktrace) do
@@ -600,7 +599,7 @@ defmodule Jido.AI.Turn do
 
     message = Exception.message(exception)
 
-    SignalHelpers.error_envelope(
+    Error.error_envelope(
       :exception,
       message,
       %{tool_name: tool_name, exception_type: exception.__struct__},
@@ -611,7 +610,7 @@ defmodule Jido.AI.Turn do
   defp format_catch(tool_name, kind, reason) do
     message = "Caught #{kind}: #{inspect(reason)}"
 
-    SignalHelpers.error_envelope(
+    Error.error_envelope(
       :caught,
       message,
       %{tool_name: tool_name, kind: kind, reason: inspect(reason)},
@@ -747,7 +746,7 @@ defmodule Jido.AI.Turn do
     raw_result =
       case tool_name do
         "" ->
-          {:error, SignalHelpers.error_envelope(:validation, "Missing tool name"), []}
+          {:error, Error.error_envelope(:validation, "Missing tool name"), []}
 
         _ ->
           execute(tool_name, arguments, context, exec_opts)

--- a/test/jido_ai/error/model_test.exs
+++ b/test/jido_ai/error/model_test.exs
@@ -89,6 +89,17 @@ defmodule Jido.AI.Error.ModelTest do
              }
     end
 
+    test "normalizes atom-keyed envelopes with string type values" do
+      input = %{type: "timeout", message: "timed out", details: %{timeout_ms: 100}}
+
+      assert Error.normalize(input) == %{
+               type: :timeout,
+               message: "timed out",
+               details: %{timeout_ms: 100},
+               retryable?: true
+             }
+    end
+
     test "normalizes non-binary messages and preserves transient retry hints" do
       input = %{type: :execution_error, message: :transient_error, details: %{}}
 
@@ -239,7 +250,10 @@ defmodule Jido.AI.Error.ModelTest do
       assert Error.retryable?(%{type: :execution_error, message: :transient_error, details: %{}})
       assert Error.retryable?(%{"type" => "execution_error", "message" => "transient_error", "details" => %{}})
       assert Error.retryable?(%{type: :execution_error, details: %{"retry" => true}})
+      assert Error.retryable?(%{type: "timeout", details: %{}})
       refute Error.retryable?(%{type: :timeout, details: %{"retry" => "false"}})
+      refute Error.retryable?(%{type: :timeout, details: %{"retry" => " FALSE "}})
+      refute Error.retryable?(%{type: :timeout, details: %{"retry" => "off"}})
       refute Error.retryable?({:error, %{type: :execution_error}, []})
       refute Error.retryable?({:ok, :done, []})
     end

--- a/test/jido_ai/error/model_test.exs
+++ b/test/jido_ai/error/model_test.exs
@@ -3,6 +3,7 @@ defmodule Jido.AI.Error.ModelTest do
 
   alias Jido.Action.Error, as: ActionError
   alias Jido.AI.Error
+  alias Jido.Signal.Error, as: SignalError
 
   test "unknown error formats wrapped payload" do
     assert Error.Unknown.message(%Error.Unknown{error: {:bad_state, %{step: 2}}}) ==
@@ -95,6 +96,17 @@ defmodule Jido.AI.Error.ModelTest do
              }
     end
 
+    test "normalizes Jido.Signal error structs through Jido.Error.to_map/1" do
+      error = SignalError.timeout_error("dispatch timed out", %{timeout: 50, retry: true})
+
+      assert Error.normalize(error) == %{
+               type: :timeout,
+               message: "dispatch timed out",
+               details: %{timeout: 50, retry: true},
+               retryable?: true
+             }
+    end
+
     test "normalizes supervisor failures without changing the public envelope shape" do
       assert Error.normalize(
                %{
@@ -155,6 +167,20 @@ defmodule Jido.AI.Error.ModelTest do
       assert is_binary(envelope.details.ref)
       assert is_binary(envelope.details.tuple)
       assert is_binary(envelope.details.nested.inner)
+      assert Jason.encode!(envelope)
+    end
+
+    test "wraps malformed details payloads without crashing normalization" do
+      envelope =
+        Error.normalize(%{
+          type: :execution_error,
+          message: "boom",
+          details: {:bad_details, self()}
+        })
+
+      assert envelope.type == :execution_error
+      assert envelope.message == "boom"
+      assert is_binary(envelope.details.details)
       assert Jason.encode!(envelope)
     end
 

--- a/test/jido_ai/error/model_test.exs
+++ b/test/jido_ai/error/model_test.exs
@@ -1,6 +1,7 @@
 defmodule Jido.AI.Error.ModelTest do
   use ExUnit.Case, async: true
 
+  alias Jido.Action.Error, as: ActionError
   alias Jido.AI.Error
 
   test "unknown error formats wrapped payload" do
@@ -46,6 +47,155 @@ defmodule Jido.AI.Error.ModelTest do
                "Invalid field: prompt"
 
       assert Error.Validation.Invalid.message(%Error.Validation.Invalid{}) == "Validation error"
+    end
+  end
+
+  describe "runtime envelope normalization" do
+    test "passes through ok and error tuples and wraps invalid values" do
+      assert Error.normalize_result({:ok, 1}) == {:ok, 1, []}
+
+      assert Error.normalize_result({:error, %{code: :x, message: "boom"}}) ==
+               {:error, %{type: :x, message: "boom", details: %{}, retryable?: false}, []}
+
+      assert {:error, envelope, []} = Error.normalize_result(:bad, :invalid_result, "Bad result")
+      assert envelope.type == :invalid_result
+      assert envelope.retryable? == false
+    end
+
+    test "normalizes structs and retryable aliases into the canonical envelope" do
+      input = %{code: :timeout, message: "timed out", details: %{timeout_ms: 100}, retryable: true}
+
+      assert Error.normalize(input) == %{
+               type: :timeout,
+               message: "timed out",
+               details: %{timeout_ms: 100},
+               retryable?: true
+             }
+    end
+
+    test "normalizes non-binary messages and preserves transient retry hints" do
+      input = %{type: :execution_error, message: :transient_error, details: %{}}
+
+      assert Error.normalize(input) == %{
+               type: :execution_error,
+               message: "transient_error",
+               details: %{},
+               retryable?: true
+             }
+    end
+
+    test "normalizes Jido.Action error structs through Jido.Error.to_map/1" do
+      error = ActionError.execution_error("boom", %{step: :list, retry: false})
+
+      assert Error.normalize(error) == %{
+               type: :execution_error,
+               message: "boom",
+               details: %{step: :list, retry: false},
+               retryable?: false
+             }
+    end
+
+    test "normalizes supervisor failures without changing the public envelope shape" do
+      assert Error.normalize(
+               %{
+                 type: :supervisor,
+                 message: "Failed to start LLM task",
+                 details: %{reason: ":noproc"},
+                 retryable?: true
+               },
+               :llm_error,
+               "LLM request failed"
+             ) == %{
+               type: :supervisor,
+               message: "Failed to start LLM task",
+               details: %{reason: ":noproc"},
+               retryable?: true
+             }
+    end
+
+    test "normalizes plain exceptions with caller fallback type and details" do
+      envelope = Error.normalize(RuntimeError.exception("boom"), :execution_error, "Tool execution failed")
+
+      assert envelope.type == :execution_error
+      assert envelope.message == "boom"
+      assert envelope.details.message == "boom"
+      assert envelope.retryable? == false
+    end
+
+    test "normalizes timeout atoms and timeout detail tuples as retryable" do
+      assert Error.normalize(:timeout) == %{
+               type: :timeout,
+               message: "Tool execution timed out",
+               details: %{},
+               retryable?: true
+             }
+
+      assert Error.normalize({:timeout, %{timeout_ms: 50}}) == %{
+               type: :timeout,
+               message: "Tool execution timed out",
+               details: %{timeout_ms: 50},
+               retryable?: true
+             }
+    end
+
+    test "normalizes details into JSON-safe values" do
+      envelope =
+        Error.normalize(%{
+          type: :execution_error,
+          message: "boom",
+          details: %{
+            pid: self(),
+            ref: make_ref(),
+            tuple: {:error, :bad},
+            nested: %{inner: {:ok, :value}}
+          }
+        })
+
+      assert is_binary(envelope.details.pid)
+      assert is_binary(envelope.details.ref)
+      assert is_binary(envelope.details.tuple)
+      assert is_binary(envelope.details.nested.inner)
+      assert Jason.encode!(envelope)
+    end
+
+    test "error_envelope/4 sanitizes direct details payloads" do
+      envelope =
+        Error.error_envelope(:execution_error, "boom", %{
+          pid: self(),
+          ref: make_ref(),
+          tuple: {:error, :bad},
+          map_key: %{1 => :one}
+        })
+
+      assert is_binary(envelope.details.pid)
+      assert is_binary(envelope.details.ref)
+      assert is_binary(envelope.details.tuple)
+      assert envelope.details.map_key["1"] == :one
+      assert Jason.encode!(envelope)
+    end
+
+    test "to_map/1 serializes any error as the canonical envelope" do
+      assert Error.to_map({:validation, %{field: :query}}) == %{
+               type: :validation,
+               message: "Tool validation failed",
+               details: %{details: %{field: :query}},
+               retryable?: false
+             }
+    end
+  end
+
+  describe "retryable?/1" do
+    test "uses canonical retryable flags first" do
+      assert Error.retryable?(%{type: :execution_error, retryable?: true})
+      refute Error.retryable?(%{type: :timeout, retryable?: false})
+    end
+
+    test "handles tuple results and conservative fallback types" do
+      assert Error.retryable?({:error, %{type: :timeout}, []})
+      assert Error.retryable?(:transient)
+      assert Error.retryable?(%{type: :execution_error, message: :transient_error, details: %{}})
+      refute Error.retryable?({:error, %{type: :execution_error}, []})
+      refute Error.retryable?({:ok, :done, []})
     end
   end
 end

--- a/test/jido_ai/error/model_test.exs
+++ b/test/jido_ai/error/model_test.exs
@@ -74,6 +74,21 @@ defmodule Jido.AI.Error.ModelTest do
              }
     end
 
+    test "normalizes string-keyed envelopes without changing the canonical shape" do
+      input = %{
+        "type" => "timeout",
+        "message" => "timed out",
+        "details" => %{"retry" => true, "timeout_ms" => 100}
+      }
+
+      assert Error.normalize(input) == %{
+               type: :timeout,
+               message: "timed out",
+               details: %{"retry" => true, "timeout_ms" => 100},
+               retryable?: true
+             }
+    end
+
     test "normalizes non-binary messages and preserves transient retry hints" do
       input = %{type: :execution_error, message: :transient_error, details: %{}}
 
@@ -159,6 +174,7 @@ defmodule Jido.AI.Error.ModelTest do
             pid: self(),
             ref: make_ref(),
             tuple: {:error, :bad},
+            improper_list: [1 | 2],
             nested: %{inner: {:ok, :value}}
           }
         })
@@ -166,6 +182,7 @@ defmodule Jido.AI.Error.ModelTest do
       assert is_binary(envelope.details.pid)
       assert is_binary(envelope.details.ref)
       assert is_binary(envelope.details.tuple)
+      assert is_binary(envelope.details.improper_list)
       assert is_binary(envelope.details.nested.inner)
       assert Jason.encode!(envelope)
     end
@@ -220,6 +237,9 @@ defmodule Jido.AI.Error.ModelTest do
       assert Error.retryable?({:error, %{type: :timeout}, []})
       assert Error.retryable?(:transient)
       assert Error.retryable?(%{type: :execution_error, message: :transient_error, details: %{}})
+      assert Error.retryable?(%{"type" => "execution_error", "message" => "transient_error", "details" => %{}})
+      assert Error.retryable?(%{type: :execution_error, details: %{"retry" => true}})
+      refute Error.retryable?(%{type: :timeout, details: %{"retry" => "false"}})
       refute Error.retryable?({:error, %{type: :execution_error}, []})
       refute Error.retryable?({:ok, :done, []})
     end

--- a/test/jido_ai/signal/helpers_test.exs
+++ b/test/jido_ai/signal/helpers_test.exs
@@ -2,89 +2,6 @@ defmodule Jido.AI.Signal.HelpersTest do
   use ExUnit.Case, async: true
 
   alias Jido.AI.Signal.Helpers
-  alias Jido.Action.Error, as: ActionError
-
-  describe "normalize_result/3" do
-    test "passes through ok and error tuples and wraps invalid values" do
-      assert Helpers.normalize_result({:ok, 1}) == {:ok, 1, []}
-
-      assert Helpers.normalize_result({:error, %{code: :x, message: "boom"}}) ==
-               {:error, %{type: :x, message: "boom", details: %{}, retryable?: false}, []}
-
-      assert {:error, envelope, []} = Helpers.normalize_result(:bad, :invalid_result, "Bad result")
-      assert envelope.type == :invalid_result
-      assert envelope.retryable? == false
-    end
-
-    test "normalizes structs and retryable aliases into the canonical envelope" do
-      input = %{code: :timeout, message: "timed out", details: %{timeout_ms: 100}, retryable: true}
-
-      assert Helpers.normalize_error(input) == %{
-               type: :timeout,
-               message: "timed out",
-               details: %{timeout_ms: 100},
-               retryable?: true
-             }
-    end
-
-    test "normalizes non-binary messages and preserves transient retry hints" do
-      input = %{type: :execution_error, message: :transient_error, details: %{}}
-
-      assert Helpers.normalize_error(input) == %{
-               type: :execution_error,
-               message: "transient_error",
-               details: %{},
-               retryable?: true
-             }
-    end
-
-    test "normalizes Jido.Action error structs through Jido.Error.to_map/1" do
-      error = ActionError.execution_error("boom", %{step: :list, retry: false})
-
-      assert Helpers.normalize_error(error) == %{
-               type: :execution_error,
-               message: "boom",
-               details: %{step: :list, retry: false},
-               retryable?: false
-             }
-    end
-
-    test "normalizes details into JSON-safe values" do
-      envelope =
-        Helpers.normalize_error(%{
-          type: :execution_error,
-          message: "boom",
-          details: %{
-            pid: self(),
-            ref: make_ref(),
-            tuple: {:error, :bad},
-            nested: %{inner: {:ok, :value}}
-          }
-        })
-
-      assert is_binary(envelope.details.pid)
-      assert is_binary(envelope.details.ref)
-      assert is_binary(envelope.details.tuple)
-      assert is_binary(envelope.details.nested.inner)
-      assert Jason.encode!(envelope)
-    end
-
-    test "error_envelope/4 sanitizes direct details payloads" do
-      envelope =
-        Helpers.error_envelope(:execution_error, "boom", %{
-          pid: self(),
-          ref: make_ref(),
-          tuple: {:error, :bad},
-          map_key: %{1 => :one}
-        })
-
-      assert is_binary(envelope.details.pid)
-      assert is_binary(envelope.details.ref)
-      assert is_binary(envelope.details.tuple)
-      assert envelope.details.map_key["1"] == :one
-      assert Jason.encode!(envelope)
-    end
-  end
 
   describe "correlation_id/1" do
     test "prefers request_id then call_id then run_id then id" do
@@ -93,21 +10,6 @@ defmodule Jido.AI.Signal.HelpersTest do
       assert Helpers.correlation_id(%{run_id: "run_1"}) == "run_1"
       assert Helpers.correlation_id(%{"id" => "id_1"}) == "id_1"
       assert Helpers.correlation_id(nil) == nil
-    end
-  end
-
-  describe "retryable?/1" do
-    test "uses canonical retryable flags first" do
-      assert Helpers.retryable?(%{type: :execution_error, retryable?: true})
-      refute Helpers.retryable?(%{type: :timeout, retryable?: false})
-    end
-
-    test "handles tuple results and conservative fallback types" do
-      assert Helpers.retryable?({:error, %{type: :timeout}, []})
-      assert Helpers.retryable?(:transient)
-      assert Helpers.retryable?(%{type: :execution_error, message: :transient_error, details: %{}})
-      refute Helpers.retryable?({:error, %{type: :execution_error}, []})
-      refute Helpers.retryable?({:ok, :done, []})
     end
   end
 

--- a/test/jido_ai/signal/helpers_test.exs
+++ b/test/jido_ai/signal/helpers_test.exs
@@ -1,6 +1,7 @@
 defmodule Jido.AI.Signal.HelpersTest do
   use ExUnit.Case, async: true
 
+  alias Jido.AI.Error
   alias Jido.AI.Signal.Helpers
 
   describe "correlation_id/1" do
@@ -17,6 +18,21 @@ defmodule Jido.AI.Signal.HelpersTest do
     test "removes control bytes and truncates by max chars" do
       assert Helpers.sanitize_delta("abc" <> <<1>> <> "def", 10) == "abcdef"
       assert Helpers.sanitize_delta("abcdefghijklmnopqrstuvwxyz", 5) == "abcde"
+    end
+  end
+
+  describe "error compatibility delegates" do
+    test "forward to Jido.AI.Error" do
+      assert apply(Helpers, :error_envelope, [:execution_error, "boom", %{}, false]) ==
+               Error.error_envelope(:execution_error, "boom")
+
+      assert apply(Helpers, :normalize_error, [:timeout, :execution_error, "failed", %{}]) ==
+               Error.normalize(:timeout, :execution_error, "failed")
+
+      assert apply(Helpers, :normalize_result, [{:error, :timeout}, :tool_error, "failed"]) ==
+               Error.normalize_result({:error, :timeout}, :tool_error, "failed")
+
+      assert apply(Helpers, :retryable?, [:timeout])
     end
   end
 end


### PR DESCRIPTION
## Summary
- move AI runtime error envelope normalization, serialization, result tuple normalization, and retryability policy into Jido.AI.Error
- keep Signal.Helpers focused on signal correlation/delta shaping, with compatibility delegates for existing callers
- update tool, LLM, directive, policy, and strategy runtime paths to call Jido.AI.Error directly
- document the runtime error boundary APIs in the developer error model guide

Closes #264

## Testing
- mix compile --warnings-as-errors
- mix test test/jido_ai/error/model_test.exs test/jido_ai/signal/helpers_test.exs test/jido_ai/directive/exec_runtime_test.exs test/jido_ai/turn_test.exs test/jido_ai/react/runtime_runner_test.exs
- mix credo --min-priority high --all
- mix test test/jido_ai/error/model_test.exs test/jido_ai/signal/helpers_test.exs test/jido_ai/directive/exec_runtime_test.exs test/jido_ai/directive/deadlock_prevention_test.exs test/jido_ai/turn_test.exs test/jido_ai/react/runtime_runner_test.exs test/jido_ai/strategy/react_test.exs test/jido_ai/strategy/tree_of_thoughts_test.exs
- mix precommit
- mix test
- mix docs (passes with existing ReqLLM.ContentPart.file_id/3 docs warning until the matching ReqLLM release is available)