### PR TITLE
feat(react): emit keepalive events during tool execution to prevent stream idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- `:keepalive` runtime event kind and a new opt-in `:tool_heartbeat_ms` ReAct
-  config option (default `0` = off). When `> 0`, the ReAct runner emits a
-  periodic `:keepalive` event every `tool_heartbeat_ms` while tools execute.
-  This keeps both stream idle layers alive — the runner's `next_event/2`
-  (`stream_timeout_ms`) and the `Jido.AI.Request.Stream` enumerable
-  (`stream_event_timeout_ms`) — so a consumer that sets a short
-  `stream_event_timeout_ms` no longer times out and aborts a run during a
-  long-running tool call. `:tool_heartbeat_ms` is threaded through the same call
-  sites as `:stream_timeout_ms` (per-agent macro option, per-request
-  `ask`/`ask_sync`/`ask_stream` options, and the ReAct action schemas), and
-  truly-dead streams still time out normally when no heartbeat is configured.
-
 ## [2.0.0-rc.0] - 2026-02-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `:keepalive` runtime event kind and a new opt-in `:tool_heartbeat_ms` ReAct
+  config option (default `0` = off). When `> 0`, the ReAct runner emits a
+  periodic `:keepalive` event every `tool_heartbeat_ms` while tools execute.
+  This keeps both stream idle layers alive — the runner's `next_event/2`
+  (`stream_timeout_ms`) and the `Jido.AI.Request.Stream` enumerable
+  (`stream_event_timeout_ms`) — so a consumer that sets a short
+  `stream_event_timeout_ms` no longer times out and aborts a run during a
+  long-running tool call. `:tool_heartbeat_ms` is threaded through the same call
+  sites as `:stream_timeout_ms` (per-agent macro option, per-request
+  `ask`/`ask_sync`/`ask_stream` options, and the ReAct action schemas), and
+  truly-dead streams still time out normally when no heartbeat is configured.
+
 ## [2.0.0-rc.0] - 2026-02-22
 
 ### Added

--- a/guides/developer/configuration_reference.md
+++ b/guides/developer/configuration_reference.md
@@ -27,6 +27,16 @@ Package defaults are built into `Jido.AI`; `model_aliases` is merged on top for 
   - `tool_timeout_ms`: `15_000`
   - `tool_max_retries`: `1`
   - `tool_retry_backoff_ms`: `200`
+  - `stream_timeout_ms`: `0` (0 = auto-derive the runner's inter-event idle
+    timeout from `tool_timeout_ms + 60_000`; `stream_receive_timeout_ms` is
+    accepted as a compatibility alias)
+  - `tool_heartbeat_ms`: `0` (0 = off). When `> 0`, the runner emits a
+    `:keepalive` runtime event every interval *while tools execute*. Tools
+    produce no stream events while running, which would otherwise starve a
+    consumer that set a short `stream_event_timeout_ms` on
+    `Jido.AI.Request.Stream.events/2` (or a short `stream_timeout_ms` on the
+    runner) and abort the run mid-tool. The heartbeat keeps both idle layers
+    alive; truly-dead streams (no tool, no heartbeat) still time out normally.
   - `req_http_options`: `[]`
   - `llm_opts`: `[]`
   - `request_transformer`: `nil`
@@ -73,7 +83,7 @@ Package defaults are built into `Jido.AI`; `model_aliases` is merged on top for 
 
 - await timeout: `30_000ms`
 - max retained requests per agent state: `100`
-- request-scoped ReAct overrides: `tools`, `allowed_tools`, `request_transformer`, `max_iterations`, `tool_context`, `req_http_options`, `llm_opts`
+- request-scoped ReAct overrides: `tools`, `allowed_tools`, `request_transformer`, `max_iterations`, `stream_timeout_ms`, `tool_heartbeat_ms`, `tool_context`, `req_http_options`, `llm_opts`
 
 ## Security Defaults
 

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -36,6 +36,10 @@ defmodule Jido.AI.Agent do
     from tool_timeout_ms + 60s). How long to wait for events between coordinator
     updates. Increase for agents with slow LLM responses or long tool executions.
     `:stream_receive_timeout_ms` is accepted as a compatibility alias.
+  - `:tool_heartbeat_ms` - Tool-execution keepalive interval in ms (default: 0 =
+    off). When `> 0`, the runner emits a `:keepalive` event every interval while
+    tools execute, keeping a short-`stream_event_timeout_ms` consumer alive
+    through long-running tool calls.
   - `:effect_policy` - Agent-level effect policy (default allow-list)
   - `:strategy_effect_policy` - Optional strategy-level narrowing policy (cannot broaden agent policy)
   - `:runtime_adapter` - Deprecated compatibility flag (delegated ReAct runtime is always enabled)
