### PR TITLE
fix(observe): bound telemetry and transport payloads

### DIFF
--- a/guides/user/observability_basics.md
+++ b/guides/user/observability_basics.md
@@ -30,7 +30,7 @@ obs_cfg = %{emit_telemetry?: true, emit_llm_deltas?: false}
   )
 ```
 
-`Observe` normalizes required metadata/measurement keys before emit.
+`Observe` normalizes required metadata/measurement keys before emit. Metadata also passes through the telemetry sanitizer boundary: sensitive keys are redacted, large nested values are bounded, and payload-shaped fields such as `result`, `output`, `content`, `messages`, or raw provider responses are summarized instead of emitted as raw blobs.
 
 Required metadata keys:
 `agent_id`, `request_id`, `run_id`, `iteration`, `llm_call_id`, `tool_call_id`, `tool_name`, `model`, `termination_reason`, `error_type`.
@@ -50,6 +50,27 @@ Required measurement keys:
   nil
 )
 ```
+
+## Sanitizer Profiles
+
+Use `Observe.sanitize_telemetry_metadata/1` for event metadata and `Observe.sanitize_transport_payload/1` before JSON/public transport encoding.
+
+```elixir
+metadata =
+  Observe.sanitize_telemetry_metadata(%{
+    request_id: "req-42",
+    api_key: "secret",
+    result: {:ok, %{large_payload: String.duplicate("x", 10_000)}, []}
+  })
+
+payload =
+  Observe.sanitize_transport_payload(%{
+    ok: true,
+    result: %{token: "secret", value: {:not_json_safe, self()}}
+  })
+```
+
+`sanitize_sensitive/1` remains available when you only need recursive key-based redaction.
 
 ## Telemetry + Signal Example
 
@@ -73,7 +94,7 @@ metadata =
 :ok = Observe.emit(%{emit_telemetry?: true}, Observe.request(:start), %{duration_ms: 0}, metadata)
 ```
 
-Use `Observe.sanitize_sensitive/1` before attaching user/tool payloads to telemetry metadata.
+Prefer `Observe.sanitize_telemetry_metadata/1` before attaching user/tool payloads to telemetry metadata. Direct `Observe.emit/5` calls apply that profile automatically.
 
 ## Enable/Disable Behavior
 

--- a/guides/user/turn_and_tool_results.md
+++ b/guides/user/turn_and_tool_results.md
@@ -265,7 +265,7 @@ Tool execution emits `:telemetry` events via `Jido.AI.Observe`:
 | Event | Path | Measurements | Key Metadata |
 |---|---|---|---|
 | start | `[:jido, :ai, :tool, :execute, :start]` | `system_time` | `tool_name`, `params`, `call_id`, `run_id`, `agent_id`, `iteration` |
-| stop | `[:jido, :ai, :tool, :execute, :stop]` | `duration_ms`, `duration` | `tool_name`, `result`, `call_id`, `run_id`, `agent_id`, `thread_id` |
+| stop | `[:jido, :ai, :tool, :execute, :stop]` | `duration_ms`, `duration` | `tool_name`, `result` summary, `call_id`, `run_id`, `agent_id`, `thread_id` |
 | exception | `[:jido, :ai, :tool, :execute, :exception]` | `duration_ms`, `duration` | `tool_name`, `reason`, `call_id`, `run_id`, `agent_id`, `thread_id` |
 
 Subscribe example:
@@ -281,7 +281,7 @@ Subscribe example:
 )
 ```
 
-Sensitive parameters are sanitized via `Observe.sanitize_sensitive/1` before emission.
+Telemetry metadata is passed through `Observe.sanitize_telemetry_metadata/1` before emission. Sensitive parameters are redacted, large nested values are bounded, and tool `result` metadata is retained as a low-cardinality summary rather than the raw result blob. Tool-result content sent back through the model/tool transport is encoded through `Observe.sanitize_transport_payload/1` so arbitrary action outputs become bounded JSON-safe data.
 
 ## Failure Mode: Tool Not Found
 

--- a/lib/jido_ai/observe.ex
+++ b/lib/jido_ai/observe.ex
@@ -9,8 +9,10 @@ defmodule Jido.AI.Observe do
   - Feature-gated event emission
   - Span lifecycle wrappers that honor AI observability config
   - Sensitive value redaction helpers for telemetry payloads
