### PR TITLE
fix(context): preserve file reference media types

### DIFF
--- a/lib/jido_ai/context.ex
+++ b/lib/jido_ai/context.ex
@@ -527,19 +527,73 @@ defmodule Jido.AI.Context do
     end
   end
 
-  defp normalize_tool_content_part_map(type, part) when type in [:file, "file"] do
-    data = get_field(part, :data)
-    filename = get_field(part, :filename)
-    media_type = get_field(part, :media_type, "application/octet-stream")
+  defp normalize_tool_content_part_map(type, part)
+       when type in [:file, "file", :file_id, "file_id", :document, "document"] do
+    file_id = part_binary_field(part, :file_id)
+    data = part_field(part, :data)
+    filename = part_binary_field(part, :filename)
+    media_type = part_binary_field(part, :media_type)
 
-    if is_binary(data) and is_binary(filename) do
-      ContentPart.file(data, filename, media_type)
-    else
-      nil
+    cond do
+      is_binary(file_id) ->
+        file_id
+        |> ContentPart.file_id(media_type || "application/pdf", part_metadata(part))
+        |> maybe_put_filename(filename)
+
+      is_binary(data) and is_binary(filename) ->
+        ContentPart.file(data, filename, media_type || "application/octet-stream")
+
+      true ->
+        nil
     end
   end
 
   defp normalize_tool_content_part_map(_, _), do: nil
+
+  defp part_field(part, key) do
+    source = part_source(part)
+    get_field(part, key) || get_field(source, key)
+  end
+
+  defp part_source(part) do
+    case get_field(part, :source) do
+      %{} = source -> source
+      source when is_list(source) -> if(Keyword.keyword?(source), do: Map.new(source), else: %{})
+      _source -> %{}
+    end
+  end
+
+  defp part_binary_field(part, key) do
+    case part_field(part, key) do
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> nil
+          value -> value
+        end
+
+      _value ->
+        nil
+    end
+  end
+
+  defp part_metadata(part) do
+    metadata =
+      case get_field(part, :metadata) do
+        metadata when is_map(metadata) -> metadata
+        metadata when is_list(metadata) -> if(Keyword.keyword?(metadata), do: Map.new(metadata), else: %{})
+        _metadata -> %{}
+      end
+
+    Enum.reduce([:title, :context, :citations], metadata, fn key, acc ->
+      case part_field(part, key) do
+        nil -> acc
+        value -> Map.put_new(acc, key, value)
+      end
+    end)
+  end
+
+  defp maybe_put_filename(part, filename) when is_binary(filename), do: %{part | filename: filename}
+  defp maybe_put_filename(part, _filename), do: part
 
   defp extract_entry_thinking(content) when is_list(content) do
     thinking =

--- a/lib/jido_ai/turn.ex
+++ b/lib/jido_ai/turn.ex
@@ -929,25 +929,79 @@ defmodule Jido.AI.Turn do
     end
   end
 
-  defp normalize_content_part_map(type, part) when type in [:file, "file"] do
-    data = get_field(part, :data)
-    filename = get_field(part, :filename)
-    media_type = get_field(part, :media_type, "application/octet-stream")
+  defp normalize_content_part_map(type, part)
+       when type in [:file, "file", :file_id, "file_id", :document, "document"] do
+    file_id = part_binary_field(part, :file_id)
+    data = part_field(part, :data)
+    filename = part_binary_field(part, :filename)
+    media_type = part_binary_field(part, :media_type)
 
-    if is_binary(data) and is_binary(filename) do
-      ContentPart.file(data, filename, media_type)
-    else
-      nil
+    cond do
+      is_binary(file_id) ->
+        file_id
+        |> ContentPart.file_id(media_type || "application/pdf", part_metadata(part))
+        |> maybe_put_filename(filename)
+
+      is_binary(data) and is_binary(filename) ->
+        ContentPart.file(data, filename, media_type || "application/octet-stream")
+
+      true ->
+        nil
     end
   end
 
   defp normalize_content_part_map(_, _), do: nil
 
