### PR TITLE
chore(deps): drop unused direct dependencies

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -10,8 +10,6 @@ Unknown function 'Elixir.Unicode':is_visible_latin1/1
 Unknown function 'Elixir.Unicode':to_ucs4be/1
 deps/jido_signal/lib/jido_signal/using.ex:6: Function validate_policy_extension_data/4 will never be called
 deps/jido_signal/lib/jido_signal/using.ex:6: Function validate_policy_extension_entry/3 will never be called
-deps/jido_signal/lib/jido_signal/using.ex:11: Function validate_policy_extension_data/4 will never be called
-deps/jido_signal/lib/jido_signal/using.ex:11: Function validate_policy_extension_entry/3 will never be called
 deps/jido_signal/lib/jido_signal/using.ex:336: The pattern 'false' can never match the type 'true'
 missing specification for function from_latin9/1
 missing specification for function from_ucs2be/1

--- a/lib/jido_ai/signals/definition.ex
+++ b/lib/jido_ai/signals/definition.ex
@@ -1,0 +1,233 @@
+defmodule Jido.AI.Signal.Definition do
+  @moduledoc false
+
+  @typedoc false
+  @type schema :: keyword(keyword())
+
+  defmacro __using__(opts) do
+    type = Keyword.fetch!(opts, :type)
+    default_source = Keyword.get(opts, :default_source)
+    datacontenttype = Keyword.get(opts, :datacontenttype)
+    dataschema = Keyword.get(opts, :dataschema)
+    schema = Keyword.get(opts, :schema, [])
+
+    unless is_binary(type) and type != "" do
+      raise ArgumentError, "signal type must be a non-empty string"
+    end
+
+    unless Keyword.keyword?(schema) do
+      raise ArgumentError, "signal schema must be a keyword list"
+    end
+
+    quote bind_quoted: [
+            type: type,
+            default_source: default_source,
+            datacontenttype: datacontenttype,
+            dataschema: dataschema,
+            schema: schema
+          ] do
+      @signal_type type
+      @signal_default_source default_source
+      @signal_datacontenttype datacontenttype
+      @signal_dataschema dataschema
+      @signal_schema schema
+
+      @doc "Returns the CloudEvents type emitted by this signal module."
+      @spec type() :: String.t()
+      def type, do: @signal_type
+
+      @doc "Returns the default CloudEvents source for this signal module."
+      @spec default_source() :: String.t() | nil
+      def default_source, do: @signal_default_source
+
+      @doc "Returns the configured data content type, if present."
+      @spec datacontenttype() :: String.t() | nil
+      def datacontenttype, do: @signal_datacontenttype
+
+      @doc "Returns the configured data schema URI, if present."
+      @spec dataschema() :: String.t() | nil
+      def dataschema, do: @signal_dataschema
+
+      @doc "Returns the field schema used to validate signal data."
+      @spec schema() :: keyword(keyword())
+      def schema, do: @signal_schema
+
+      @doc "Returns the extension policy for this signal module."
+      @spec extension_policy() :: map()
+      def extension_policy, do: %{}
+
+      @doc "Returns this signal definition as metadata."
+      @spec to_json() :: map()
+      def to_json do
+        %{
+          type: @signal_type,
+          default_source: @signal_default_source,
+          datacontenttype: @signal_datacontenttype,
+          dataschema: @signal_dataschema,
+          schema: @signal_schema,
+          extension_policy: %{}
+        }
+      end
+
+      @doc "Returns this signal definition as metadata."
+      @spec __signal_metadata__() :: map()
+      def __signal_metadata__, do: to_json()
+
+      @doc "Builds a validated `Jido.Signal` from signal data."
+      @spec new(map(), keyword()) :: {:ok, Jido.Signal.t()} | {:error, term()}
+      def new(data \\ %{}, opts \\ []) do
+        with {:ok, validated_data} <-
+               Jido.AI.Signal.Definition.validate_data(__MODULE__, @signal_schema, data) do
+          __MODULE__
+          |> Jido.AI.Signal.Definition.build_attrs(
+            @signal_type,
+            @signal_default_source,
+            @signal_datacontenttype,
+            @signal_dataschema,
+            validated_data,
+            opts
+          )
+          |> Jido.Signal.from_map()
+        end
+      end
+
+      @doc "Builds a validated `Jido.Signal` or raises when validation fails."
+      @spec new!(map(), keyword()) :: Jido.Signal.t() | no_return()
+      def new!(data \\ %{}, opts \\ []) do
+        case new(data, opts) do
+          {:ok, signal} -> signal
+          {:error, reason} -> raise RuntimeError, message: Jido.AI.Signal.Definition.error_message(reason)
+        end
+      end
+
+      @doc "Validates data against this signal module's schema."
+      @spec validate_data(map()) :: {:ok, map()} | {:error, String.t()}
+      def validate_data(data) do
+        Jido.AI.Signal.Definition.validate_data(__MODULE__, @signal_schema, data)
+      end
+    end
+  end
+
+  @doc "Validates signal data against the given schema."
+  @spec validate_data(module(), schema(), map()) :: {:ok, map()} | {:error, String.t()}
+  def validate_data(module, schema, data) when is_map(data) do
+    schema_keys = Keyword.keys(schema)
+
+    with {:ok, normalized_data} <- normalize_input(module, data, schema_keys) do
+      Enum.reduce_while(schema, {:ok, %{}}, fn {field, opts}, {:ok, acc} ->
+        case Map.fetch(normalized_data, field) do
+          {:ok, value} ->
+            case validate_field(module, field, value, opts) do
+              :ok -> {:cont, {:ok, Map.put(acc, field, value)}}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+
+          :error ->
+            cond do
+              Keyword.has_key?(opts, :default) ->
+                {:cont, {:ok, Map.put(acc, field, Keyword.fetch!(opts, :default))}}
+
+              Keyword.get(opts, :required, false) ->
+                {:halt, {:error, "Signal #{inspect(module)} missing required field #{inspect(field)}"}}
+
+              true ->
+                {:cont, {:ok, acc}}
+            end
+        end
+      end)
+    end
+  end
+
+  def validate_data(module, _schema, data) do
+    {:error, "Signal #{inspect(module)} expected data to be a map, got: #{inspect(data)}"}
+  end
+
+  @doc "Builds CloudEvents attributes for a typed signal module."
+  @spec build_attrs(
+          module(),
+          String.t(),
+          String.t() | nil,
+          String.t() | nil,
+          String.t() | nil,
+          map(),
+          Enumerable.t()
+        ) :: map()
+  def build_attrs(module, type, default_source, datacontenttype, dataschema, data, opts) do
+    %{
+      "data" => data,
+      "id" => Jido.Signal.ID.generate!(),
+      "source" => default_source || module_source(module),
+      "specversion" => "1.0.2",
+      "time" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "type" => type
+    }
+    |> put_optional("datacontenttype", datacontenttype)
+    |> put_optional("dataschema", dataschema)
+    |> Map.merge(stringify_keys(opts))
+  end
+
+  @doc false
+  @spec error_message(term()) :: String.t()
+  def error_message(reason) when is_binary(reason), do: reason
+  def error_message(reason), do: inspect(reason)
+
+  defp normalize_input(module, data, schema_keys) do
+    Enum.reduce_while(data, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+      case normalize_key(key, schema_keys) do
+        {:ok, normalized_key} ->
+          {:cont, {:ok, Map.put(acc, normalized_key, value)}}
+
+        :error ->
+          {:halt, {:error, "Signal #{inspect(module)} received unknown field #{inspect(key)}"}}
+      end
+    end)
+  end
+
+  defp normalize_key(key, schema_keys) when is_atom(key) do
+    if key in schema_keys, do: {:ok, key}, else: :error
+  end
+
+  defp normalize_key(key, schema_keys) when is_binary(key) do
+    case Enum.find(schema_keys, &(Atom.to_string(&1) == key)) do
+      nil -> :error
+      normalized_key -> {:ok, normalized_key}
+    end
+  end
+
+  defp normalize_key(_key, _schema_keys), do: :error
+
+  defp validate_field(module, field, value, opts) do
+    type = Keyword.get(opts, :type, :any)
+
+    if valid_type?(type, value) do
+      :ok
+    else
+      {:error,
+       "Signal #{inspect(module)} expected #{inspect(field)} to be #{type_description(type)}, got: #{inspect(value)}"}
+    end
+  end
+
+  defp valid_type?(:any, _value), do: true
+  defp valid_type?(:atom, value), do: is_atom(value)
+  defp valid_type?(:integer, value), do: is_integer(value)
+  defp valid_type?(:map, value), do: is_map(value)
+  defp valid_type?(:string, value), do: is_binary(value)
+  defp valid_type?(_type, _value), do: false
+
+  defp type_description(:atom), do: "an atom"
+  defp type_description(:integer), do: "an integer"
+  defp type_description(:map), do: "a map"
+  defp type_description(:string), do: "a string"
+  defp type_description(type), do: inspect(type)
+
+  defp put_optional(map, _key, nil), do: map
+  defp put_optional(map, key, value), do: Map.put(map, key, value)
+
+  defp stringify_keys(values) do
+    Enum.into(values, %{}, fn {key, value} -> {to_string(key), value} end)
+  end
+
+  defp module_source(module) do
+    "/" <> (module |> Module.split() |> Enum.map_join("/", &Macro.underscore/1))
+  end
+end