+  - Bounded telemetry and transport-safe payload shaping
   """
 
+  alias Jido.AI.Observe.Sanitize
   alias Jido.Observe, as: CoreObserve
 
   require Logger
@@ -40,34 +42,13 @@ defmodule Jido.AI.Observe do
     :queue_ms
   ]
 
-  @sensitive_exact_keys MapSet.new([
-                          "api_key",
-                          "apikey",
-                          "password",
-                          "secret",
-                          "token",
-                          "auth_token",
-                          "authtoken",
-                          "private_key",
-                          "privatekey",
-                          "access_key",
-                          "accesskey",
-                          "bearer",
-                          "api_secret",
-                          "apisecret",
-                          "client_secret",
-                          "clientsecret"
-                        ])
-
-  @sensitive_contains ["secret_"]
-  @sensitive_suffixes ["_secret", "_key", "_token", "_password"]
-
   @type obs_cfg :: map() | nil
   @type event_name :: [atom()]
   @type measurements :: map()
   @type metadata :: map()
   @type span_ctx :: CoreObserve.span_ctx() | :noop
   @type feature_gate :: :llm_deltas
+  @type sanitize_profile :: Sanitize.profile()
 
   @doc """
   Builds an LLM telemetry event path under `[:jido, :ai, :llm, ...]`.
@@ -126,6 +107,7 @@ defmodule Jido.AI.Observe do
         metadata
         |> ensure_required_metadata()
         |> enrich_with_trace_metadata()
+        |> sanitize_telemetry_metadata()
       )
     end
 
@@ -150,6 +132,7 @@ defmodule Jido.AI.Observe do
         metadata
         |> ensure_required_metadata()
         |> enrich_with_trace_metadata()
+        |> sanitize_telemetry_metadata()
       )
     else
       :noop