@@ -335,6 +339,7 @@ defmodule Jido.AI.Agent do
     tool_max_retries = Keyword.get(opts, :tool_max_retries, 1)
     tool_retry_backoff_ms = Keyword.get(opts, :tool_retry_backoff_ms, 200)
     stream_timeout_ms = Keyword.get(opts, :stream_timeout_ms, Keyword.get(opts, :stream_receive_timeout_ms, 0))
+    tool_heartbeat_ms = Keyword.get(opts, :tool_heartbeat_ms, 0)
     # ReAct delegation is always enabled; keep runtime_adapter option for compatibility only.
     _runtime_adapter_opt = Keyword.get(opts, :runtime_adapter, true)
     runtime_adapter = true
@@ -419,6 +424,7 @@ defmodule Jido.AI.Agent do
         tool_max_retries: tool_max_retries,
         tool_retry_backoff_ms: tool_retry_backoff_ms,
         stream_timeout_ms: stream_timeout_ms,
+        tool_heartbeat_ms: tool_heartbeat_ms,
         runtime_adapter: runtime_adapter,
         runtime_task_supervisor: runtime_task_supervisor,
         observability: observability,
@@ -507,6 +513,9 @@ defmodule Jido.AI.Agent do
       - `:max_iterations` - Request-scoped maximum reasoning iterations
       - `:stream_timeout_ms` - Request-scoped runtime inactivity timeout.
         `:stream_receive_timeout_ms` is accepted as a compatibility alias.
+      - `:tool_heartbeat_ms` - Request-scoped tool-execution keepalive interval in
+        ms (0 = off). Emits a `:keepalive` event while tools run so a short
+        `stream_event_timeout_ms` consumer survives long tool calls.
       - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
       - `:llm_opts` - Per-request ReqLLM generation options forwarded to ReAct runtime
       - `:file_id` / `:file_ids` / `:file_reference` / `:file_references` - Uploaded
@@ -609,6 +618,9 @@ defmodule Jido.AI.Agent do
       - `:max_iterations` - Request-scoped maximum reasoning iterations
       - `:stream_timeout_ms` - Request-scoped runtime inactivity timeout.
         `:stream_receive_timeout_ms` is accepted as a compatibility alias.
+      - `:tool_heartbeat_ms` - Request-scoped tool-execution keepalive interval in
+        ms (0 = off). Emits a `:keepalive` event while tools run so a short
+        `stream_event_timeout_ms` consumer survives long tool calls.
       - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
       - `:llm_opts` - Per-request ReqLLM generation options forwarded to ReAct runtime
       - `:file_id` / `:file_ids` / `:file_reference` / `:file_references` - Uploaded

--- a/lib/jido_ai/reasoning/react/actions/collect.ex
+++ b/lib/jido_ai/reasoning/react/actions/collect.ex
@@ -30,6 +30,7 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Collect do
         req_http_options: Zoi.list(Zoi.any()) |> Zoi.optional(),
         stream_receive_timeout_ms: Zoi.integer() |> Zoi.optional(),
         stream_timeout_ms: Zoi.integer() |> Zoi.optional(),
+        tool_heartbeat_ms: Zoi.integer() |> Zoi.optional(),
         tool_timeout_ms: Zoi.integer() |> Zoi.default(15_000),
         tool_max_retries: Zoi.integer() |> Zoi.default(1),
         tool_retry_backoff_ms: Zoi.integer() |> Zoi.default(200),

--- a/lib/jido_ai/reasoning/react/actions/continue.ex
+++ b/lib/jido_ai/reasoning/react/actions/continue.ex
@@ -28,6 +28,7 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Continue do
         req_http_options: Zoi.list(Zoi.any()) |> Zoi.optional(),
         stream_receive_timeout_ms: Zoi.integer() |> Zoi.optional(),
         stream_timeout_ms: Zoi.integer() |> Zoi.optional(),
+        tool_heartbeat_ms: Zoi.integer() |> Zoi.optional(),
         tool_timeout_ms: Zoi.integer() |> Zoi.default(15_000),
         tool_max_retries: Zoi.integer() |> Zoi.default(1),
         tool_retry_backoff_ms: Zoi.integer() |> Zoi.default(200),

--- a/lib/jido_ai/reasoning/react/actions/helpers.ex
+++ b/lib/jido_ai/reasoning/react/actions/helpers.ex
@@ -25,6 +25,7 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Helpers do
       llm_timeout_ms: params[:llm_timeout_ms] || params[:timeout_ms],
       req_http_options: params[:req_http_options],
       stream_timeout_ms: Map.get(params, :stream_timeout_ms, Map.get(params, :stream_receive_timeout_ms)),
