### PR TITLE
Emit canonical runtime events from ReAct

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -8,6 +8,11 @@ Unknown function 'Elixir.Unicode':is_unicode/1
 Unknown function 'Elixir.Unicode':is_visible_ascii/1
 Unknown function 'Elixir.Unicode':is_visible_latin1/1
 Unknown function 'Elixir.Unicode':to_ucs4be/1
+deps/jido_signal/lib/jido_signal/using.ex:6: Function validate_policy_extension_data/4 will never be called
+deps/jido_signal/lib/jido_signal/using.ex:6: Function validate_policy_extension_entry/3 will never be called
+deps/jido_signal/lib/jido_signal/using.ex:11: Function validate_policy_extension_data/4 will never be called
+deps/jido_signal/lib/jido_signal/using.ex:11: Function validate_policy_extension_entry/3 will never be called
+deps/jido_signal/lib/jido_signal/using.ex:336: The pattern 'false' can never match the type 'true'
 missing specification for function from_latin9/1
 missing specification for function from_ucs2be/1
 missing specification for function from_ucs2be/2

--- a/lib/jido_ai/reasoning/graph_of_thoughts/machine.ex
+++ b/lib/jido_ai/reasoning/graph_of_thoughts/machine.ex
@@ -344,21 +344,20 @@ defmodule Jido.AI.Reasoning.GraphOfThoughts.Machine do
   """
   @spec get_ancestors(t(), String.t()) :: [String.t()]
   def get_ancestors(machine, node_id) do
-    get_ancestors_recursive(machine, node_id, MapSet.new())
-    |> MapSet.to_list()
+    machine
+    |> get_ancestors_recursive(node_id, [])
+    |> Enum.reverse()
   end
 
-  @spec get_ancestors_recursive(t(), String.t(), MapSet.t(String.t())) :: MapSet.t(String.t())
+  @spec get_ancestors_recursive(t(), String.t(), [String.t()]) :: [String.t()]
   defp get_ancestors_recursive(machine, node_id, visited) do
     parents = get_parents(machine, node_id)
 
     Enum.reduce(parents, visited, fn parent_id, acc ->
-      if MapSet.member?(acc, parent_id) do
+      if parent_id in acc do
         acc
       else
-        acc
-        |> MapSet.put(parent_id)
-        |> then(&get_ancestors_recursive(machine, parent_id, &1))
+        get_ancestors_recursive(machine, parent_id, [parent_id | acc])
       end
     end)
   end
@@ -368,21 +367,20 @@ defmodule Jido.AI.Reasoning.GraphOfThoughts.Machine do
   """
   @spec get_descendants(t(), String.t()) :: [String.t()]
   def get_descendants(machine, node_id) do
-    get_descendants_recursive(machine, node_id, MapSet.new())
-    |> MapSet.to_list()
+    machine
+    |> get_descendants_recursive(node_id, [])
+    |> Enum.reverse()
   end
 
-  @spec get_descendants_recursive(t(), String.t(), MapSet.t(String.t())) :: MapSet.t(String.t())
+  @spec get_descendants_recursive(t(), String.t(), [String.t()]) :: [String.t()]
   defp get_descendants_recursive(machine, node_id, visited) do
     children = get_children(machine, node_id)
 
     Enum.reduce(children, visited, fn child_id, acc ->
-      if MapSet.member?(acc, child_id) do
+      if child_id in acc do
         acc
       else
-        acc
-        |> MapSet.put(child_id)
-        |> then(&get_descendants_recursive(machine, child_id, &1))
+        get_descendants_recursive(machine, child_id, [child_id | acc])
       end
     end)
   end

--- a/lib/jido_ai/reasoning/react/event.ex
+++ b/lib/jido_ai/reasoning/react/event.ex
@@ -1,79 +1,24 @@
 defmodule Jido.AI.Reasoning.ReAct.Event do
   @moduledoc """
-  Compatibility wrapper around `Jido.AI.Runtime.Event`.
+  Deprecated compatibility wrapper for `Jido.AI.Runtime.Event`.
 
-  ReAct still emits `:input_injected` as a runtime-only compatibility event even
-  though that kind is not part of the generic shared runtime event contract.
+  ReAct streams now emit `Jido.AI.Runtime.Event` directly. Use the canonical
+  runtime event module for new code.
   """
 
   alias Jido.AI.Runtime.Event, as: RuntimeEvent
 
-  @kind_values RuntimeEvent.kinds() ++ [:input_injected]
+  @type t :: RuntimeEvent.t()
 