@@ -200,18 +183,32 @@ defmodule Jido.AI.Observe do
   Redacts sensitive keys recursively for telemetry-safe payloads.
   """
   @spec sanitize_sensitive(term()) :: term()
-  def sanitize_sensitive(payload) when is_map(payload) do
-    Map.new(payload, fn {key, value} ->
-      if sensitive_key?(key) do
-        {key, "[REDACTED]"}
-      else
-        {key, sanitize_sensitive(value)}
-      end
-    end)
-  end
+  defdelegate sanitize_sensitive(payload), to: Sanitize, as: :sensitive
 
-  def sanitize_sensitive(payload) when is_list(payload), do: Enum.map(payload, &sanitize_sensitive/1)
-  def sanitize_sensitive(payload), do: payload
+  @doc """
+  Sanitizes arbitrary payloads for a specific boundary profile.
+
+  The `:telemetry` profile keeps metadata low-cardinality by redacting
+  sensitive keys, truncating large values, and summarizing payload-shaped
+  fields such as results and provider responses.
+
+  The `:transport` profile preserves more payload detail while converting
+  arbitrary terms into bounded JSON-safe data.
+  """
+  @spec sanitize(term(), sanitize_profile(), keyword()) :: term()
+  defdelegate sanitize(payload, profile, opts \\ []), to: Sanitize
+
+  @doc """
+  Sanitizes event metadata before it crosses the telemetry boundary.
+  """
+  @spec sanitize_telemetry_metadata(term(), keyword()) :: term()
+  defdelegate sanitize_telemetry_metadata(metadata, opts \\ []), to: Sanitize, as: :telemetry_metadata
+
+  @doc """
+  Sanitizes a public/tool payload into bounded JSON-safe data.
+  """
+  @spec sanitize_transport_payload(term(), keyword()) :: term()
+  defdelegate sanitize_transport_payload(payload, opts \\ []), to: Sanitize, as: :transport_payload
 
   defp emit_enabled?(obs_cfg, opts) do
     Map.get(obs_cfg, :emit_telemetry?, true) and feature_gate_enabled?(obs_cfg, Keyword.get(opts, :feature_gate))
@@ -258,16 +255,4 @@ defmodule Jido.AI.Observe do
         )
     end
   end
-
-  defp sensitive_key?(key) when is_atom(key), do: key |> Atom.to_string() |> sensitive_key?()
-
-  defp sensitive_key?(key) when is_binary(key) do
-    key = String.downcase(key)
-
-    MapSet.member?(@sensitive_exact_keys, key) or
-      Enum.any?(@sensitive_contains, &String.contains?(key, &1)) or
-      Enum.any?(@sensitive_suffixes, &String.ends_with?(key, &1))
-  end
-
-  defp sensitive_key?(_key), do: false
 end

--- a/lib/jido_ai/observe/sanitize.ex
+++ b/lib/jido_ai/observe/sanitize.ex
@@ -1,0 +1,376 @@
+defmodule Jido.AI.Observe.Sanitize do
+  @moduledoc """
+  Sanitizer boundary for AI telemetry and public/tool transport payloads.
+
+  The telemetry profile keeps metadata low-cardinality by redacting sensitive
+  keys, bounding nested values, and summarizing payload-shaped fields.
+
+  The transport profile preserves more payload detail while converting arbitrary
+  terms into bounded JSON-safe data.
+  """
+
+  @sensitive_exact_keys MapSet.new([
+                          "api_key",
+                          "apikey",
+                          "password",
+                          "secret",
+                          "token",
+                          "auth_token",
+                          "authtoken",
+                          "private_key",
+                          "privatekey",
+                          "access_key",
+                          "accesskey",
+                          "bearer",
+                          "api_secret",
+                          "apisecret",
+                          "client_secret",
+                          "clientsecret"
+                        ])
+
+  @sensitive_contains ["secret_"]
+  @sensitive_suffixes ["_secret", "_key", "_token", "_password"]
+
+  @redacted "[REDACTED]"
+  @truncated_key :__jido_ai_truncated__
+
+  @telemetry_payload_summary_keys MapSet.new([
+                                    :content,
+                                    "content",
+                                    :messages,
+                                    "messages",
+                                    :output,
+                                    "output",
+                                    :raw,
+                                    "raw",
+                                    :raw_result,
+                                    "raw_result",
+                                    :raw_response,
+                                    "raw_response",
+                                    :response,
+                                    "response",
+                                    :result,
+                                    "result"
+                                  ])
+
+  @telemetry_defaults %{
+    max_depth: 4,
+    max_list_items: 10,
+    max_map_entries: 32,
+    max_string_chars: 512,
+    max_inspect_chars: 512
+  }
+
+  @transport_defaults %{
+    max_depth: 8,
+    max_list_items: 100,
+    max_map_entries: 100,
+    max_string_chars: 16_384,
+    max_inspect_chars: 2_048
+  }
+
+  @type profile :: :telemetry | :transport
+
+  @doc """
+  Redacts sensitive keys recursively without changing payload shape otherwise.
+  """
+  @spec sensitive(term()) :: term()
+  def sensitive(payload) when is_map(payload) do
+    Map.new(payload, fn {key, value} ->
+      if sensitive_key?(key) do
+        {key, @redacted}
+      else
+        {key, sensitive(value)}
+      end
+    end)
+  end
+
+  def sensitive(payload) when is_list(payload) do
+    if proper_list?(payload), do: Enum.map(payload, &sensitive/1), else: inspect_limited(payload, 512)
+  end
+
+  def sensitive(payload), do: payload
+
+  @doc """
+  Sanitizes arbitrary payloads for a specific boundary profile.
+  """
+  @spec sanitize(term(), profile(), keyword()) :: term()
+  def sanitize(payload, profile, opts \\ [])
+
+  def sanitize(payload, :telemetry, opts) when is_list(opts) do
+    sanitize_value(payload, :telemetry, sanitize_opts(@telemetry_defaults, opts), 0)
+  end
+
+  def sanitize(payload, :transport, opts) when is_list(opts) do
+    sanitize_value(payload, :transport, sanitize_opts(@transport_defaults, opts), 0)
+  end
+
+  @doc """
+  Sanitizes event metadata before it crosses the telemetry boundary.
+  """
+  @spec telemetry_metadata(term(), keyword()) :: term()
+  def telemetry_metadata(metadata, opts \\ []), do: sanitize(metadata, :telemetry, opts)
+
+  @doc """
+  Sanitizes public/tool payloads into bounded JSON-safe data.
+  """
+  @spec transport_payload(term(), keyword()) :: term()
+  def transport_payload(payload, opts \\ []), do: sanitize(payload, :transport, opts)
+
+  defp sanitize_opts(defaults, opts) do
+    Enum.reduce(opts, defaults, fn
+      {key, value}, acc when is_map_key(acc, key) and is_integer(value) and value > 0 -> Map.put(acc, key, value)
+      _other, acc -> acc
+    end)
+  end
+
+  defp sanitize_value(value, _profile, _opts, _depth) when is_nil(value) or is_boolean(value) or is_number(value),
+    do: value
+
+  defp sanitize_value(value, _profile, _opts, _depth) when is_atom(value), do: value
+
+  defp sanitize_value(value, _profile, opts, _depth) when is_binary(value) do
+    sanitize_binary(value, opts.max_string_chars)
+  end
+
+  defp sanitize_value(value, profile, opts, depth) when depth >= opts.max_depth do
+    summarize_value(value, profile, opts)
+  end
+
+  defp sanitize_value(%module{} = value, profile, opts, depth) do
+    cond do
+      is_exception(value) ->
+        %{
+          type: module_label(module),
+          message: sanitize_binary(Exception.message(value), opts.max_string_chars)
+        }
+
+      profile == :transport ->
+        value
+        |> Map.from_struct()
+        |> Map.put(:__struct__, module_label(module))
+        |> sanitize_value(profile, opts, depth + 1)
+
+      true ->
+        summarize_value(value, profile, opts)
+    end
+  end
+
+  defp sanitize_value(value, profile, opts, depth) when is_map(value) do
+    {entries, omitted_count} =
+      value
+      |> Enum.take(opts.max_map_entries + 1)
+      |> then(fn entries ->
+        if length(entries) > opts.max_map_entries do
+          {Enum.take(entries, opts.max_map_entries), map_size(value) - opts.max_map_entries}
+        else
+          {entries, 0}
+        end
+      end)
+
+    entries
+    |> Map.new(fn {key, entry_value} ->
+      cond do
+        sensitive_key?(key) ->
+          {sanitize_key(key), @redacted}
+
+        profile == :telemetry and telemetry_payload_summary_key?(key) ->
+          {sanitize_key(key), summarize_value(entry_value, profile, opts)}
+
+        true ->
+          {sanitize_key(key), sanitize_value(entry_value, profile, opts, depth + 1)}
+      end
+    end)
+    |> maybe_put_truncated(omitted_count)
+  end
+
+  defp sanitize_value(value, profile, opts, depth) when is_list(value) do
+    if proper_list?(value) do
+      {items, omitted_count} = take_with_omitted_count(value, opts.max_list_items)
+
+      items
+      |> Enum.map(&sanitize_value(&1, profile, opts, depth + 1))
+      |> maybe_append_truncated(omitted_count)
+    else
+      summarize_value(value, profile, opts)
+    end
+  end
+
+  defp sanitize_value(value, profile, opts, depth) when is_tuple(value) do
+    if profile == :transport do
+      value
+      |> Tuple.to_list()
+      |> Enum.map(&sanitize_value(&1, profile, opts, depth + 1))
+      |> then(&%{type: :tuple, items: &1, size: tuple_size(value)})
+    else
+      summarize_value(value, profile, opts)
+    end
+  end
+
+  defp sanitize_value(value, profile, opts, _depth), do: summarize_value(value, profile, opts)
+
+  defp summarize_value(value, profile, opts) do
+    value
+    |> summary_base()
+    |> maybe_add_summary_details(value, profile, opts)
+  end
+
+  defp summary_base(value) when is_binary(value), do: %{type: :string, bytes: byte_size(value)}
+  defp summary_base(value) when is_list(value), do: %{type: :list, length: safe_length(value)}
+  defp summary_base(value) when is_map(value), do: %{type: :map, size: map_size(value), keys: summary_keys(value)}
+  defp summary_base(value) when is_tuple(value), do: %{type: :tuple, size: tuple_size(value)}
+  defp summary_base(value) when is_function(value), do: %{type: :function}
+  defp summary_base(value) when is_pid(value), do: %{type: :pid}
+  defp summary_base(value) when is_port(value), do: %{type: :port}
+  defp summary_base(value) when is_reference(value), do: %{type: :reference}
+  defp summary_base(value) when is_atom(value), do: %{type: :atom, value: value}
+  defp summary_base(value) when is_number(value), do: %{type: :number, value: value}
+  defp summary_base(_value), do: %{type: :term}
+
+  defp maybe_add_summary_details(summary, {:ok, payload, effects}, profile, opts) when is_list(effects) do
+    Map.merge(summary, %{
+      status: :ok,
+      value: summarize_value(payload, profile, opts),
+      effects_count: length(effects)
+    })
+  end
+
+  defp maybe_add_summary_details(summary, {:error, error, effects}, profile, opts) when is_list(effects) do
+    Map.merge(summary, %{
+      status: :error,
+      error: summarize_error(error, profile, opts),
+      effects_count: length(effects)
+    })
+  end
+
+  defp maybe_add_summary_details(summary, %{} = value, profile, opts) do
+    cond do
+      Map.has_key?(value, :type) or Map.has_key?(value, "type") or Map.has_key?(value, :message) or
+          Map.has_key?(value, "message") ->
+        Map.put(summary, :error, summarize_error(value, profile, opts))
+
+      true ->
+        summary
+    end
+  end
+
+  defp maybe_add_summary_details(summary, value, _profile, opts) when is_binary(value) do
+    Map.put(summary, :truncated?, String.valid?(value) and String.length(value) > opts.max_string_chars)
+  end
+
+  defp maybe_add_summary_details(summary, value, :transport, opts) do
+    if json_scalar?(value) do
+      summary
+    else
+      Map.put(summary, :inspect, inspect_limited(value, opts.max_inspect_chars))
+    end
+  end
+
+  defp maybe_add_summary_details(summary, _value, _profile, _opts), do: summary
+
+  defp summarize_error(%{} = error, profile, opts) do
+    %{}
+    |> maybe_put_summary_field(:type, Map.get(error, :type, Map.get(error, "type")))
+    |> maybe_put_summary_field(:code, Map.get(error, :code, Map.get(error, "code")))
+    |> maybe_put_summary_field(
+      :message,
+      sanitize_summary_message(Map.get(error, :message, Map.get(error, "message")), opts)
+    )
+    |> maybe_put_summary_field(:retryable?, Map.get(error, :retryable?, Map.get(error, "retryable?")))
+    |> case do
+      empty when empty == %{} -> summarize_value(Map.drop(error, [:details, "details"]), profile, opts)
+      summary -> summary
+    end
+  end
+
+  defp summarize_error(error, _profile, opts) when is_exception(error) do
+    %{type: module_label(error.__struct__), message: sanitize_binary(Exception.message(error), opts.max_string_chars)}
+  end
+
+  defp summarize_error(error, profile, opts), do: summarize_value(error, profile, opts)
+
+  defp maybe_put_summary_field(map, _key, nil), do: map
+  defp maybe_put_summary_field(map, key, value), do: Map.put(map, key, value)
+
+  defp sanitize_summary_message(nil, _opts), do: nil
+
+  defp sanitize_summary_message(message, opts) when is_binary(message),
+    do: sanitize_binary(message, opts.max_string_chars)
+
+  defp sanitize_summary_message(message, _opts) when is_atom(message), do: message
+  defp sanitize_summary_message(message, opts), do: inspect_limited(message, opts.max_inspect_chars)
+
+  defp sanitize_binary(value, max_chars) do
+    cond do
+      not String.valid?(value) ->
+        "[BINARY #{byte_size(value)} bytes]"
+
+      String.length(value) > max_chars ->
+        String.slice(value, 0, max_chars) <> "...[truncated]"
+
+      true ->
+        value
+    end
+  end
+
+  defp sanitize_key(key) when is_binary(key) or is_atom(key), do: key
+  defp sanitize_key(key), do: inspect_limited(key, @telemetry_defaults.max_inspect_chars)
+
+  defp telemetry_payload_summary_key?(key), do: MapSet.member?(@telemetry_payload_summary_keys, key)
+
+  defp take_with_omitted_count(list, max_items) do
+    items = Enum.take(list, max_items + 1)
+
+    if length(items) > max_items do
+      {Enum.take(items, max_items), length(list) - max_items}
+    else
+      {items, 0}
+    end
+  end
+
+  defp maybe_put_truncated(map, omitted_count) when omitted_count > 0 do
+    Map.put(map, @truncated_key, %{omitted_entries: omitted_count})
+  end
+
+  defp maybe_put_truncated(map, _omitted_count), do: map
+
+  defp maybe_append_truncated(list, omitted_count) when omitted_count > 0 do
+    list ++ [%{@truncated_key => %{omitted_items: omitted_count}}]
+  end
+
+  defp maybe_append_truncated(list, _omitted_count), do: list
+
+  defp summary_keys(map) do
+    map
+    |> Map.keys()
+    |> Enum.take(10)
+    |> Enum.map(&sanitize_key/1)
+  end
+
+  defp safe_length(list) do
+    if proper_list?(list), do: length(list), else: :improper
+  end
+
+  defp proper_list?([]), do: true
+  defp proper_list?([_head | tail]), do: proper_list?(tail)
+  defp proper_list?(_), do: false
+
+  defp sensitive_key?(key) when is_atom(key), do: key |> Atom.to_string() |> sensitive_key?()
+
+  defp sensitive_key?(key) when is_binary(key) do
+    key = String.downcase(key)
+
+    MapSet.member?(@sensitive_exact_keys, key) or
+      Enum.any?(@sensitive_contains, &String.contains?(key, &1)) or
+      Enum.any?(@sensitive_suffixes, &String.ends_with?(key, &1))
+  end
+
+  defp sensitive_key?(_key), do: false
+
+  defp json_scalar?(value),
+    do: is_nil(value) or is_boolean(value) or is_binary(value) or is_number(value) or is_atom(value)
+
+  defp inspect_limited(value, max_chars), do: inspect(value, limit: 20, printable_limit: max_chars)
+
+  defp module_label(module) when is_atom(module), do: module |> Atom.to_string() |> String.replace_prefix("Elixir.", "")
+end

--- a/lib/jido_ai/turn.ex
+++ b/lib/jido_ai/turn.ex
@@ -815,7 +815,10 @@ defmodule Jido.AI.Turn do
   end
 
   defp encode_tool_result_envelope(payload, parts \\ []) when is_map(payload) and is_list(parts) do
-    encoded = Jason.encode!(payload)
+    encoded =
+      payload
+      |> Observe.sanitize_transport_payload()
+      |> Jason.encode!()
 
     case parts do
       [] -> encoded

--- a/mix.exs
+++ b/mix.exs
@@ -192,6 +192,7 @@ defmodule JidoAi.MixProject do
           Jido.AI.Thread.Entry,
           Jido.AI.Turn,
           Jido.AI.Observe,
+          Jido.AI.Observe.Sanitize,
           Jido.AI.Validation,
           Jido.AI.ToolAdapter,
           Jido.AI.PluginStack

--- a/test/jido_ai/executor_test.exs
+++ b/test/jido_ai/executor_test.exs
@@ -347,6 +347,25 @@ defmodule Jido.AI.TurnExecutionTest do
              }
     end
 
+    test "transport-sanitizes non-json-safe tool payloads" do
+      decoded =
+        Turn.format_tool_result_content(
+          {:ok,
+           %{
+             password: "secret",
+             tuple: {:ok, self()},
+             callback: fn -> :ok end
+           }}
+        )
+        |> decode_tool_content()
+
+      assert decoded["ok"] == true
+      assert decoded["result"]["password"] == "[REDACTED]"
+      assert decoded["result"]["tuple"]["type"] == "tuple"
+      assert decoded["result"]["tuple"]["size"] == 2
+      assert decoded["result"]["callback"]["type"] == "function"
+    end
+
     test "normalizes map content parts into multimodal tool content" do
       assert [
                %ContentPart{type: :text, text: encoded_payload},

--- a/test/jido_ai/integration/tools_phase2_test.exs
+++ b/test/jido_ai/integration/tools_phase2_test.exs
@@ -520,7 +520,10 @@ defmodule Jido.AI.Integration.ToolsPhase2Test do
       Turn.execute("nonexistent", %{}, %{}, tools: tools)
 
       assert_receive {:telemetry, [:jido, :ai, :tool, :execute, :stop], %{duration: _},
-                      %{tool_name: "nonexistent", result: {:error, %{type: :not_found}, []}}}
+                      %{
+                        tool_name: "nonexistent",
+                        result: %{status: :error, error: %{type: :not_found}}
+                      }}
 
       :telemetry.detach("integration-stop-error-handler")
     end

--- a/test/jido_ai/observe_test.exs
+++ b/test/jido_ai/observe_test.exs
@@ -72,6 +72,73 @@ defmodule Jido.AI.ObserveTest do
     assert Enum.at(sanitized.notes, 1).private_key == "[REDACTED]"
   end
 
+  test "sanitize_telemetry_metadata redacts, bounds, and summarizes payload fields" do
+    metadata = %{
+      request_id: "req_1",
+      params: %{
+        "api_key" => "secret",
+        "query" => String.duplicate("x", 20)
+      },
+      result:
+        {:error,
+         %{
+           type: :timeout,
+           message: String.duplicate("timeout ", 10),
+           details: %{token: "secret"}
+         }, []},
+      tags: Enum.to_list(1..6)
+    }
+
+    sanitized =
+      Observe.sanitize_telemetry_metadata(metadata,
+        max_string_chars: 12,
+        max_list_items: 3
+      )
+
+    assert sanitized.params["api_key"] == "[REDACTED]"
+    assert sanitized.params["query"] == "xxxxxxxxxxxx...[truncated]"
+
+    assert sanitized.result.status == :error
+    assert sanitized.result.error.type == :timeout
+    assert sanitized.result.error.message == "timeout time...[truncated]"
+    refute match?({:error, _, _}, sanitized.result)
+
+    assert Enum.take(sanitized.tags, 3) == [1, 2, 3]
+    assert List.last(sanitized.tags) == %{__jido_ai_truncated__: %{omitted_items: 3}}
+  end
+
+  test "sanitize_telemetry_metadata does not inspect unexpected payload terms" do
+    sanitized =
+      Observe.sanitize_telemetry_metadata(%{
+        result: {:unexpected, %{api_key: "secret", value: "visible"}}
+      })
+
+    assert sanitized.result == %{type: :tuple, size: 2}
+    refute inspect(sanitized) =~ "secret"
+    refute inspect(sanitized) =~ "visible"
+  end
+
+  test "sanitize_transport_payload produces bounded JSON-safe data" do
+    payload = %{
+      ok: true,
+      result: %{
+        password: "secret",
+        tuple: {:ok, self()},
+        callback: fn -> :ok end,
+        text: String.duplicate("a", 16)
+      }
+    }
+
+    sanitized = Observe.sanitize_transport_payload(payload, max_string_chars: 8)
+
+    assert sanitized.result.password == "[REDACTED]"
+    assert sanitized.result.tuple.type == :tuple
+    assert sanitized.result.tuple.size == 2
+    assert sanitized.result.callback.type == :function
+    assert sanitized.result.text == "aaaaaaaa...[truncated]"
+    assert {:ok, _json} = Jason.encode(sanitized)
+  end
+
   test "emit executes telemetry with normalized shape" do
     ref = make_ref()
     handler_id = "observe-test-emit-#{inspect(ref)}"
@@ -100,6 +167,40 @@ defmodule Jido.AI.ObserveTest do
     assert measurements.duration_ms == 1
     assert metadata.request_id == "req_1"
     assert Map.has_key?(metadata, :agent_id)
+  end
+
+  test "emit sanitizes telemetry metadata before delivery" do
+    ref = make_ref()
+    handler_id = "observe-test-emit-sanitize-#{inspect(ref)}"
+
+    :telemetry.attach(
+      handler_id,
+      Observe.request(:complete),
+      fn _event, _measurements, metadata, _ ->
+        send(self(), {:telemetry_seen, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    :ok =
+      Observe.emit(
+        %{emit_telemetry?: true},
+        Observe.request(:complete),
+        %{duration_ms: 1},
+        %{
+          request_id: "req_1",
+          api_key: "secret",
+          result: {:ok, %{payload: String.duplicate("x", 1_000)}, []}
+        }
+      )
+
+    assert_receive {:telemetry_seen, metadata}
+    assert metadata.api_key == "[REDACTED]"
+    assert metadata.result.status == :ok
+    assert metadata.result.value.type == :map
+    refute match?({:ok, _, _}, metadata.result)
   end
 
   test "emit does not emit telemetry when disabled" do


### PR DESCRIPTION
## Summary

Closes #265.

Adds an explicit AI observability sanitizer boundary with separate telemetry and transport profiles:

- introduces `Jido.AI.Observe.Sanitize` plus `Jido.AI.Observe` delegate helpers
- applies telemetry-profile sanitization automatically inside `Observe.emit/5` and `Observe.start_span/3`
- summarizes payload-shaped telemetry fields such as `result`, `output`, `content`, `messages`, and raw responses instead of emitting raw blobs
- uses the transport profile before tool-result JSON encoding so arbitrary action outputs become bounded JSON-safe payloads
- updates observability/tool-result docs and regression coverage for redaction, truncation, nested values, telemetry summaries, and non-JSON-safe transport terms

## Validation

- `mix test`
- `mix precommit`
- `mix dialyzer`
- `mix credo --min-priority high --all`
- `mix docs` (passes with existing `ReqLLM.Message.ContentPart.file_id/3` docs warning in `lib/jido_ai/query.ex`)