+      tool_heartbeat_ms: params[:tool_heartbeat_ms],
       tool_timeout_ms: params[:tool_timeout_ms],
       tool_max_retries: params[:tool_max_retries],
       tool_retry_backoff_ms: params[:tool_retry_backoff_ms],

--- a/lib/jido_ai/reasoning/react/actions/start.ex
+++ b/lib/jido_ai/reasoning/react/actions/start.ex
@@ -29,6 +29,7 @@ defmodule Jido.AI.Reasoning.ReAct.Actions.Start do
         req_http_options: Zoi.list(Zoi.any()) |> Zoi.optional(),
         stream_receive_timeout_ms: Zoi.integer() |> Zoi.optional(),
         stream_timeout_ms: Zoi.integer() |> Zoi.optional(),
+        tool_heartbeat_ms: Zoi.integer() |> Zoi.optional(),
         tool_timeout_ms: Zoi.integer() |> Zoi.default(15_000),
         tool_max_retries: Zoi.integer() |> Zoi.default(1),
         tool_retry_backoff_ms: Zoi.integer() |> Zoi.default(200),

--- a/lib/jido_ai/reasoning/react/config.ex
+++ b/lib/jido_ai/reasoning/react/config.ex
@@ -64,6 +64,7 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
               max_iterations: Zoi.integer() |> Zoi.default(@default_max_iterations),
               streaming: Zoi.boolean() |> Zoi.default(true),
               stream_timeout_ms: Zoi.integer() |> Zoi.default(0),
+              tool_heartbeat_ms: Zoi.integer() |> Zoi.default(0),
               effect_policy: Zoi.any() |> Zoi.default(%{}),
               output: Zoi.any() |> Zoi.nullish(),
               llm: @llm_schema,
@@ -154,6 +155,7 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
         normalize_pos_integer(get_opt(opts_map, :max_iterations, @default_max_iterations), @default_max_iterations),
       streaming: normalize_boolean(get_opt(opts_map, :streaming, true), true),
       stream_timeout_ms: normalize_non_neg_integer(resolve_stream_timeout_ms(opts_map), 0),
+      tool_heartbeat_ms: normalize_non_neg_integer(get_opt(opts_map, :tool_heartbeat_ms, 0), 0),
       effect_policy: get_opt(opts_map, :effect_policy, %{}),
       output: output,
       llm: llm,
@@ -219,6 +221,18 @@ defmodule Jido.AI.Reasoning.ReAct.Config do
       ms -> ms
     end
   end