-  @type t :: %__MODULE__{
-          id: String.t(),
-          seq: integer(),
-          at_ms: integer(),
-          run_id: String.t(),
-          request_id: String.t(),
-          iteration: integer(),
-          kind: atom(),
-          llm_call_id: String.t() | nil,
-          tool_call_id: String.t() | nil,
-          tool_name: String.t() | nil,
-          data: map()
-        }
-
-  defstruct [
-    :id,
-    :seq,
-    :at_ms,
-    :run_id,
-    :request_id,
-    :iteration,
-    :kind,
-    :llm_call_id,
-    :tool_call_id,
-    :tool_name,
-    data: %{}
-  ]
-
+  @deprecated "Use Jido.AI.Runtime.Event.schema/0 instead"
   @doc false
-  def schema, do: RuntimeEvent.schema()
+  defdelegate schema(), to: RuntimeEvent
 
+  @deprecated "Use Jido.AI.Runtime.Event.kinds/0 instead"
   @spec kinds() :: [atom()]
-  def kinds, do: @kind_values
+  defdelegate kinds(), to: RuntimeEvent
 
-  @doc """
-  Create a new event envelope.
-  """
-  @spec new(map()) :: t()
-  def new(attrs) when is_map(attrs) do
-    attrs =
-      attrs
-      |> Map.put_new(:id, "evt_#{Jido.Util.generate_id()}")
-      |> Map.put_new(:at_ms, System.system_time(:millisecond))
-      |> Map.put_new(:llm_call_id, nil)
-      |> Map.put_new(:tool_call_id, nil)
-      |> Map.put_new(:tool_name, nil)
-      |> Map.put_new(:data, %{})
-
-    case Zoi.parse(RuntimeEvent.schema(), attrs) do
-      {:ok, event} ->
-        event
-        |> validate_kind!()
-        |> Map.from_struct()
-        |> then(&struct!(__MODULE__, &1))
-
-      {:error, errors} ->
-        raise ArgumentError, "invalid ReAct event: #{inspect(errors)}"
-    end
-  end
-
-  defp validate_kind!(%RuntimeEvent{kind: kind} = event) when kind in @kind_values, do: event
-
-  defp validate_kind!(%RuntimeEvent{kind: kind}) do
-    raise ArgumentError,
-          "invalid ReAct event kind: #{inspect(kind)}; expected one of #{inspect(@kind_values)}"
-  end
+  @deprecated "Use Jido.AI.Runtime.Event.new/1 instead"
+  @spec new(map()) :: RuntimeEvent.t()
+  defdelegate new(attrs), to: RuntimeEvent
 end

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -9,7 +9,8 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   alias Jido.AI.Output
   alias Jido.AI.PendingInputServer
   alias Jido.AI.Query
-  alias Jido.AI.Reasoning.ReAct.{Config, Event, PendingToolCall, State, Token, ToolSelection}
+  alias Jido.AI.Reasoning.ReAct.{Config, PendingToolCall, State, Token, ToolSelection}
+  alias Jido.AI.Runtime.Event
   alias Jido.AI.Effects
   alias Jido.AI.Context, as: AIContext
   alias Jido.AI.Error

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -908,7 +908,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   defp process_context_modify(agent, _params), do: {agent, []}
 
   defp initial_context(%Agent{} = agent, config) do
-    state = agent.state || %{}
+    state = agent.state
 
     case Map.fetch(state, :context) do
       {:ok, nil} ->

--- a/lib/jido_ai/reasoning/react/worker/strategy.ex
+++ b/lib/jido_ai/reasoning/react/worker/strategy.ex
@@ -7,7 +7,8 @@ defmodule Jido.AI.Reasoning.ReAct.Worker.Strategy do
   alias Jido.Agent.Directive, as: AgentDirective
   alias Jido.Agent.Strategy.State, as: StratState
   alias Jido.AI.Query
-  alias Jido.AI.Reasoning.ReAct.{Config, Event, Runner, Signal}
+  alias Jido.AI.Reasoning.ReAct.{Config, Runner, Signal}
+  alias Jido.AI.Runtime.Event
 
   @start :react_worker_start
   @cancel :react_worker_cancel

--- a/lib/jido_ai/request/stream.ex
+++ b/lib/jido_ai/request/stream.ex
@@ -3,11 +3,11 @@ defmodule Jido.AI.Request.Stream do
   Request-scoped runtime event streaming helpers.
 
   The stream transport is intentionally narrow: callers can provide a pid sink
