### PR TITLE
fix(react): start worker for multimodal queries

### DIFF
--- a/lib/jido_ai/reasoning/react/worker/strategy.ex
+++ b/lib/jido_ai/reasoning/react/worker/strategy.ex
@@ -162,7 +162,7 @@ defmodule Jido.AI.Reasoning.ReAct.Worker.Strategy do
   defp process_instruction(_agent, _instruction), do: :noop
 
   defp start_run(agent, %{request_id: request_id, run_id: run_id, query: query, config: config_input} = params)
-       when is_binary(request_id) and is_binary(run_id) and is_binary(query) do
+       when is_binary(request_id) and is_binary(run_id) and (is_binary(query) or is_list(query)) do
     state = StratState.get(agent, %{})
 
     if state[:status] == :running and is_binary(state[:active_request_id]) do

--- a/test/jido_ai/react/worker_strategy_test.exs
+++ b/test/jido_ai/react/worker_strategy_test.exs
@@ -1,0 +1,61 @@
+defmodule Jido.AI.Reasoning.ReAct.WorkerStrategyTest do
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Jido.Agent.Strategy.State, as: StratState
+  alias Jido.AI.Reasoning.ReAct.Config
+  alias Jido.AI.Reasoning.ReAct.Worker.Strategy
+  alias ReqLLM.Message.ContentPart
+
+  setup :set_mimic_from_context
+
+  test "starts delegated runtime for multimodal query lists" do
+    parent = self()
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, messages, _opts ->
+      send(parent, {:req_llm_messages, messages})
+      {:ok, resolved_model} = ReqLLM.model(model)
+      {:ok, metadata_handle} = ReqLLM.StreamResponse.MetadataHandle.start_link(fn -> %{finish_reason: :stop} end)
+
+      {:ok,
+       %ReqLLM.StreamResponse{
+         stream: [ReqLLM.StreamChunk.text("Done")],
+         metadata_handle: metadata_handle,
+         model: resolved_model,
+         context: ReqLLM.Context.new([]),
+         cancel: fn -> :ok end
+       }}
+    end)
+
+    query = [
+      ContentPart.text("Summarize this document."),
+      ContentPart.file_id("file_123")
+    ]
+
+    agent =
+      %Jido.Agent{id: "worker-test", name: "worker", state: %{}}
+      |> then(fn agent ->
+        {agent, []} = Strategy.init(agent, %{})
+        agent
+      end)
+
+    start =
+      %Jido.Instruction{
+        action: :react_worker_start,
+        params: %{
+          request_id: "req_file",
+          run_id: "req_file",
+          query: query,
+          config: Config.new(%{model: :capable, tools: %{}})
+        }
+      }
+
+    {agent, []} = Strategy.cmd(agent, [start], %{})
+
+    state = StratState.get(agent, %{})
+    assert state.status == :running
+    assert state.active_request_id == "req_file"
+
+    assert_receive {:req_llm_messages, [%{role: :user, content: ^query}]}, 200
+  end
+end


### PR DESCRIPTION
## Summary
- Allow the delegated ReAct worker to start when the query is a multimodal content-part list
- Add a regression test covering file-reference queries passing through the worker to ReqLLM

Fixes #302

## Validation
- mix test test/jido_ai/react/worker_strategy_test.exs
- mix test test/jido_ai/react/runtime_runner_test.exs test/jido_ai/strategy/react_test.exs test/jido_ai/query_test.exs test/jido_ai/request_test.exs test/jido_ai/agent_test.exs test/jido_ai/react/worker_strategy_test.exs
- mix test.fast