+
+  @doc """
+  Returns the tool-execution heartbeat interval in milliseconds.
+
+  When `> 0`, the ReAct runner emits a `:keepalive` event every interval while
+  tools are executing, so a consumer that sets a short
+  `stream_event_timeout_ms` on `Jido.AI.Request.Stream.events/2` does not time
+  out during a long-running tool call. `0` (default) disables heartbeats.
+  """
+  @spec tool_heartbeat_ms(t()) :: non_neg_integer()
+  def tool_heartbeat_ms(%__MODULE__{tool_heartbeat_ms: ms}) when is_integer(ms) and ms >= 0, do: ms
+  def tool_heartbeat_ms(%__MODULE__{}), do: 0
 
   @doc """
   Convert config to generation options for `ReqLLM.Generation.stream_text/3`

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -667,18 +667,24 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
             )
           end)
 
+        heartbeat = start_tool_heartbeat(state, owner, ref, config)
+
         results =
-          pending
-          |> Task.async_stream(
-            fn call -> execute_tool_with_retries(call, tool_config, context) end,
-            ordered: true,
-            max_concurrency: tool_config.tool_exec.concurrency,
-            timeout: tool_config.tool_exec.timeout_ms + 50
-          )
-          |> Enum.map(fn
-            {:ok, result} -> result
-            {:exit, reason} -> {:error, %{type: :task_exit, reason: inspect(reason)}}
-          end)
+          try do
+            pending
+            |> Task.async_stream(
+              fn call -> execute_tool_with_retries(call, tool_config, context) end,
+              ordered: true,
+              max_concurrency: tool_config.tool_exec.concurrency,
+              timeout: tool_config.tool_exec.timeout_ms + 50
+            )
+            |> Enum.map(fn
+              {:ok, result} -> result
+              {:exit, reason} -> {:error, %{type: :task_exit, reason: inspect(reason)}}
+            end)
+          after
+            stop_tool_heartbeat(heartbeat)
+          end
 
         {state, updated_context} =
           Enum.reduce(results, {state, state.context}, fn
@@ -1122,6 +1128,57 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   defp notify_progress(owner, ref) do
     send(owner, {:react_runner, ref, :progress})
     :ok
+  end
+
+  # Periodic keepalive during tool execution: tools produce no stream events
+  # while they run, which would starve a consumer that set a short
+  # `stream_event_timeout_ms` on the request stream enumerable. Emitting a real
+  # `:keepalive` event keeps BOTH idle layers (runner `next_event/2` and
+  # `Jido.AI.Request.Stream`) alive without affecting tool semantics. Opt-in via
+  # `tool_heartbeat_ms` (0 = disabled).
+  defp start_tool_heartbeat(%State{} = state, owner, ref, %Config{} = config) do
+    case Config.tool_heartbeat_ms(config) do
+      interval when is_integer(interval) and interval > 0 ->
+        template = %{
+          run_id: state.run_id,
+          request_id: state.request_id,
+          iteration: state.iteration,
+          seq: state.seq
+        }
+
+        spawn_link(fn -> tool_heartbeat_loop(owner, ref, interval, template) end)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp stop_tool_heartbeat(nil), do: :ok
+
+  defp stop_tool_heartbeat(pid) when is_pid(pid) do
+    Process.unlink(pid)
+    send(pid, :stop)
+    :ok
+  end
+
+  defp tool_heartbeat_loop(owner, ref, interval, template) do
+    receive do
+      :stop -> :ok
+    after
+      interval ->
+        event =
+          Event.new(%{
+            seq: template.seq,
+            run_id: template.run_id,
+            request_id: template.request_id,
+            iteration: template.iteration,
+            kind: :keepalive,
+            data: %{source: :tool_execution}
+          })
+
+        send(owner, {:react_runner, ref, :event, event})
+        tool_heartbeat_loop(owner, ref, interval, template)
+    end
   end
 
   defp cleanup(_owner, %{pid: pid} = state) when is_pid(pid) do

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -669,22 +669,33 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
 
         heartbeat = start_tool_heartbeat(state, owner, ref, config)
 
-        results =
+        {results, heartbeat_last_seq} =
           try do
-            pending
-            |> Task.async_stream(
-              fn call -> execute_tool_with_retries(call, tool_config, context) end,
-              ordered: true,
-              max_concurrency: tool_config.tool_exec.concurrency,
-              timeout: tool_config.tool_exec.timeout_ms + 50
-            )
-            |> Enum.map(fn
-              {:ok, result} -> result
-              {:exit, reason} -> {:error, %{type: :task_exit, reason: inspect(reason)}}
-            end)
+            mapped =
+              pending
+              |> Task.async_stream(
+                fn call -> execute_tool_with_retries(call, tool_config, context) end,
+                ordered: true,
+                max_concurrency: tool_config.tool_exec.concurrency,
+                timeout: tool_config.tool_exec.timeout_ms + 50
+              )
+              |> Enum.map(fn
+                {:ok, result} -> result
+                {:exit, reason} -> {:error, %{type: :task_exit, reason: inspect(reason)}}
+              end)
+
+            # Synchronously stop the heartbeat and learn the highest seq it
+            # allocated, so the runner can resume above that range.
+            {mapped, stop_tool_heartbeat(heartbeat)}
           after
-            stop_tool_heartbeat(heartbeat)
+            # Crash-safety net: guarantee the heartbeat process is gone even if
+            # the tool block raised before the synchronous stop ran.
+            kill_tool_heartbeat(heartbeat)
           end
+
+        # Adopt the heartbeat's final seq so the next emitted event is strictly
+        # greater than every keepalive (preserves unique + monotonic seqs).
+        state = State.adopt_seq(state, heartbeat_last_seq)
 
         {state, updated_context} =
           Enum.reduce(results, {state, state.context}, fn
@@ -1136,39 +1147,70 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   # `:keepalive` event keeps BOTH idle layers (runner `next_event/2` and
   # `Jido.AI.Request.Stream`) alive without affecting tool semantics. Opt-in via
   # `tool_heartbeat_ms` (0 = disabled).
+  #
+  # The heartbeat runs in a separate process because the runner is blocked inside
+  # `Task.async_stream` for the whole tool window and cannot allocate seqs itself.
+  # The runner does NOT emit any event during that window, so the seq range
+  # `[base + 1, ..]` is exclusively the heartbeat's: it allocates a fresh,
+  # strictly-increasing seq per keepalive (never reusing a value), and on stop
+  # reports the highest seq it reached so the runner can resume above it via
+  # `State.adopt_seq/2`. This keeps every event seq unique and monotonic.
   defp start_tool_heartbeat(%State{} = state, owner, ref, %Config{} = config) do
     case Config.tool_heartbeat_ms(config) do
       interval when is_integer(interval) and interval > 0 ->
         template = %{
           run_id: state.run_id,
           request_id: state.request_id,
-          iteration: state.iteration,
-          seq: state.seq
+          iteration: state.iteration
         }
 
-        spawn_link(fn -> tool_heartbeat_loop(owner, ref, interval, template) end)
+        base_seq = state.seq
+        spawn_link(fn -> tool_heartbeat_loop(owner, ref, interval, base_seq, template) end)
 
       _ ->
         nil
     end
   end
 
-  defp stop_tool_heartbeat(nil), do: :ok
+  # Synchronously stop the heartbeat and return the highest seq it allocated
+  # (or `nil` when there was no heartbeat). The handshake guarantees the
+  # heartbeat has emitted its last keepalive before the runner resumes, so the
+  # reconciled seq covers every keepalive in flight.
+  defp stop_tool_heartbeat(nil), do: nil
 
   defp stop_tool_heartbeat(pid) when is_pid(pid) do
     Process.unlink(pid)
-    send(pid, :stop)
+    send(pid, {:stop, self()})
+
+    receive do
+      {:heartbeat_stopped, ^pid, last_seq} -> last_seq
+    after
+      1_000 ->
+        Process.exit(pid, :kill)
+        nil
+    end
+  end
+
+  defp kill_tool_heartbeat(nil), do: :ok
+
+  defp kill_tool_heartbeat(pid) when is_pid(pid) do
+    Process.unlink(pid)
+    Process.exit(pid, :kill)
     :ok
   end
 
-  defp tool_heartbeat_loop(owner, ref, interval, template) do
+  defp tool_heartbeat_loop(owner, ref, interval, seq, template) do
     receive do
-      :stop -> :ok
+      {:stop, from} ->
+        send(from, {:heartbeat_stopped, self(), seq})
+        :ok
     after
       interval ->
+        next_seq = seq + 1
+
         event =
           Event.new(%{
-            seq: template.seq,
+            seq: next_seq,
             run_id: template.run_id,
             request_id: template.request_id,
             iteration: template.iteration,
@@ -1177,7 +1219,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
           })
 
         send(owner, {:react_runner, ref, :event, event})
-        tool_heartbeat_loop(owner, ref, interval, template)
+        tool_heartbeat_loop(owner, ref, interval, next_seq, template)
     end
   end
 

--- a/lib/jido_ai/reasoning/react/state.ex
+++ b/lib/jido_ai/reasoning/react/state.ex
@@ -163,6 +163,23 @@ defmodule Jido.AI.Reasoning.ReAct.State do
   end
 
   @doc """