-  and receive canonical ReAct runtime events for one request.
+  and receive canonical runtime events for one request.
   """
 
-  alias Jido.AI.Reasoning.ReAct.Event
   alias Jido.AI.Request.Handle
+  alias Jido.AI.Runtime.Event
 
   @message_tag :jido_ai_request_event
   @terminal_kinds [:request_completed, :request_failed, :request_cancelled]

--- a/lib/jido_ai/runtime/event.ex
+++ b/lib/jido_ai/runtime/event.ex
@@ -1,6 +1,9 @@
 defmodule Jido.AI.Runtime.Event do
   @moduledoc """
   Canonical runtime event envelope shared across AI reasoning runtimes.
+
+  `:input_injected` records user-visible input added to an active runtime run,
+  such as pending input drained by ReAct before continuing a request.
   """
 
   @kind_values [
@@ -17,7 +20,8 @@ defmodule Jido.AI.Runtime.Event do
     :checkpoint,
     :request_completed,
     :request_failed,
-    :request_cancelled
+    :request_cancelled,
+    :input_injected
   ]
 
   @schema Zoi.struct(

--- a/test/jido_ai/agent_test.exs
+++ b/test/jido_ai/agent_test.exs
@@ -9,7 +9,7 @@ defmodule Jido.AI.AgentTest do
   alias Jido.AI.Context, as: AIContext
   alias Jido.AI.Request
   alias Jido.AI.Agent
-  alias Jido.AI.Reasoning.ReAct.Event
+  alias Jido.AI.Runtime.Event
   alias Jido.AI.Reasoning.ReAct.Strategy, as: ReAct
   alias ReqLLM.Message.ContentPart
 

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -280,7 +280,7 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
       |> Enum.to_list()
 
     assert length(events) >= 6
-    assert Enum.all?(events, &is_map/1)
+    assert Enum.all?(events, &match?(%Jido.AI.Runtime.Event{}, &1))
 
     seqs = Enum.map(events, & &1.seq)
     assert seqs == Enum.sort(seqs)
@@ -451,6 +451,7 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
       ReAct.stream("Q1", config, request_id: "req_pending_after_final", run_id: "req_pending_after_final")
       |> Enum.to_list()
 
+    assert Enum.all?(events, &match?(%Jido.AI.Runtime.Event{}, &1))
     assert Enum.count(events, &(&1.kind == :llm_started)) == 2
     assert Enum.count(events, &(&1.kind == :llm_completed)) == 2
     assert Enum.count(events, &(&1.kind == :input_injected)) == 1

--- a/test/jido_ai/request_test.exs
+++ b/test/jido_ai/request_test.exs
@@ -3,7 +3,7 @@ defmodule JidoTest.AI.RequestTest do
 
   alias Jido.AI.Request
   alias Jido.AI.Request.Handle
-  alias Jido.AI.Reasoning.ReAct.Event
+  alias Jido.AI.Runtime.Event
   alias ReqLLM.Message.ContentPart
 
   defmodule TestRequestTransformer do

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -6,7 +6,7 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
   alias Jido.AI.Directive
   alias Jido.AI.PendingInputServer
   alias Jido.AI.Request
-  alias Jido.AI.Reasoning.ReAct.Event
+  alias Jido.AI.Runtime.Event
   alias Jido.AI.Reasoning.ReAct.Strategy, as: ReAct
   alias Jido.Thread
   alias Jido.Thread.Agent, as: ThreadAgent


### PR DESCRIPTION
## Summary
- add `:input_injected` to the canonical `Jido.AI.Runtime.Event` contract
- make ReAct runner, worker forwarding, and request stream helpers use `Jido.AI.Runtime.Event`
- keep `Jido.AI.Reasoning.ReAct.Event` as a deprecated compatibility wrapper via `@deprecated`
- strengthen ReAct runtime tests to assert canonical runtime event structs

## Why
`Jido.AI.Runtime.Event` is documented as the canonical runtime event envelope, but ReAct streams emitted `Jido.AI.Reasoning.ReAct.Event` because ReAct needed one extra `:input_injected` kind. Consumers matching the canonical runtime event struct could silently ignore ReAct stream events.

This makes the public runtime stream contract a single event entity while preserving source compatibility for callers that still use `ReAct.Event.new/1`, `kinds/0`, or `schema/0`.

## Validation
- `mix test test/jido_ai/react/runtime_runner_test.exs test/jido_ai/react/public_api_test.exs test/jido_ai/strategy/react_test.exs test/jido_ai/request_test.exs`
- `mix test`
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --min-priority high --all`
- `mix doctor --summary --raise`

`mix quality` currently reaches Dialyzer and fails on pre-existing warnings unrelated to this branch (`deps/jido_signal`, graph_of_thoughts opaque MapSet warnings, and `react/strategy.ex:911 guard_fail`).
