### PR TITLE
fix(output): accept string-keyed JSON Schema in imported_schema?/1

### DIFF
--- a/lib/jido_ai/output.ex
+++ b/lib/jido_ai/output.ex
@@ -220,8 +220,8 @@ defmodule Jido.AI.Output do
   @doc false
   @spec imported_schema?(term()) :: boolean()
   def imported_schema?(%{} = schema) do
-    type = schema[:type]
-    properties = schema[:properties]
+    type = schema[:type] || schema["type"]
+    properties = schema[:properties] || schema["properties"]
     type in ["object", :object] and is_map(properties)
   end
 

--- a/test/jido_ai/output_test.exs
+++ b/test/jido_ai/output_test.exs
@@ -69,6 +69,17 @@ defmodule Jido.AI.OutputTest do
     assert {:error, _reason} = Output.new(schema: Zoi.string())
   end
 
+  test "accepts a string-keyed JSON Schema (as decoded from JSON over the wire)" do
+    json_schema = %{
+      "type" => "object",
+      "properties" => %{"summary" => %{"type" => "string"}},
+      "required" => ["summary"]
+    }
+
+    assert Output.imported_schema?(json_schema)
+    assert {:ok, %Output{schema_kind: :json_schema}} = Output.new(schema: json_schema)
+  end
+
   test "adds structured output instructions to message lists" do
     {:ok, output} = Output.new(schema: @schema)
 


### PR DESCRIPTION
## Problem

`Jido.AI.Output.imported_schema?/1` reads the schema's `type` and `properties` with **atom keys only**:

```elixir
def imported_schema?(%{} = schema) do
  type = schema[:type]
  properties = schema[:properties]
  type in ["object", :object] and is_map(properties)
end
```

A JSON Schema that arrives decoded from the wire is fully **string-keyed** (`%{"type" => "object", "properties" => %{...}}`). For such a map `schema[:type]` returns `nil`, so `imported_schema?/1` is false and `schema_kind/1` errors with *"output schema must be a Zoi object schema or imported JSON object schema"* — even though `ReqLLM.Schema`/`JSV` downstream validate string-keyed JSON Schemas natively.

The inconsistency: the **value** check already tolerates both `"object"` and `:object`, signalling intent to accept JSON-decoded input, but the **key** access did not.

## Fix

Fall back to the string key for both reads:

```elixir
type = schema[:type] || schema["type"]
properties = schema[:properties] || schema["properties"]
```

- Atom-keyed schemas (authored in Elixir) keep working unchanged.
- JSON-decoded (string-keyed) schemas now classify as `:json_schema` and flow through to JSV, which normalizes atom/string keys itself.

No other code path in the `:json_schema` branch reads the schema with atom keys, so this single function is the only gate.

## Test

Adds a case asserting a fully string-keyed JSON Schema passes `imported_schema?/1` and `Output.new/1` returns `schema_kind: :json_schema`. Full `output_test.exs` suite passes (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)