+  defp part_field(part, key) do
+    source = part_source(part)
+    get_field(part, key) || get_field(source, key)
+  end
+
+  defp part_source(part) do
+    case get_field(part, :source) do
+      %{} = source -> source
+      source when is_list(source) -> if(Keyword.keyword?(source), do: Map.new(source), else: %{})
+      _source -> %{}
+    end
+  end
+
+  defp part_binary_field(part, key) do
+    case part_field(part, key) do
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> nil
+          value -> value
+        end
+
+      _value ->
+        nil
+    end
+  end
+
+  defp part_metadata(part) do
+    metadata =
+      case get_field(part, :metadata) do
+        metadata when is_map(metadata) -> metadata
+        metadata when is_list(metadata) -> if(Keyword.keyword?(metadata), do: Map.new(metadata), else: %{})
+        _metadata -> %{}
+      end
+
+    Enum.reduce([:title, :context, :citations], metadata, fn key, acc ->
+      case part_field(part, key) do
+        nil -> acc
+        value -> Map.put_new(acc, key, value)
+      end
+    end)
+  end
+
+  defp maybe_put_filename(part, filename) when is_binary(filename), do: %{part | filename: filename}
+  defp maybe_put_filename(part, _filename), do: part
+
   defp content_parts_list?(parts) when is_list(parts) and parts != [] do
     Enum.all?(parts, fn
       %ContentPart{} -> true
-      %{type: type} when type in [:text, :thinking, :image_url, :image, :file] -> true
-      %{"type" => type} when type in ["text", "thinking", "image_url", "image", "file"] -> true
+      %{type: type} when type in [:text, :thinking, :image_url, :image, :file, :file_id, :document] -> true
+      %{"type" => type} when type in ["text", "thinking", "image_url", "image", "file", "file_id", "document"] -> true
       _ -> false
     end)
   end

--- a/test/jido_ai/thread_test.exs
+++ b/test/jido_ai/thread_test.exs
@@ -615,6 +615,57 @@ defmodule Jido.AI.ContextTest do
                %ContentPart{type: :image_url, url: "https://example.com/chart.png"}
              ] = projected.content
     end
+
+    test "preserves uploaded file reference media types when importing messages" do
+      parts = [
+        %{"type" => "text", "text" => "Summarize these files"},
+        %{
+          "type" => "file",
+          "file_id" => "file_text",
+          "media_type" => "text/plain",
+          "filename" => "notes.txt",
+          "metadata" => %{"purpose" => "fixture"}
+        },
+        %{
+          type: :document,
+          source: %{file_id: "file_pdf", media_type: "application/pdf"},
+          title: "Source PDF"
+        }
+      ]
+
+      messages = [
+        %{role: :user, content: parts}
+      ]
+
+      thread = AIContext.new() |> AIContext.append_messages(messages)
+
+      [entry] = thread.entries
+
+      assert [
+               %ContentPart{type: :text, text: "Summarize these files"},
+               %ContentPart{
+                 type: :file,
+                 file_id: "file_text",
+                 media_type: "text/plain",
+                 filename: "notes.txt",
+                 metadata: %{"purpose" => "fixture"}
+               },
+               %ContentPart{
+                 type: :file,
+                 file_id: "file_pdf",
+                 media_type: "application/pdf",
+                 metadata: %{title: "Source PDF"}
+               }
+             ] = entry.content
+
+      [projected] = AIContext.to_messages(thread)
+
+      assert [
+               %ContentPart{type: :text, text: "Summarize these files"},
+               %ContentPart{type: :file, file_id: "file_text", media_type: "text/plain"},
+               %ContentPart{type: :file, file_id: "file_pdf", media_type: "application/pdf"}
+             ] = projected.content
+    end
   end
 
   # ============================================================================

--- a/test/jido_ai/turn_test.exs
+++ b/test/jido_ai/turn_test.exs
@@ -410,6 +410,32 @@ defmodule Jido.AI.TurnTest do
                "result" => nil
              }
     end
+
+    test "map-based uploaded file references preserve media types outside JSON payload" do
+      file_part = %{
+        type: :file_id,
+        file_id: "file_text",
+        media_type: "text/plain",
+        filename: "notes.txt",
+        metadata: %{purpose: "fixture"}
+      }
+
+      assert [
+               %ContentPart{type: :text, text: encoded_payload},
+               %ContentPart{
+                 type: :file,
+                 file_id: "file_text",
+                 media_type: "text/plain",
+                 filename: "notes.txt",
+                 metadata: %{purpose: "fixture"}
+               }
+             ] = Turn.format_tool_result_content({:ok, [file_part]})
+
+      assert Jason.decode!(encoded_payload) == %{
+               "ok" => true,
+               "result" => nil
+             }
+    end
   end
 
   describe "run_tools/3" do


### PR DESCRIPTION
## Summary
- preserve uploaded file-reference maps as ReqLLM ContentPart.file_id/3 parts during Jido.AI context import/rehydration
- retain file_id media_type, filename, metadata, and Anthropic document metadata from top-level or nested source maps
- accept :file_id and :document map aliases in tool-result content normalization

Fixes #302

## Validation
- mix test test/jido_ai/thread_test.exs test/jido_ai/turn_test.exs test/jido_ai/query_test.exs test/jido_ai/request_test.exs test/jido_ai/react/worker_strategy_test.exs test/jido_ai/react/runtime_runner_test.exs
- mix test.fast
- mix quality
- mix test