--- a/lib/jido_ai/signals/embed_result.ex
+++ b/lib/jido_ai/signals/embed_result.ex
@@ -3,7 +3,7 @@ defmodule Jido.AI.Signal.EmbedResult do
   Signal for embedding generation completion.
   """
 
-  use Jido.Signal,
+  use Jido.AI.Signal.Definition,
     type: "ai.embed.result",
     default_source: "/ai/embed",
     schema: [

--- a/lib/jido_ai/signals/llm_delta.ex
+++ b/lib/jido_ai/signals/llm_delta.ex
@@ -3,7 +3,7 @@ defmodule Jido.AI.Signal.LLMDelta do
   Signal for streaming LLM token chunks.
   """
 
-  use Jido.Signal,
+  use Jido.AI.Signal.Definition,
     type: "ai.llm.delta",
     default_source: "/ai/llm",
     schema: [

--- a/lib/jido_ai/signals/llm_response.ex
+++ b/lib/jido_ai/signals/llm_response.ex
@@ -8,7 +8,7 @@ defmodule Jido.AI.Signal.LLMResponse do
 
   alias Jido.AI.Turn
 
-  use Jido.Signal,
+  use Jido.AI.Signal.Definition,
     type: "ai.llm.response",
     default_source: "/ai/llm",
     schema: [

--- a/lib/jido_ai/signals/request_completed.ex
+++ b/lib/jido_ai/signals/request_completed.ex
@@ -3,7 +3,7 @@ defmodule Jido.AI.Signal.RequestCompleted do
   Signal for request lifecycle completion.
   """
 
-  use Jido.Signal,
+  use Jido.AI.Signal.Definition,
     type: "ai.request.completed",
     default_source: "/ai/request",
     schema: [

--- a/lib/jido_ai/signals/request_error.ex
+++ b/lib/jido_ai/signals/request_error.ex
@@ -3,7 +3,7 @@ defmodule Jido.AI.Signal.RequestError do
   Signal for request rejection.
   """
 
-  use Jido.Signal,
+  use Jido.AI.Signal.Definition,
     type: "ai.request.error",
     default_source: "/ai/strategy",
     schema: [

--- a/lib/jido_ai/signals/request_failed.ex
+++ b/lib/jido_ai/signals/request_failed.ex
@@ -3,7 +3,7 @@ defmodule Jido.AI.Signal.RequestFailed do
   Signal for request lifecycle failure.
   """
 
-  use Jido.Signal,
+  use Jido.AI.Signal.Definition,
     type: "ai.request.failed",
     default_source: "/ai/request",
     schema: [

--- a/lib/jido_ai/signals/request_started.ex
+++ b/lib/jido_ai/signals/request_started.ex
@@ -3,7 +3,7 @@ defmodule Jido.AI.Signal.RequestStarted do
   Signal for request lifecycle start.
   """
 
-  use Jido.Signal,
+  use Jido.AI.Signal.Definition,
     type: "ai.request.started",
     default_source: "/ai/request",
     schema: [

--- a/lib/jido_ai/signals/tool_result.ex
+++ b/lib/jido_ai/signals/tool_result.ex
@@ -3,7 +3,7 @@ defmodule Jido.AI.Signal.ToolResult do
   Signal for tool execution completion.
   """
 
-  use Jido.Signal,
+  use Jido.AI.Signal.Definition,
     type: "ai.tool.result",
     default_source: "/ai/tool",
     schema: [

--- a/lib/jido_ai/signals/tool_started.ex
+++ b/lib/jido_ai/signals/tool_started.ex
@@ -3,7 +3,7 @@ defmodule Jido.AI.Signal.ToolStarted do
   Signal emitted when a tool execution starts.
   """
 
-  use Jido.Signal,
+  use Jido.AI.Signal.Definition,
     type: "ai.tool.started",
     default_source: "/ai/tool",
     schema: [

--- a/lib/jido_ai/signals/usage.ex
+++ b/lib/jido_ai/signals/usage.ex
@@ -3,7 +3,7 @@ defmodule Jido.AI.Signal.Usage do
   Signal for token usage and cost tracking.
   """
 
-  use Jido.Signal,
+  use Jido.AI.Signal.Definition,
     type: "ai.usage",
     default_source: "/ai/usage",
     schema: [

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,6 @@ defmodule JidoAi.MixProject do
       # Runtime
       {:fsmx, "~> 0.5"},
       {:jason, "~> 1.4"},
-      {:nimble_options, "~> 1.1"},
       {:splode, "~> 0.3.0"},
       {:yaml_elixir, "~> 2.12"},
       {:zoi, "~> 0.18"},
@@ -81,7 +80,6 @@ defmodule JidoAi.MixProject do
       {:git_hooks, "~> 0.8", only: [:dev, :test], runtime: false},
       {:git_ops, "~> 2.9", only: :dev, runtime: false},
       {:mimic, "~> 2.0", only: :test},
-      {:stream_data, "~> 1.0", only: [:dev, :test]},
       {:igniter, "~> 0.7", optional: true}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -51,7 +51,6 @@
   "sourceror": {:hex, :sourceror, "1.12.0", "da354c5f35aad3cc1132f5d5b0d8437d865e2661c263260480bab51b5eedb437", [:mix], [], "hexpm", "755703683bd014ebcd5de9acc24b68fb874a660a568d1d63f8f98cd8a6ef9cd0"},
   "spitfire": {:hex, :spitfire, "0.3.13", "edd207b065eaec57acc5484097d0aa3e97fe4246168c54e67a9af040b8dee4c1", [:mix], [], "hexpm", "3601be88ceed4967b584e96444de3e1d12d6555ae0864a7390b9cd5332d134b4"},
   "splode": {:hex, :splode, "0.3.1", "9843c54f84f71b7833fec3f0be06c3cfb5be6b35960ee195ea4fad84b1c25030", [:mix], [], "hexpm", "8f2309b6ec2ecbb01435656429ed1d9ed04ba28797a3280c3b0d1217018ecfbd"},
-  "stream_data": {:hex, :stream_data, "1.3.0", "bde37905530aff386dea1ddd86ecbf00e6642dc074ceffc10b7d4e41dfd6aac9", [:mix], [], "hexpm", "3cc552e286e817dca43c98044c706eec9318083a1480c52ae2688b08e2936e3c"},
   "telemetry": {:hex, :telemetry, "1.4.2", "a0cb522801dffb1c49fe6e30561badffc7b6d0e180db1300df759faa22062855", [:rebar3], [], "hexpm", "928f6495066506077862c0d1646609eed891a4326bee3126ba54b60af61febb1"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "1.1.0", "5bd5f3b5637e0abea0426b947e3ce5dd304f8b3bc6617039e2b5a008adc02f8f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "e7b79e8ddfde70adb6db8a6623d1778ec66401f366e9a8f5dd0955c56bc8ce67"},
   "text_diff": {:hex, :text_diff, "0.1.0", "1caf3175e11a53a9a139bc9339bd607c47b9e376b073d4571c031913317fecaa", [:mix], [], "hexpm", "d1ffaaecab338e49357b6daa82e435f877e0649041ace7755583a0ea3362dbd7"},

--- a/test/jido_ai/signal_test.exs
+++ b/test/jido_ai/signal_test.exs
@@ -31,6 +31,72 @@ defmodule Jido.AI.SignalTest do
     end
   end
 
+  describe "typed signal validation" do
+    test "reports missing required fields" do
+      assert {:error, message} = LLMDelta.new(%{call_id: "call_missing_delta"})
+      assert message =~ "missing required field :delta"
+
+      assert_raise RuntimeError, ~r/missing required field :delta/, fn ->
+        LLMDelta.new!(%{call_id: "call_missing_delta"})
+      end
+    end
+
+    test "rejects unknown fields" do
+      assert {:error, message} =
+               LLMDelta.new(%{
+                 call_id: "call_unknown",
+                 delta: "hello",
+                 unknown: true
+               })
+
+      assert message =~ "received unknown field :unknown"
+    end
+
+    test "rejects invalid field types" do
+      assert {:error, message} =
+               LLMDelta.new(%{
+                 call_id: "call_bad_type",
+                 delta: "hello",
+                 seq: "1"
+               })
+
+      assert message =~ "expected :seq to be an integer"
+    end
+
+    test "accepts string keys for schema fields and applies signal options" do
+      assert {:ok, signal} =
+               LLMDelta.new(
+                 %{
+                   "call_id" => "call_string_keys",
+                   "delta" => "hello"
+                 },
+                 source: "/custom/source",
+                 subject: "subject-1"
+               )
+
+      assert signal.source == "/custom/source"
+      assert signal.subject == "subject-1"
+      assert signal.data.call_id == "call_string_keys"
+      assert signal.data.delta == "hello"
+      assert signal.data.chunk_type == :content
+    end
+
+    test "exposes signal metadata accessors" do
+      assert LLMDelta.type() == "ai.llm.delta"
+      assert LLMDelta.default_source() == "/ai/llm"
+      assert LLMDelta.datacontenttype() == nil
+      assert LLMDelta.dataschema() == nil
+      assert LLMDelta.extension_policy() == %{}
+
+      metadata = LLMDelta.__signal_metadata__()
+
+      assert metadata.type == LLMDelta.type()
+      assert metadata.default_source == LLMDelta.default_source()
+      assert metadata.schema == LLMDelta.schema()
+      assert metadata.extension_policy == %{}
+    end
+  end
+
   describe "LLMResponse" do
     test "creates signal with required fields" do
       signal =


### PR DESCRIPTION
## Summary
- remove unused direct `nimble_options` and `stream_data` dependencies
- update Jido ecosystem locks to `jido` 2.3.2, `jido_action` 2.3.1, and `jido_signal` 2.2.2
- clean lockfile entries made unreachable by the updated upstream packages

## Testing
- `mix precommit`
- `mix test`