+  Advances the event sequence counter to `seq` when it is ahead of the current
+  value, leaving it untouched otherwise.
+
+  Used to reconcile sequence numbers allocated out-of-band by the tool-execution
+  heartbeat (which runs in a separate process while the runner is blocked inside
+  `Task.async_stream`). Adopting the heartbeat's final seq guarantees the next
+  normal event the runner emits is strictly greater than every keepalive,
+  preserving the monotonic-and-unique seq invariant.
+  """
+  @spec adopt_seq(t(), integer() | nil) :: t()
+  def adopt_seq(%__MODULE__{} = state, seq) when is_integer(seq) and seq > state.seq do
+    %{state | seq: seq, updated_at_ms: now_ms()}
+  end
+
+  def adopt_seq(%__MODULE__{} = state, _seq), do: state
+
+  @doc """
   Increments the reasoning iteration counter.
   """
   @spec inc_iteration(t()) :: t()

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -75,6 +75,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           stream_receive_timeout_ms: pos_integer(),
           stream_timeout_ms: non_neg_integer(),
           stream_receive_timeout_ms: pos_integer(),
+          tool_heartbeat_ms: non_neg_integer(),
           tool_timeout_ms: pos_integer(),
           tool_max_retries: non_neg_integer(),
           tool_retry_backoff_ms: non_neg_integer(),
@@ -192,6 +193,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           stream_to: Zoi.any() |> Zoi.optional(),
           stream_receive_timeout_ms: Zoi.integer() |> Zoi.optional(),
           stream_timeout_ms: Zoi.integer() |> Zoi.optional(),
+          tool_heartbeat_ms: Zoi.integer() |> Zoi.optional(),
           req_http_options: Zoi.list(Zoi.any()) |> Zoi.optional(),
           llm_opts: Zoi.any() |> Zoi.optional(),
           max_iterations: Zoi.integer() |> Zoi.optional(),
@@ -660,6 +662,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
             tools: effective_tools,
             stream_receive_timeout_ms: Map.get(params, :stream_receive_timeout_ms),
             stream_timeout_ms: Map.get(params, :stream_timeout_ms),
+            tool_heartbeat_ms: Map.get(params, :tool_heartbeat_ms),
             max_iterations: Map.get(params, :max_iterations),
             request_transformer: request_transformer,
             output: output,
@@ -1932,6 +1935,12 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
         Map.get(config, :stream_timeout_ms, Map.get(config, :stream_receive_timeout_ms, 0))
       )
 
+    tool_heartbeat_ms =
+      case Keyword.fetch(opts, :tool_heartbeat_ms) do
+        {:ok, ms} when is_integer(ms) and ms >= 0 -> ms
+        _ -> Map.get(config, :tool_heartbeat_ms, 0)
+      end
+
     runtime_opts = %{
       model: config[:model],
       system_prompt: config[:system_prompt],
@@ -1941,6 +1950,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       max_tokens: config[:max_tokens],
       streaming: config[:streaming],
       stream_timeout_ms: stream_timeout_ms,
+      tool_heartbeat_ms: tool_heartbeat_ms,
       req_http_options: req_http_options,
       llm_opts: llm_opts,
       tool_timeout_ms: config[:tool_timeout_ms],
@@ -2239,6 +2249,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
         |> normalize_stream_receive_timeout_ms(30_000),
       request_policy: request_policy,
       stream_timeout_ms: Keyword.get(opts, :stream_timeout_ms, 0),
+      tool_heartbeat_ms: Keyword.get(opts, :tool_heartbeat_ms, 0),
       tool_timeout_ms: Keyword.get(opts, :tool_timeout_ms, 15_000),
       tool_max_retries: Keyword.get(opts, :tool_max_retries, 1),
       tool_retry_backoff_ms: Keyword.get(opts, :tool_retry_backoff_ms, 200),

--- a/lib/jido_ai/request.ex
+++ b/lib/jido_ai/request.ex
@@ -161,6 +161,8 @@ defmodule Jido.AI.Request do
   - `:max_iterations` - ReAct-only request-scoped maximum reasoning iterations
   - `:stream_timeout_ms` - ReAct-only request-scoped runtime inactivity timeout.
     `:stream_receive_timeout_ms` is accepted as a compatibility alias.
+  - `:tool_heartbeat_ms` - ReAct-only request-scoped tool-execution keepalive
+    interval in ms (0 = off). Emits a `:keepalive` event while tools run.
   - `:req_http_options` - Per-request Req HTTP options forwarded to ReAct runtime
   - `:llm_opts` - Per-request ReqLLM generation options forwarded to ReAct runtime
   - `:file_id` / `:file_ids` / `:file_reference` / `:file_references` - Uploaded
@@ -195,6 +197,7 @@ defmodule Jido.AI.Request do
     request_transformer = Keyword.get(opts, :request_transformer)
     max_iterations = Keyword.get(opts, :max_iterations)
     stream_timeout_ms = Keyword.get(opts, :stream_timeout_ms, Keyword.get(opts, :stream_receive_timeout_ms))
+    tool_heartbeat_ms = Keyword.get(opts, :tool_heartbeat_ms)
     req_http_options = Keyword.get(opts, :req_http_options, [])
     llm_opts = Keyword.get(opts, :llm_opts, [])
     output = Keyword.get(opts, :output)
@@ -215,6 +218,7 @@ defmodule Jido.AI.Request do
         |> maybe_add_request_transformer(request_transformer)
         |> maybe_add_max_iterations(max_iterations)
         |> maybe_add_stream_timeout_ms(stream_timeout_ms)
+        |> maybe_add_tool_heartbeat_ms(tool_heartbeat_ms)
         |> maybe_add_req_http_options(req_http_options)
         |> maybe_add_llm_opts(llm_opts)
         |> maybe_add_output(output)
@@ -568,6 +572,13 @@ defmodule Jido.AI.Request do
   end
 
   defp maybe_add_stream_timeout_ms(payload, _), do: payload
+
+  defp maybe_add_tool_heartbeat_ms(payload, tool_heartbeat_ms)
+       when is_integer(tool_heartbeat_ms) and tool_heartbeat_ms >= 0 do
+    Map.put(payload, :tool_heartbeat_ms, tool_heartbeat_ms)
+  end
+
+  defp maybe_add_tool_heartbeat_ms(payload, _), do: payload
 
   defp maybe_add_max_iterations(payload, max_iterations)
        when is_integer(max_iterations) and max_iterations > 0 do

--- a/lib/jido_ai/runtime/event.ex
+++ b/lib/jido_ai/runtime/event.ex
@@ -14,6 +14,7 @@ defmodule Jido.AI.Runtime.Event do
     :output_failed,
     :tool_started,
     :tool_completed,
+    :keepalive,
     :checkpoint,
     :request_completed,
     :request_failed,

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -96,6 +96,18 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     end
   end
 
+  defmodule HeartbeatSlowTool do
+    use Jido.Action,
+      name: "heartbeat_slow_tool",
+      description: "sleeps long enough for multiple heartbeats",
+      schema: Zoi.object(%{})
+
+    def run(_params, _context) do
+      Process.sleep(500)
+      {:ok, %{marker: :slow}}
+    end
+  end
+
   defmodule FastOrderTool do
     use Jido.Action,
       name: "fast_order_tool",
@@ -1706,6 +1718,98 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     test "default tool timeout gives 75s stream timeout" do
       config = Config.new(%{model: :capable})
       assert Config.stream_timeout(config) == 75_000
+    end
+  end
+
+  describe "tool_heartbeat" do
+    test "emits :keepalive events while a slow tool executes" do
+      Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+        count = :persistent_term.get({__MODULE__, :hb_llm_call_count}, 0) + 1
+        :persistent_term.put({__MODULE__, :hb_llm_call_count}, count)
+
+        if count == 1 do
+          {:ok,
+           responses_stream_response(
+             [ReqLLM.StreamChunk.tool_call("heartbeat_slow_tool", %{}, %{id: "tc_hb_slow"})],
+             %{finish_reason: :tool_calls, usage: %{input_tokens: 5, output_tokens: 3}},
+             model
+           )}
+        else
+          {:ok,
+           responses_stream_response(
+             [ReqLLM.StreamChunk.text("Slow tool complete")],
+             %{finish_reason: :stop, usage: %{input_tokens: 2, output_tokens: 1}},
+             model
+           )}
+        end
+      end)
+
+      config =
+        Config.new(%{
+          model: :capable,
+          tools: %{HeartbeatSlowTool.name() => HeartbeatSlowTool},
+          # A 250ms stream idle timeout is shorter than the 500ms tool, so without
+          # heartbeats the run would abort mid-tool. The 50ms heartbeat fires well
+          # within that window and resets both idle layers, so the run survives.
+          stream_timeout_ms: 250,
+          tool_heartbeat_ms: 50
+        })
+
+      events =
+        ReAct.stream("Run slow tool", config, request_id: "req_hb", run_id: "run_hb")
+        |> Enum.to_list()
+
+      keepalives = Enum.filter(events, &(&1.kind == :keepalive))
+
+      assert keepalives != [], "expected at least one :keepalive event during slow tool execution"
+      assert Enum.all?(keepalives, &(&1.data.source == :tool_execution))
+
+      # The run is NOT aborted mid-tool: the tool completes and the run finishes.
+      assert Enum.any?(events, &(&1.kind == :tool_completed and &1.data.tool_call_id == "tc_hb_slow"))
+      assert Enum.any?(events, &(&1.kind == :request_completed))
+    after
+      :persistent_term.erase({__MODULE__, :hb_llm_call_count})
+    end
+
+    test "emits no :keepalive events when tool_heartbeat_ms is 0 (default)" do
+      Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+        count = :persistent_term.get({__MODULE__, :hb0_llm_call_count}, 0) + 1
+        :persistent_term.put({__MODULE__, :hb0_llm_call_count}, count)
+
+        if count == 1 do
+          {:ok,
+           responses_stream_response(
+             [ReqLLM.StreamChunk.tool_call("heartbeat_slow_tool", %{}, %{id: "tc_hb0_slow"})],
+             %{finish_reason: :tool_calls, usage: %{input_tokens: 5, output_tokens: 3}},
+             model
+           )}
+        else
+          {:ok,
+           responses_stream_response(
+             [ReqLLM.StreamChunk.text("Slow tool complete")],
+             %{finish_reason: :stop, usage: %{input_tokens: 2, output_tokens: 1}},
+             model
+           )}
+        end
+      end)
+
+      config =
+        Config.new(%{
+          model: :capable,
+          tools: %{HeartbeatSlowTool.name() => HeartbeatSlowTool}
+        })
+
+      assert Config.tool_heartbeat_ms(config) == 0
+
+      events =
+        ReAct.stream("Run slow tool", config, request_id: "req_hb0", run_id: "run_hb0")
+        |> Enum.to_list()
+
+      refute Enum.any?(events, &(&1.kind == :keepalive))
+      assert Enum.any?(events, &(&1.kind == :tool_completed and &1.data.tool_call_id == "tc_hb0_slow"))
+      assert Enum.any?(events, &(&1.kind == :request_completed))
+    after
+      :persistent_term.erase({__MODULE__, :hb0_llm_call_count})
     end
   end
 

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -1764,8 +1764,26 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
       assert keepalives != [], "expected at least one :keepalive event during slow tool execution"
       assert Enum.all?(keepalives, &(&1.data.source == :tool_execution))
 
+      # Regression: keepalive events must not reuse or duplicate sequence numbers.
+      # The heartbeat allocates seqs out-of-band (separate process) while the
+      # runner is blocked in Task.async_stream; every event seq across the whole
+      # run must remain unique and monotonically increasing, and the keepalives
+      # must interleave above the prior events and below the events emitted after
+      # the tool completes.
+      seqs = Enum.map(events, & &1.seq)
+      assert seqs == Enum.sort(seqs), "event seqs must be monotonically increasing across keepalives"
+      assert seqs == Enum.uniq(seqs), "event seqs must be unique even when keepalives are emitted"
+
+      keepalive_seqs = Enum.map(keepalives, & &1.seq)
+      assert keepalive_seqs == Enum.uniq(keepalive_seqs), "each keepalive must carry a distinct seq"
+
+      tool_completed = Enum.find(events, &(&1.kind == :tool_completed and &1.data.tool_call_id == "tc_hb_slow"))
+      assert tool_completed
+      # Every keepalive precedes the post-tool event, proving the runner resumed
+      # above the heartbeat's allocated range rather than colliding with it.
+      assert Enum.all?(keepalive_seqs, &(&1 < tool_completed.seq))
+
       # The run is NOT aborted mid-tool: the tool completes and the run finishes.
-      assert Enum.any?(events, &(&1.kind == :tool_completed and &1.data.tool_call_id == "tc_hb_slow"))
       assert Enum.any?(events, &(&1.kind == :request_completed))
     after
       :persistent_term.erase({__MODULE__, :hb_llm_call_count})


### PR DESCRIPTION
## Summary

A ReAct run streams events to a consumer via `Agent.ask_stream/3` → `Request.Stream.events/2` (an enumerable the consumer folds over). There are **two idle layers** that abort a run when no events flow:

1. The runner's `next_event/2` receive loop — gated by `stream_timeout_ms` (made configurable in #193).
2. The `Jido.AI.Request.Stream` enumerable — gated by the consumer-supplied `stream_event_timeout_ms`.

During a **long-running tool call**, tools run via `Task.async_stream` and emit **no stream events**, so a consumer that sets a short `stream_event_timeout_ms` (e.g. to detect dead streams quickly) times out and aborts the run **mid-tool** — even though the tool is working fine. Only real `%ReAct.Event{}`s reset Layer 2; the internal `:progress` heartbeat used during LLM token streaming does **not** reach it.

This is the tool-**execution** counterpart to the tool-**input** starvation fixed by #193 / #195 / #246: those keep the stream alive while the model *generates* a large tool input; this keeps it alive while the tool *runs*.

## Approach

Opt-in periodic keepalive with **zero default behavior change**:

- New runtime event kind `:keepalive` (auto-propagates to `ReAct.Event`).
- New ReAct config option **`tool_heartbeat_ms`** (default `0` = off). When `> 0`, the runner spawns a heartbeat process around the `Task.async_stream` tool execution that emits a real `:keepalive` event every interval, resetting **both** idle layers. The ticker is reliably stopped via `try/after` (and `spawn_link`'d so it dies with the coordinator).
- `tool_heartbeat_ms` is threaded through the same call sites as `stream_timeout_ms` (per-agent macro option, per-request `ask`/`ask_sync`/`ask_stream` options, request payload, ReAct action schemas, and strategy config/runtime plumbing).

Truly-dead streams (no tool, no heartbeat) still time out normally. Consumers that don't opt in see no new events. This mirrors the existing `on_heartbeat`/`heartbeat_interval_ms` liveness pattern already used in [`jido_shell`](https://github.com/agentjido/jido_shell)'s streaming shell layer — applied here at the ReAct tool-execution boundary.

## Usage

```elixir
use Jido.AI.Agent,
  tool_timeout_ms: 1_800_000,   # tools may run up to 30 min
  tool_heartbeat_ms: 15_000     # emit a :keepalive every 15s while they run

# or per-request:
MyAgent.ask_stream(pid, "do the long thing", tool_heartbeat_ms: 15_000)
```

## Test plan

- New `describe "tool_heartbeat"` in `test/jido_ai/react/runtime_runner_test.exs`:
  - a 500 ms tool with `stream_timeout_ms: 250` (shorter than the tool) + `tool_heartbeat_ms: 50` → `:keepalive` events are emitted and the run **completes** instead of aborting mid-tool;
  - default (`tool_heartbeat_ms: 0`) → **no** `:keepalive` events (backward compat).
- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix test --exclude flaky` (zero new failures), `mix credo --strict` (zero new issues), `mix doctor`, and `mix dialyzer` (0 errors) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
