### PR TITLE
feat(skill): add lazy skill loading

### DIFF
--- a/guides/developer/actions_catalog.md
+++ b/guides/developer/actions_catalog.md
@@ -25,13 +25,15 @@ For direct app integration (`Jido.Exec`-driven), this is the primary standalone 
 5. Quota operations:
    - `Jido.AI.Actions.Quota.GetStatus`
    - `Jido.AI.Actions.Quota.Reset`
-6. Reasoning templates (optional):
+6. Skill orchestration:
+   - `Jido.AI.Actions.Skill.LoadSkill`
+7. Reasoning templates (optional):
    - `Jido.AI.Actions.Reasoning.Analyze`
    - `Jido.AI.Actions.Reasoning.Infer`
    - `Jido.AI.Actions.Reasoning.Explain`
-7. Dedicated strategy orchestration:
+8. Dedicated strategy orchestration:
    - `Jido.AI.Actions.Reasoning.RunStrategy`
-8. Compatibility convenience:
+9. Compatibility convenience:
    - `Jido.AI.Actions.LLM.Complete`
 
 ## LLM Actions
@@ -106,6 +108,14 @@ For direct app integration (`Jido.Exec`-driven), this is the primary standalone 
   - Output contract: `%{quota: %{scope, reset}}`.
   - Runnable example: [`examples/scripts/demo/actions_quota_runtime_demo.exs`](https://github.com/agentjido/jido_ai/blob/v2.0.0-rc.0/examples/scripts/demo/actions_quota_runtime_demo.exs)
 
+## Skill Actions
+
+- `Jido.AI.Actions.Skill.LoadSkill`
+  - Use when a prompt advertises a compact skill index and the selected skill body should be loaded only on demand.
+  - Required params: `name`. Optional params: `include_metadata` (default `true`).
+  - Output contract: `%{name, description, instructions}` plus metadata fields when requested.
+  - Pair with `Jido.AI.Skill.Prompt.render_registry_index/1` for tag-filtered skill indexes.
+
 ## Reasoning Actions
 
 - `Jido.AI.Actions.Reasoning.Analyze`
@@ -148,6 +158,7 @@ These belong to strategy orchestration and are not app-level AI primitives.
 - Need structured planning templates: use Planning actions.
 - Need in-process memory upsert/recall/clear primitives: use Retrieval actions.
 - Need rolling quota status or a quota counter reset operation: use Quota actions.
+- Need lazy skill body loading from a compact prompt index: use `LoadSkill`.
 - Need explicit reasoning strategy execution as a callable capability: use `RunStrategy`.
 
 ## Failure Mode: Action Used Outside Expected Context

--- a/guides/developer/skills_system.md
+++ b/guides/developer/skills_system.md
@@ -11,6 +11,7 @@ After this guide, you can load skill files, register specs, render prompts, and 
 - `Jido.AI.Skill.Loader`
 - `Jido.AI.Skill.Registry`
 - `Jido.AI.Skill.Prompt`
+- `Jido.AI.Actions.Skill.LoadSkill`
 - `mix jido_ai.skill`
 
 ## Lifecycle: Load, Register, Resolve, Retire
@@ -33,6 +34,36 @@ Registry lifecycle guarantees:
 - explicit startup via `start_link/1`
 - lazy startup via `ensure_started/0` used by public APIs
 - safe unregister/clear operations for runtime teardown
+
+## Lazy Loading Skill Bodies
+
+Use a compact skill index when full skill bodies would make the agent prompt too
+large. The index advertises names and descriptions only; the model can call the
+packaged `load_skill` action to retrieve the selected body.
+
+```elixir
+index =
+  Jido.AI.Skill.Prompt.render_registry_index(
+    tags: "support-agent",
+    include_allowed_tools: true
+  )
+
+# Add `index` to your agent system prompt and expose this action with the agent tools.
+Jido.AI.Actions.Skill.LoadSkill
+```
+
+The rendered index includes guidance for the model to call `load_skill` with the
+skill name. `render_registry_index/1` accepts `:tags` and `:tag_match` so agents
+can advertise only the skills intended for that agent.
+
+You can load a skill directly from application code as well:
+
+```elixir
+{:ok, loaded} =
+  Jido.AI.Actions.Skill.LoadSkill.run(%{name: "code-review"}, %{})
+
+loaded.instructions
+```
 
 ## CLI Surface + Error Handling
 

--- a/guides/user/package_overview.md
+++ b/guides/user/package_overview.md
@@ -153,9 +153,11 @@ Finalized standalone action set (recommended):
    - `Jido.AI.Actions.Reasoning.Analyze`
    - `Jido.AI.Actions.Reasoning.Infer`
    - `Jido.AI.Actions.Reasoning.Explain`
-5. Dedicated strategy orchestration
+5. Skill orchestration
+   - `Jido.AI.Actions.Skill.LoadSkill` (lazy skill body loading from a compact prompt index)
+6. Dedicated strategy orchestration
    - `Jido.AI.Actions.Reasoning.RunStrategy` (isolated strategy execution for `:cod | :cot | :aot | :tot | :got | :trm | :adaptive`)
-6. Compatibility convenience
+7. Compatibility convenience
    - `Jido.AI.Actions.LLM.Complete` (simple completion path; overlaps with `Chat` and can remain as convenience)
 
 Not part of standalone action surface:

--- a/lib/jido_ai/actions/skill/load_skill.ex
+++ b/lib/jido_ai/actions/skill/load_skill.ex
@@ -1,0 +1,102 @@
+defmodule Jido.AI.Actions.Skill.LoadSkill do
+  @moduledoc """
+  A Jido.Action for lazily loading registered skill instructions.
+
+  Pair this action with `Jido.AI.Skill.Prompt.render_registry_index/1` to expose
+  a compact skill index in an agent prompt. The model can call `load_skill` only
+  after selecting a relevant skill, keeping full skill bodies out of the prompt
+  until they are needed.
+
+  ## Parameters
+
+  * `name` (required) - Registered skill name to load.
+  * `include_metadata` (optional) - Include skill metadata in the response
+    (default: `true`).
+
+  ## Examples
+
+      {:ok, result} =
+        Jido.Exec.run(Jido.AI.Actions.Skill.LoadSkill, %{name: "code-review"})
+
+      result.instructions
+      #=> "# Code Review..."
+  """
+
+  use Jido.Action,
+    name: "load_skill",
+    description: """
+    Loads the full instructions for a registered skill by name. Call this after
+    selecting a skill from a compact skill index.
+    """,
+    category: "ai",
+    tags: ["skills", "lazy-loading"],
+    vsn: "1.0.0",
+    schema:
+      Zoi.object(%{
+        name: Zoi.string(description: "The registered skill name to load"),
+        include_metadata:
+          Zoi.boolean(description: "Include metadata such as tags and allowed tools")
+          |> Zoi.default(true)
+          |> Zoi.optional()
+      })
+
+  alias Jido.AI.Skill
+  alias Jido.AI.Skill.{Registry, Spec}
+  alias Jido.AI.Validation
+
+  @doc """
+  Loads the requested skill body from the registry.
+  """
+  @impl Jido.Action
+  def run(params, _context) do
+    with {:ok, name} <- validate_name(params[:name]) do
+      case Skill.resolve(name) do
+        {:ok, %Spec{} = spec} ->
+          {:ok, payload(spec, params[:include_metadata] != false)}
+
+        {:error, _reason} ->
+          {:error,
+           %{
+             type: :skill_not_found,
+             message: "Unknown skill '#{name}'",
+             available_skills: Registry.list() |> Enum.sort()
+           }}
+      end
+    end
+  end
+
+  defp validate_name(name) when is_binary(name) do
+    name = String.trim(name)
+
+    with false <- name == "",
+         {:ok, _name} <- Validation.validate_string(name, max_length: 128, allow_empty: false) do
+      {:ok, name}
+    else
+      true -> {:error, %{type: :invalid_skill_name, message: "Skill name is required"}}
+      {:error, reason} -> {:error, %{type: :invalid_skill_name, message: "Invalid skill name", reason: reason}}
+    end
+  end
+
+  defp validate_name(_), do: {:error, %{type: :invalid_skill_name, message: "Skill name is required"}}
+
+  defp payload(%Spec{} = spec, true) do
+    spec
+    |> payload(false)
+    |> Map.merge(%{
+      allowed_tools: spec.allowed_tools,
+      tags: spec.tags,
+      metadata: spec.metadata || %{},
+      license: spec.license,
+      compatibility: spec.compatibility,
+      vsn: spec.vsn
+    })
+  end
+
+  defp payload(%Spec{} = spec, false) do
+    %{
+      name: spec.name,
+      description: spec.description,
+      instructions: Skill.body(spec)
+    }
+  end
+end

--- a/lib/jido_ai/actions/skill/load_skill.ex
+++ b/lib/jido_ai/actions/skill/load_skill.ex
@@ -128,15 +128,6 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
     end
   end
 
-  defp load_instructions(%Spec{name: name}) do
-    {:error,
-     %{
-       type: :skill_body_unavailable,
-       message: "Could not load skill body for '#{name}'",
-       reason: :invalid_body_ref
-     }}
-  end
-
   defp payload(%Spec{} = spec, instructions, true) do
     spec
     |> payload(instructions, false)

--- a/lib/jido_ai/actions/skill/load_skill.ex
+++ b/lib/jido_ai/actions/skill/load_skill.ex
@@ -44,44 +44,102 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
   alias Jido.AI.Skill.{Registry, Spec}
   alias Jido.AI.Validation
 
+  @name_regex ~r/^[a-z0-9]+(-[a-z0-9]+)*$/
+  @max_name_length 64
+
   @doc """
   Loads the requested skill body from the registry.
   """
   @impl Jido.Action
-  def run(params, _context) do
-    with {:ok, name} <- validate_name(params[:name]) do
-      case Skill.resolve(name) do
-        {:ok, %Spec{} = spec} ->
-          {:ok, payload(spec, params[:include_metadata] != false)}
-
-        {:error, _reason} ->
-          {:error,
-           %{
-             type: :skill_not_found,
-             message: "Unknown skill '#{name}'",
-             available_skills: Registry.list() |> Enum.sort()
-           }}
-      end
+  def run(params, _context) when is_map(params) do
+    with {:ok, name} <- validate_name(param(params, :name)),
+         {:ok, include_metadata?} <- validate_include_metadata(param(params, :include_metadata, true)),
+         {:ok, %Spec{} = spec} <- resolve_skill(name),
+         {:ok, instructions} <- load_instructions(spec) do
+      {:ok, payload(spec, instructions, include_metadata?)}
     end
   end
 
-  defp validate_name(name) when is_binary(name) do
-    name = String.trim(name)
+  def run(_params, _context), do: {:error, %{type: :invalid_params, message: "Parameters must be a map"}}
 
-    with false <- name == "",
-         {:ok, _name} <- Validation.validate_string(name, max_length: 128, allow_empty: false) do
-      {:ok, name}
-    else
-      true -> {:error, %{type: :invalid_skill_name, message: "Skill name is required"}}
+  defp param(params, key, default \\ nil) do
+    Map.get(params, key, Map.get(params, Atom.to_string(key), default))
+  end
+
+  defp validate_name(nil), do: {:error, %{type: :invalid_skill_name, message: "Skill name is required"}}
+
+  defp validate_name(name) do
+    case Validation.validate_string(name, max_length: @max_name_length, allow_empty: false) do
+      {:ok, name} -> validate_name_format(name)
+      {:error, :empty_string} -> {:error, %{type: :invalid_skill_name, message: "Skill name is required"}}
       {:error, reason} -> {:error, %{type: :invalid_skill_name, message: "Invalid skill name", reason: reason}}
     end
   end
 
-  defp validate_name(_), do: {:error, %{type: :invalid_skill_name, message: "Skill name is required"}}
+  defp validate_name_format(name) do
+    if Regex.match?(@name_regex, name) do
+      {:ok, name}
+    else
+      {:error, %{type: :invalid_skill_name, message: "Invalid skill name", reason: :invalid_format}}
+    end
+  end
 
-  defp payload(%Spec{} = spec, true) do
+  defp validate_include_metadata(nil), do: {:ok, true}
+  defp validate_include_metadata(include_metadata?) when is_boolean(include_metadata?), do: {:ok, include_metadata?}
+
+  defp validate_include_metadata(_include_metadata?) do
+    {:error,
+     %{
+       type: :invalid_include_metadata,
+       message: "include_metadata must be a boolean"
+     }}
+  end
+
+  defp resolve_skill(name) do
+    case Skill.resolve(name) do
+      {:ok, %Spec{} = spec} ->
+        {:ok, spec}
+
+      {:error, _reason} ->
+        {:error,
+         %{
+           type: :skill_not_found,
+           message: "Unknown skill '#{name}'",
+           available_skills: Registry.list() |> Enum.sort()
+         }}
+    end
+  end
+
+  defp load_instructions(%Spec{body_ref: {:inline, instructions}}) when is_binary(instructions), do: {:ok, instructions}
+  defp load_instructions(%Spec{body_ref: nil}), do: {:ok, ""}
+
+  defp load_instructions(%Spec{name: name, body_ref: {:file, path}}) when is_binary(path) do
+    case File.read(path) do
+      {:ok, instructions} ->
+        {:ok, instructions}
+
+      {:error, reason} ->
+        {:error,
+         %{
+           type: :skill_body_unavailable,
+           message: "Could not load skill body for '#{name}'",
+           reason: reason
+         }}
+    end
+  end
+
+  defp load_instructions(%Spec{name: name}) do
+    {:error,
+     %{
+       type: :skill_body_unavailable,
+       message: "Could not load skill body for '#{name}'",
+       reason: :invalid_body_ref
+     }}
+  end
+
+  defp payload(%Spec{} = spec, instructions, true) do
     spec
-    |> payload(false)
+    |> payload(instructions, false)
     |> Map.merge(%{
       allowed_tools: spec.allowed_tools,
       tags: spec.tags,
@@ -92,11 +150,11 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
     })
   end
 
-  defp payload(%Spec{} = spec, false) do
+  defp payload(%Spec{} = spec, instructions, false) do
     %{
       name: spec.name,
       description: spec.description,
-      instructions: Skill.body(spec)
+      instructions: instructions
     }
   end
 end

--- a/lib/jido_ai/skill/prompt.ex
+++ b/lib/jido_ai/skill/prompt.ex
@@ -7,7 +7,13 @@ defmodule Jido.AI.Skill.Prompt do
   """
 
   alias Jido.AI.Skill
-  alias Jido.AI.Skill.Spec
+  alias Jido.AI.Skill.{Registry, Spec}
+
+  @default_index_header "## Skills"
+  @default_load_instruction """
+  When the user's request matches a skill above, call `load_skill` with the skill
+  name to retrieve the full instructions, then follow them step by step.
+  """
 
   @doc """
   Renders a list of skills into a formatted prompt section.
@@ -39,6 +45,60 @@ defmodule Jido.AI.Skill.Prompt do
     else
       "#{header}\n\n#{skill_sections}"
     end
+  end
+
+  @doc """
+  Renders a compact, model-facing skill index.
+
+  Unlike `render/2`, this function intentionally omits skill bodies so prompts
+  can advertise available skills without loading their full instructions. Pair
+  the rendered index with `Jido.AI.Actions.Skill.LoadSkill` so a model can load
+  the selected skill body on demand.
+
+  ## Options
+
+  - `:tags` - String, atom, or list of tags used to filter skills.
+  - `:tag_match` - `:any` (default) or `:all` when multiple tags are provided.
+  - `:header` - Header text (default: `"## Skills"`). Set to `false` or `nil`
+    to omit.
+  - `:load_instruction` - Instruction appended after the index. Set to `false`
+    or `nil` to omit.
+  - `:include_allowed_tools` - Append allowed tool names to each entry.
+  """
+  @spec render_index([module() | Spec.t() | String.t()], keyword()) :: String.t()
+  def render_index(skills, opts \\ []) do
+    tag_filter = normalize_tags(Keyword.get(opts, :tags, []))
+    tag_match = Keyword.get(opts, :tag_match, :any)
+    include_allowed_tools = Keyword.get(opts, :include_allowed_tools, false)
+
+    entries =
+      skills
+      |> Enum.map(&resolve_skill/1)
+      |> Enum.reject(&is_nil/1)
+      |> filter_by_tags(tag_filter, tag_match)
+      |> Enum.map_join("\n", &format_index_entry(&1, include_allowed_tools))
+
+    if entries == "" do
+      ""
+    else
+      opts
+      |> index_parts(entries)
+      |> Enum.join("\n\n")
+    end
+  end
+
+  @doc """
+  Renders a compact index for skills currently registered in the runtime registry.
+
+  This is the common entry point for lazy skill loading: register runtime skills,
+  render a filtered index into the agent system prompt, and expose the
+  `load_skill` action so the agent can retrieve the full body only when needed.
+  """
+  @spec render_registry_index(keyword()) :: String.t()
+  def render_registry_index(opts \\ []) do
+    Registry.all()
+    |> Enum.sort_by(& &1.name)
+    |> render_index(opts)
   end
 
   @doc """
@@ -120,6 +180,65 @@ defmodule Jido.AI.Skill.Prompt do
     """
     |> String.trim_trailing()
   end
+
+  defp index_parts(opts, entries) do
+    header = Keyword.get(opts, :header, @default_index_header)
+    load_instruction = Keyword.get(opts, :load_instruction, @default_load_instruction)
+
+    [header, entries, load_instruction]
+    |> Enum.reject(&(&1 in [nil, false, ""]))
+    |> Enum.map(&String.trim/1)
+  end
+
+  defp format_index_entry(%Spec{} = spec, include_allowed_tools) do
+    tools =
+      case {include_allowed_tools, spec.allowed_tools} do
+        {true, [_ | _] = allowed_tools} -> " (tools: #{Enum.join(allowed_tools, ", ")})"
+        _ -> ""
+      end
+
+    description =
+      spec.description
+      |> String.trim()
+      |> String.replace("\n", "\n  ")
+
+    "* **#{spec.name}**: #{description}#{tools}"
+  end
+
+  defp filter_by_tags(specs, [], _tag_match), do: specs
+
+  defp filter_by_tags(specs, tags, :all) do
+    required = MapSet.new(tags)
+
+    Enum.filter(specs, fn %Spec{tags: spec_tags} ->
+      spec_set = spec_tags |> normalize_tags() |> MapSet.new()
+      MapSet.subset?(required, spec_set)
+    end)
+  end
+
+  defp filter_by_tags(specs, tags, _tag_match) do
+    wanted = MapSet.new(tags)
+
+    Enum.filter(specs, fn %Spec{tags: spec_tags} ->
+      spec_tags
+      |> normalize_tags()
+      |> Enum.any?(&MapSet.member?(wanted, &1))
+    end)
+  end
+
+  defp normalize_tags(nil), do: []
+  defp normalize_tags(tag) when is_atom(tag), do: [Atom.to_string(tag)]
+  defp normalize_tags(tag) when is_binary(tag), do: [tag]
+
+  defp normalize_tags(tags) when is_list(tags) do
+    tags
+    |> Enum.flat_map(&normalize_tags/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp normalize_tags(_), do: []
 
   defp get_tool_name(tool) when is_atom(tool) do
     if function_exported?(tool, :name, 0) do

--- a/mix.exs
+++ b/mix.exs
@@ -220,6 +220,9 @@ defmodule JidoAi.MixProject do
         "Actions — Quota": [
           ~r/Jido\.AI\.Actions\.Quota\..*/
         ],
+        "Actions — Skill": [
+          ~r/Jido\.AI\.Actions\.Skill\..*/
+        ],
         "Reasoning Strategies": [
           Jido.AI.Reasoning.Helpers,
           ~r/Jido\.AI\.Reasoning\..*/

--- a/test/jido_ai/skill/prompt_test.exs
+++ b/test/jido_ai/skill/prompt_test.exs
@@ -22,6 +22,20 @@ defmodule Jido.AI.Skill.PromptTest do
       description: "Minimal skill with no tools."
   end
 
+  defmodule TaggedSkill do
+    use Jido.AI.Skill,
+      name: "tagged-skill",
+      description: """
+      Helps tagged agents.
+      Use when the agent needs scoped instructions.
+      """,
+      allowed_tools: ~w(load_skill),
+      tags: ["support", "agent-a"],
+      body: """
+      # Tagged Skill Body
+      """
+  end
+
   # Mock tool modules
   defmodule MockToolA do
     def name, do: "tool_a"
@@ -104,6 +118,61 @@ defmodule Jido.AI.Skill.PromptTest do
     test "returns empty string for unknown skill" do
       result = Prompt.render_one("unknown")
       assert result == ""
+    end
+  end
+
+  describe "render_index/2" do
+    test "renders compact entries without skill bodies" do
+      result = Prompt.render_index([TestSkill, TaggedSkill], include_allowed_tools: true)
+
+      assert result =~ "## Skills"
+      assert result =~ "* **test-skill**: A test skill. (tools: tool_a, tool_b)"
+      assert result =~ "* **tagged-skill**: Helps tagged agents.\n  Use when the agent needs scoped instructions."
+      assert result =~ "call `load_skill`"
+      refute result =~ "# Test Skill Body"
+      refute result =~ "# Tagged Skill Body"
+    end
+
+    test "filters compact entries by any tag" do
+      result = Prompt.render_index([TestSkill, TaggedSkill], tags: ["agent-a"])
+
+      assert result =~ "tagged-skill"
+      refute result =~ "test-skill"
+    end
+
+    test "filters compact entries by all tags" do
+      result = Prompt.render_index([TaggedSkill], tags: ["support", "agent-a"], tag_match: :all)
+      assert result =~ "tagged-skill"
+
+      result = Prompt.render_index([TaggedSkill], tags: ["support", "agent-b"], tag_match: :all)
+      assert result == ""
+    end
+
+    test "can omit header and load instruction" do
+      result = Prompt.render_index([TestSkill], header: false, load_instruction: false)
+
+      assert result == "* **test-skill**: A test skill."
+    end
+  end
+
+  describe "render_registry_index/1" do
+    test "renders registered skills filtered by tag" do
+      Registry.register(%{
+        TaggedSkill.manifest()
+        | name: "runtime-agent-skill",
+          tags: ["agent-b"]
+      })
+
+      Registry.register(%{
+        TestSkill.manifest()
+        | name: "runtime-other-skill",
+          tags: ["other"]
+      })
+
+      result = Prompt.render_registry_index(tags: "agent-b")
+
+      assert result =~ "runtime-agent-skill"
+      refute result =~ "runtime-other-skill"
     end
   end
 

--- a/test/jido_ai/skills/schema_integration_test.exs
+++ b/test/jido_ai/skills/schema_integration_test.exs
@@ -21,21 +21,8 @@ defmodule Jido.AI.Plugins.SchemaIntegrationTest do
   }
 
   alias Jido.AI.Actions.Reasoning.RunStrategy
+  alias Jido.AI.Actions.Skill.LoadSkill
   alias Jido.AI.Actions.ToolCalling.{CallWithTools, ExecuteTool, ListTools}
-
-  require Jido.AI.Plugins.Chat
-  require Jido.AI.Actions.LLM.{Chat, Complete, Embed, GenerateObject}
-  require Jido.AI.Plugins.Planning
-  require Jido.AI.Actions.Planning.{Plan, Decompose, Prioritize}
-  require Jido.AI.Plugins.Reasoning.Adaptive
-  require Jido.AI.Plugins.Reasoning.AlgorithmOfThoughts
-  require Jido.AI.Plugins.Reasoning.ChainOfDraft
-  require Jido.AI.Plugins.Reasoning.ChainOfThought
-  require Jido.AI.Plugins.Reasoning.GraphOfThoughts
-  require Jido.AI.Plugins.Reasoning.TRM
-  require Jido.AI.Plugins.Reasoning.TreeOfThoughts
-  require Jido.AI.Actions.Reasoning.RunStrategy
-  require Jido.AI.Actions.ToolCalling.{CallWithTools, ExecuteTool, ListTools}
 
   describe "LLM and Tool-Calling Action Schemas" do
     test "Chat action has schema function" do
@@ -85,6 +72,12 @@ defmodule Jido.AI.Plugins.SchemaIntegrationTest do
     end
   end
 
+  describe "Skill Action Schemas" do
+    test "LoadSkill action has schema function" do
+      assert function_exported?(LoadSkill, :schema, 0)
+    end
+  end
+
   describe "Schema Structure" do
     test "all core action schemas return map-like structures" do
       actions = [
@@ -98,13 +91,14 @@ defmodule Jido.AI.Plugins.SchemaIntegrationTest do
         CallWithTools,
         ExecuteTool,
         ListTools,
+        LoadSkill,
         RunStrategy
       ]
 
       for action <- actions do
         schema = action.schema()
 
-        assert is_map(schema) or is_struct(schema),
+        assert is_map(schema),
                "#{inspect(action)} schema should return a map-like structure"
       end
     end

--- a/test/jido_ai/skills/skill/actions/load_skill_test.exs
+++ b/test/jido_ai/skills/skill/actions/load_skill_test.exs
@@ -1,0 +1,76 @@
+defmodule Jido.AI.Actions.Skill.LoadSkillTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.AI.Actions.Skill.LoadSkill
+  alias Jido.AI.Skill.{Registry, Spec}
+
+  setup do
+    start_supervised!(Registry)
+
+    :ok =
+      Registry.register(%Spec{
+        name: "insights",
+        description: "Analyze product signals.",
+        body_ref: {:inline, "# Insights\n\nFollow the product analysis workflow."},
+        allowed_tools: ["read_file", "search"],
+        tags: ["product", "analyst"],
+        metadata: %{owner: "research"},
+        license: "MIT",
+        compatibility: ">= 2.0.0",
+        vsn: "1.2.3"
+      })
+
+    :ok
+  end
+
+  describe "schema" do
+    test "has expected fields" do
+      assert LoadSkill.schema().fields[:name].meta.required == true
+      assert LoadSkill.schema().fields[:include_metadata].value == true
+    end
+  end
+
+  describe "run/2" do
+    test "loads full instructions for a registered skill" do
+      assert {:ok, result} = LoadSkill.run(%{name: "insights"}, %{})
+
+      assert result.name == "insights"
+      assert result.description == "Analyze product signals."
+      assert result.instructions == "# Insights\n\nFollow the product analysis workflow."
+      assert result.allowed_tools == ["read_file", "search"]
+      assert result.tags == ["product", "analyst"]
+      assert result.metadata == %{owner: "research"}
+      assert result.license == "MIT"
+      assert result.compatibility == ">= 2.0.0"
+      assert result.vsn == "1.2.3"
+    end
+
+    test "can omit metadata fields" do
+      assert {:ok, result} = LoadSkill.run(%{name: "insights", include_metadata: false}, %{})
+
+      assert result == %{
+               name: "insights",
+               description: "Analyze product signals.",
+               instructions: "# Insights\n\nFollow the product analysis workflow."
+             }
+    end
+
+    test "trims skill names before lookup" do
+      assert {:ok, result} = LoadSkill.run(%{name: " insights "}, %{})
+      assert result.name == "insights"
+    end
+
+    test "returns structured error with available skills when missing" do
+      assert {:error, error} = LoadSkill.run(%{name: "missing"}, %{})
+
+      assert error.type == :skill_not_found
+      assert error.message == "Unknown skill 'missing'"
+      assert error.available_skills == ["insights"]
+    end
+
+    test "rejects missing or blank skill names" do
+      assert {:error, %{type: :invalid_skill_name}} = LoadSkill.run(%{}, %{})
+      assert {:error, %{type: :invalid_skill_name}} = LoadSkill.run(%{name: "  "}, %{})
+    end
+  end
+end

--- a/test/jido_ai/skills/skill/actions/load_skill_test.exs
+++ b/test/jido_ai/skills/skill/actions/load_skill_test.exs
@@ -60,6 +60,16 @@ defmodule Jido.AI.Actions.Skill.LoadSkillTest do
       assert result.name == "insights"
     end
 
+    test "accepts string-keyed tool parameters" do
+      assert {:ok, result} = LoadSkill.run(%{"name" => "insights", "include_metadata" => false}, %{})
+
+      assert result == %{
+               name: "insights",
+               description: "Analyze product signals.",
+               instructions: "# Insights\n\nFollow the product analysis workflow."
+             }
+    end
+
     test "returns structured error with available skills when missing" do
       assert {:error, error} = LoadSkill.run(%{name: "missing"}, %{})
 
@@ -68,9 +78,46 @@ defmodule Jido.AI.Actions.Skill.LoadSkillTest do
       assert error.available_skills == ["insights"]
     end
 
-    test "rejects missing or blank skill names" do
+    test "returns structured error when a skill body file is unavailable" do
+      missing_path = Path.join(System.tmp_dir!(), "missing-skill-#{System.unique_integer([:positive])}.md")
+
+      :ok =
+        Registry.register(%Spec{
+          name: "file-backed",
+          description: "Loads from disk.",
+          body_ref: {:file, missing_path}
+        })
+
+      assert {:error, error} = LoadSkill.run(%{name: "file-backed"}, %{})
+
+      assert error.type == :skill_body_unavailable
+      assert error.message == "Could not load skill body for 'file-backed'"
+      assert error.reason == :enoent
+    end
+
+    test "rejects missing, blank, or invalid skill names" do
       assert {:error, %{type: :invalid_skill_name}} = LoadSkill.run(%{}, %{})
       assert {:error, %{type: :invalid_skill_name}} = LoadSkill.run(%{name: "  "}, %{})
+
+      assert {:error, %{type: :invalid_skill_name, reason: :invalid_format}} =
+               LoadSkill.run(%{name: "Invalid_Name"}, %{})
+
+      assert {:error, %{type: :invalid_skill_name, reason: :string_too_long}} =
+               LoadSkill.run(%{name: String.duplicate("a", 65)}, %{})
+    end
+
+    test "rejects invalid include_metadata values" do
+      assert {:error, error} = LoadSkill.run(%{name: "insights", include_metadata: "false"}, %{})
+
+      assert error.type == :invalid_include_metadata
+      assert error.message == "include_metadata must be a boolean"
+    end
+
+    test "rejects non-map parameters" do
+      assert {:error, error} = LoadSkill.run([], %{})
+
+      assert error.type == :invalid_params
+      assert error.message == "Parameters must be a map"
     end
   end
 end


### PR DESCRIPTION
## Summary

- add `Jido.AI.Actions.Skill.LoadSkill` for model-facing skill body retrieval
- add compact `Jido.AI.Skill.Prompt.render_index/2` and `render_registry_index/1` with tag filtering
- document lazy skill loading and add schema/prompt/action tests

Fixes #313

## Validation

- `mix test test/jido_ai/skill/prompt_test.exs test/jido_ai/skills/skill/actions/load_skill_test.exs test/jido_ai/skills/schema_integration_test.exs`
- `mix compile --warnings-as-errors`
- `mix test.fast`
- `mix precommit`