### PR TITLE
[codex] clarify tool action effect boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ end
 Use `jido_ai` when you need long-lived agents, tool-calling loops, or explicit reasoning strategies. You can also use it without a running agent process via `Jido.AI.generate_text/2`, `Jido.AI.ask/2`, or `Jido.Exec.run/3` with any action module.
 For cross-package tutorials and the package map, see [jido.run/ecosystem](https://jido.run/ecosystem).
 
+In `jido_ai`, tool actions are allowed to be effectful. They often perform HTTP, LLM, database, or file I/O because the model needs the result back in the same ReAct loop. The purity boundary lives in the agent strategy and runtime orchestration layer: use a tool action when the next reasoning step needs the result now, and use directives, signals, or runtime integrations when an outbound effect has already been decided and the runtime should own delivery.
+
 ## Installation
 
 ### Igniter Installation (Recommended)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ end
 Use `jido_ai` when you need long-lived agents, tool-calling loops, or explicit reasoning strategies. You can also use it without a running agent process via `Jido.AI.generate_text/2`, `Jido.AI.ask/2`, or `Jido.Exec.run/3` with any action module.
 For cross-package tutorials and the package map, see [jido.run/ecosystem](https://jido.run/ecosystem).
 
-In `jido_ai`, tool actions are allowed to be effectful. They often perform HTTP, LLM, database, or file I/O because the model needs the result back in the same ReAct loop. The purity boundary lives in the agent strategy and runtime orchestration layer: use a tool action when the next reasoning step needs the result now, and use directives, signals, or runtime integrations when an outbound effect has already been decided and the runtime should own delivery.
+In `jido_ai`, tool actions are allowed to be effectful. They often perform HTTP, LLM, database, or file I/O because the model needs the result back in the same ReAct loop.
+
+The purity boundary lives around agent strategy decisions and runtime orchestration, not necessarily inside each tool action. Use a tool action when the next reasoning step needs the result now. Use directives, signals, or runtime integrations when an outbound effect has already been decided and the runtime should own delivery, retry, and observability.
 
 ## Installation
 

--- a/guides/developer/architecture_and_runtime_flow.md
+++ b/guides/developer/architecture_and_runtime_flow.md
@@ -15,10 +15,17 @@ After this guide, you can trace one request end-to-end and debug failures at the
 
 ## Key Boundaries
 
-- Strategy: state transitions and orchestration policy
-- Directive: side-effect intent only
-- Runtime: side-effect execution and signal emission
+- Strategy: pure state transitions and orchestration policy
+- Tool action: reusable execution unit that may be pure or effectful when the current reasoning loop needs its result
+- Directive: runtime-owned side-effect intent only
+- Runtime: directive execution, tool execution, retries, timeouts, and signal emission
 - Signal: typed contract between runtime and strategy
+
+The practical rule is: use an effectful tool action when the model or workflow
+needs the result now to continue a ReAct/tool-calling loop. Use a directive,
+signal, or runtime integration when the workflow has already decided on an
+outbound effect and wants runtime policy to own delivery, retry, and
+observability.
 
 ## Minimal Trace Setup
 

--- a/guides/user/first_react_agent.md
+++ b/guides/user/first_react_agent.md
@@ -18,6 +18,16 @@ defmodule MyApp.Actions.AddNumbers do
 end
 ```
 
+This arithmetic tool is pure, but tool actions do not have to be. A ReAct agent
+uses tools when the model or workflow needs a result now, so a tool can call an
+HTTP API, query a database, read a file, run retrieval, or call another model and
+return that data from `run/2`.
+
+When the workflow has already decided on an outbound effect, such as sending a
+notification or publishing a final event, prefer a runtime-owned directive,
+signal, or integration so delivery policy stays outside the strategy decision
+logic.
+
 ## Build The Agent
 
 ```elixir

--- a/guides/user/first_react_agent.md
+++ b/guides/user/first_react_agent.md
@@ -45,6 +45,8 @@ end
 ## Optional: Configure Tool Effect Policy
 
 Use `effect_policy` to bound which tool-emitted effects are allowed at runtime.
+It applies to effects returned from the tool result, such as `StateOp.SetState`
+or `Directive.Emit`; it is not a rule that tool `run/2` functions must be pure.
 
 ```elixir
 defmodule MyApp.SafeMathAgent do

--- a/guides/user/tool_calling_with_actions.md
+++ b/guides/user/tool_calling_with_actions.md
@@ -20,6 +20,22 @@ defmodule MyApp.Actions.Multiply do
 end
 ```
 
+## Tool I/O Boundary
+
+Tool actions may be pure or effectful. In ReAct-style loops, the model calls a
+tool because it needs the result before it can continue reasoning, so HTTP, LLM,
+database, file, or retrieval I/O inside `run/2` is normal when that result is the
+tool output.
+
+Use directives, signals, or runtime integrations when the workflow has already
+decided on an outbound effect and wants the runtime to own delivery, retries, or
+observability.
+
+| Workflow step | Use |
+|---|---|
+| Fetch an account record, search an index, call a weather API, or ask another model so the current turn can continue | Effectful tool action that returns the data from `run/2` |
+| Send a final email, publish a webhook, emit an audit signal, or dispatch a notification after the decision is made | Runtime-owned directive, signal, or integration |
+
 ## One-Shot Tool Calling (`CallWithTools`)
 
 One-shot mode returns a terminal turn map without executing tools automatically.

--- a/guides/user/tool_calling_with_actions.md
+++ b/guides/user/tool_calling_with_actions.md
@@ -27,6 +27,10 @@ tool because it needs the result before it can continue reasoning, so HTTP, LLM,
 database, file, or retrieval I/O inside `run/2` is normal when that result is the
 tool output.
 
+This direct I/O is separate from tool-emitted effects returned in the optional
+third tuple. `effect_policy` filters returned effects such as `StateOp.SetState`
+or `Directive.Emit`; it does not require every `run/2` implementation to be pure.
+
 Use directives, signals, or runtime integrations when the workflow has already
 decided on an outbound effect and wants the runtime to own delivery, retries, or
 observability.


### PR DESCRIPTION
## Summary

- Clarify that `Jido.Action` tool actions may perform I/O when a ReAct/tool-calling loop needs the result immediately.
- Add a concrete decision rule for effectful tools vs runtime-owned directives, signals, and integrations.
- Distinguish direct I/O inside `run/2` from tool-emitted effects filtered by `effect_policy`.
- Align the developer architecture guide with the strategy/runtime purity boundary.

## Why

Fixes #243. The existing docs covered tools, effects, directives, and pure strategy boundaries, but did not say plainly enough that effectful tool actions are normal when the model needs the result back in the same reasoning loop.

## Validation

- `mix docs`
- `git diff --check -- README.md guides/user/tool_calling_with_actions.md guides/user/first_react_agent.md guides/developer/architecture_and_runtime_flow.md`
