### PR TITLE
fix: align Agent Skills lifecycle with specification

### DIFF
--- a/examples/lib/skills/calculator.ex
+++ b/examples/lib/skills/calculator.ex
@@ -22,7 +22,11 @@ defmodule Jido.AI.Examples.Skills.Calculator do
       end
       
       # Inject skill context into system prompt
-      skill_prompt = Jido.AI.Skill.Prompt.render([Jido.AI.Examples.Skills.Calculator])
+      skill_prompt =
+        Jido.AI.Skill.Prompt.render(
+          [Jido.AI.Examples.Skills.Calculator],
+          include_body: true
+        )
       full_prompt = skill_prompt <> "\\n\\n" <> base_system_prompt
   """
 

--- a/examples/lib/skills_demo_agent.ex
+++ b/examples/lib/skills_demo_agent.ex
@@ -63,7 +63,7 @@ defmodule Jido.AI.Examples.SkillsDemoAgent do
     Show your work clearly and provide helpful explanations.
     """
 
-    skill_prompt = Prompt.render(skills())
+    skill_prompt = Prompt.render(skills(), include_body: true)
     base <> "\n\n" <> skill_prompt
   end
 
@@ -71,7 +71,7 @@ defmodule Jido.AI.Examples.SkillsDemoAgent do
   Renders just the skill sections (for inspection/debugging).
   """
   def render_skills do
-    Prompt.render(skills())
+    Prompt.render(skills(), include_body: true)
   end
 
   @doc """

--- a/guides/developer/configuration_reference.md
+++ b/guides/developer/configuration_reference.md
@@ -40,6 +40,10 @@ Package defaults are built into `Jido.AI`; `model_aliases` is merged on top for 
   - `req_http_options`: `[]`
   - `llm_opts`: `[]`
   - `request_transformer`: `nil`
+  - `agent_skills`: `false` (explicit opt-in trust boundary). Use `true` for
+    standard `.agents/skills` roots, a list of trusted roots, or keyword options
+    with `paths`, an explicit `trust` policy, `max_depth`, `max_directories`, and
+    `exclude_directories`.
   - `signal_routes`: `[]` (agent-level routes merged with ReAct strategy routes)
 
 - CoT (`Jido.AI.CoTAgent`)

--- a/guides/developer/configuration_reference.md
+++ b/guides/developer/configuration_reference.md
@@ -43,7 +43,8 @@ Package defaults are built into `Jido.AI`; `model_aliases` is merged on top for 
   - `agent_skills`: `false` (explicit opt-in trust boundary). Use `true` for
     standard `.agents/skills` roots, a list of trusted roots, or keyword options
     with `paths`, an explicit `trust` policy, `max_depth`, `max_directories`, and
-    `exclude_directories`.
+    `exclude_directories`. Discovery and strict validation run when each agent
+    instance initializes.
   - `signal_routes`: `[]` (agent-level routes merged with ReAct strategy routes)
 
 - CoT (`Jido.AI.CoTAgent`)

--- a/guides/developer/skills_system.md
+++ b/guides/developer/skills_system.md
@@ -2,7 +2,8 @@
 
 You need to package reusable instructions/capabilities and load them safely.
 
-After this guide, you can load skill files, register specs, render prompts, and handle common runtime failures.
+After this guide, you can attach trusted Agent Skills with progressive disclosure,
+use session-scoped activation, validate skill files, and bound custom discovery.
 
 ## Core Contracts
 
@@ -10,11 +11,62 @@ After this guide, you can load skill files, register specs, render prompts, and 
 - `Jido.AI.Skill.Spec`
 - `Jido.AI.Skill.Loader`
 - `Jido.AI.Skill.Registry`
+- `Jido.AI.Skill.AgentIntegration`
 - `Jido.AI.Skill.Prompt`
 - `Jido.AI.Actions.Skill.LoadSkill`
 - `mix jido_ai.skill`
 
-## Lifecycle: Load, Register, Resolve, Retire
+## Turnkey Agent Integration
+
+`Jido.AI.Agent` can wire the complete progressive-disclosure lifecycle from one
+option. Because project skills are executable instructions, enabling standard
+root discovery is an explicit trust decision:
+
+```elixir
+defmodule MyApp.SupportAgent do
+  use Jido.AI.Agent,
+    name: "support_agent",
+    tools: [MyApp.Search],
+    system_prompt: "You are a support agent.",
+    agent_skills: true
+end
+```
+
+This discovers `.agents/skills/` and `~/.agents/skills/`, appends only the compact
+name/description catalog to the system prompt, adds
+`Jido.AI.Actions.Skill.LoadSkill` to the tools, and makes the resolved specs
+available through reserved tool context for that agent. Discovery and catalog
+construction happen when the agent module is compiled.
+
+Prefer an explicit list when only particular roots are trusted:
+
+```elixir
+use Jido.AI.Agent,
+  name: "support_agent",
+  tools: [MyApp.Search],
+  agent_skills: ["priv/skills", "/opt/my_app/skills"]
+```
+
+Discovery options can set tighter bounds:
+
+```elixir
+agent_skills: [
+  paths: ["priv/skills"],
+  trust: true,
+  max_depth: 4,
+  max_directories: 500,
+  exclude_directories: [".git", "node_modules", "deps", "_build"]
+]
+```
+
+Keyword options must include an explicit `trust` policy. Omitting it rejects
+every discovered root; passing a path list directly is the shorthand for
+trusting exactly those roots.
+
+Agent Skills integration is disabled by default so an application never starts
+trusting repository instructions merely by upgrading a dependency.
+
+## Manual Lifecycle: Load, Register, Resolve, Retire
 
 ```elixir
 {:ok, spec} = Jido.AI.Skill.Loader.load("priv/skills/code-review/SKILL.md")
@@ -24,16 +76,49 @@ After this guide, you can load skill files, register specs, render prompts, and 
 {:ok, loaded} = Jido.AI.Skill.resolve(spec.name)
 body = Jido.AI.Skill.body(loaded)
 
-prompt = Jido.AI.Skill.Prompt.render([spec.name], include_body: false)
+prompt = Jido.AI.Skill.Prompt.render_index([spec.name])
 
 :ok = Jido.AI.Skill.Registry.unregister(spec.name)
 :ok = Jido.AI.Skill.Registry.clear()
 ```
 
 Registry lifecycle guarantees:
+
 - explicit startup via `start_link/1`
 - lazy startup via `ensure_started/0` used by public APIs
 - safe unregister/clear operations for runtime teardown
+
+## Activation And Session Isolation
+
+Activation state is keyed by `{session_id, skill_name}`. Public activation calls
+default to the caller process; pass a stable ID when activation spans processes:
+
+```elixir
+{:ok, activation} =
+  Jido.AI.Skill.Activation.activate("code-review", session_id: conversation_id)
+
+activation.skill_body
+activation.root_dir
+activation.resources
+```
+
+The `load_skill` action derives its session from `session_id`, then `agent_id`,
+then `request_id` in the tool context. ReAct supplies `agent_id`, so separate
+agent instances do not share activation state. Its structured result contains:
+
+```elixir
+%{
+  name: "code-review",
+  description: "...",
+  instructions: "# Code Review ...",
+  root_dir: "/absolute/path/to/code-review",
+  resources: %{scripts: [...], references: [...], assets: [...]}
+}
+```
+
+Skill tool results are marked durable in conversation refs. A ReAct context
+replacement with `reason: :compaction` retains the skill output and its matching
+assistant tool call.
 
 ## Lazy Loading Skill Bodies
 
@@ -63,7 +148,43 @@ You can load a skill directly from application code as well:
   Jido.AI.Actions.Skill.LoadSkill.run(%{name: "code-review"}, %{})
 
 loaded.instructions
+loaded.root_dir
+loaded.resources
 ```
+
+`Prompt.render/2` now omits bodies by default. Eager rendering remains available
+for deliberate static-prompt use with `include_body: true`; use `render_index/2`
+for model-facing catalogs.
+
+## Strict And Lenient Validation
+
+Strict loading (`lenient: false`, the default) enforces the Agent Skills format:
+
+- the declared name exactly matches the parent directory
+- descriptions are non-empty and at most 1,024 characters
+- compatibility is non-empty and at most 500 characters when present
+- metadata contains only string keys and string values
+
+Lenient loading keeps interoperability behavior: it records diagnostics and can
+normalize or truncate recoverable values.
+
+## Bounded Discovery And Trust
+
+`Discovery.discover_from/2` defaults to a maximum depth of 6 and 2,000 visited
+directories, skips `.git` and `node_modules`, and does not follow directory
+symlinks. Custom callers can require trust explicitly:
+
+```elixir
+Jido.AI.Skill.Discovery.discover_from(paths,
+  trust: &MyApp.Trust.skill_root?/1,
+  max_depth: 4,
+  max_directories: 500
+)
+```
+
+An unapproved root returns `{:error, {:untrusted_skill_path, absolute_path}}`;
+exceeding the directory bound returns a structured `:discovery_limit_exceeded`
+error.
 
 ## CLI Surface + Error Handling
 
@@ -75,6 +196,7 @@ mix jido_ai.skill validate priv/skills --json
 ```
 
 CLI failure behaviors:
+
 - `mix jido_ai.skill list` with no paths prints usage help
 - `mix jido_ai.skill validate` with no paths prints usage help
 - unknown commands print `mix jido_ai.skill` help guidance
@@ -85,27 +207,32 @@ CLI failure behaviors:
 ### Invalid frontmatter or schema
 
 Symptom:
+
 - loader returns parse/validation error (`NoFrontmatter`, `InvalidYaml`, `MissingField`, `InvalidName`)
 
 Fix:
+
 - ensure YAML frontmatter contains required fields
 - validate with `mix jido_ai.skill validate ...` before loading in runtime
 
 ### Lookup failure after registration workflow
 
 Symptom:
+
 - `Jido.AI.Skill.resolve/1` or `Jido.AI.Skill.Registry.lookup/1` returns `NotFound`
 
 Fix:
+
 - ensure skills were registered into the current runtime registry instance
 - confirm normalized names (kebab-case) match lookup keys
 
 ## Defaults You Should Know
 
-- skill registry stores by skill name
+- skill registry stores specs by skill name
+- activation registry stores by session ID and skill name
 - `body_ref` can be inline or file-backed
 - allowed tools are normalized to string names
-- `Prompt.render/2` ignores unresolved skills and renders only valid specs
+- `Prompt.render/2` ignores unresolved skills, renders only valid specs, and omits bodies by default
 
 ## Demo + Examples
 
@@ -116,6 +243,7 @@ mix run examples/scripts/demo/skills_runtime_foundations_demo.exs
 ```
 
 Prerequisites:
+
 - run from the repository root
 - keep `priv/skills/code-review/SKILL.md` available (checked by script)
 
@@ -124,9 +252,11 @@ If required skill files are missing, the demo prints a skip message and continue
 ## When To Use / Not Use
 
 Use skills when:
+
 - you need reusable instruction packs across agents
 
 Do not use skills when:
+
 - static prompts in agent config are sufficient
 
 ## Next

--- a/guides/developer/skills_system.md
+++ b/guides/developer/skills_system.md
@@ -36,7 +36,9 @@ This discovers `.agents/skills/` and `~/.agents/skills/`, appends only the compa
 name/description catalog to the system prompt, adds
 `Jido.AI.Actions.Skill.LoadSkill` to the tools, and makes the resolved specs
 available through reserved tool context for that agent. Discovery and catalog
-construction happen when the agent module is compiled.
+construction happen when each agent instance initializes, so paths and bundled
+resources refer to the runtime filesystem rather than the build host. Skills
+that fail strict Agent Skills validation prevent the agent from initializing.
 
 Prefer an explicit list when only particular roots are trusted:
 
@@ -100,6 +102,9 @@ default to the caller process; pass a stable ID when activation spans processes:
 activation.skill_body
 activation.root_dir
 activation.resources
+
+# Release activation state when the session ends.
+:ok = Jido.AI.Skill.Activation.clear(session_id: conversation_id)
 ```
 
 The `load_skill` action derives its session from `session_id`, then `agent_id`,
@@ -162,8 +167,10 @@ Strict loading (`lenient: false`, the default) enforces the Agent Skills format:
 
 - the declared name exactly matches the parent directory
 - descriptions are non-empty and at most 1,024 characters
+- license is a string when present
 - compatibility is non-empty and at most 500 characters when present
 - metadata contains only string keys and string values
+- `allowed-tools` is a space-separated string when present
 
 Lenient loading keeps interoperability behavior: it records diagnostics and can
 normalize or truncate recoverable values.
@@ -171,8 +178,8 @@ normalize or truncate recoverable values.
 ## Bounded Discovery And Trust
 
 `Discovery.discover_from/2` defaults to a maximum depth of 6 and 2,000 visited
-directories, skips `.git` and `node_modules`, and does not follow directory
-symlinks. Custom callers can require trust explicitly:
+directories, skips `.git` and `node_modules`, and does not follow file or
+directory symlinks. Custom callers can require trust explicitly:
 
 ```elixir
 Jido.AI.Skill.Discovery.discover_from(paths,

--- a/guides/user/package_overview.md
+++ b/guides/user/package_overview.md
@@ -77,8 +77,10 @@ ToT flexibility controls exposed at the agent macro level:
 Skills are reusable instruction/capability units loaded at runtime:
 
 - `Jido.AI.Skill.Loader` parses skill files.
-- `Jido.AI.Skill.Registry` stores and resolves active skills.
-- Skills are strategy-agnostic and can be injected into agent behavior/context.
+- `Jido.AI.Skill.Registry` stores specs and session-scoped activations.
+- `Jido.AI.Agent` accepts `agent_skills: true`, trusted paths, or bounded discovery options.
+- Agents receive a compact catalog and load full instructions only when needed.
+- Activated skill content is retained across ReAct context compaction.
 - Skills are useful for domain behavior reuse without duplicating agent code.
 
 This is the main packaging mechanism for reusable AI behavior in your system.

--- a/lib/jido_ai/actions/skill/load_skill.ex
+++ b/lib/jido_ai/actions/skill/load_skill.ex
@@ -8,7 +8,7 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
   until they are needed.
 
   The action routes through `Jido.AI.Skill.Activation`, returning the skill root
-  and a bounded resource listing with the instructions. It scopes activation
+  and resource listing with the instructions. It scopes activation
   from `session_id`, `agent_id`, or `request_id` in the runtime context and tags
   the resulting tool message as durable for ReAct compaction.
 
@@ -105,17 +105,20 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
   end
 
   defp activate_skill(name, context) do
-    skill = Map.get(agent_skill_specs(context), name, name)
     opts = [session_id: activation_session_id(context)]
 
+    with {:ok, skill} <- activation_target(name, context) do
+      activate(name, skill, opts, context)
+    end
+  end
+
+  defp activate(name, skill, opts, context) do
     case Activation.activate(skill, opts) do
       {:ok, activation} ->
-        with :ok <- Registry.mark_durable(name, opts) do
-          {:ok, activation}
-        end
+        {:ok, activation}
 
       {:error, :skill_not_found} ->
-        skill_not_found(name, context)
+        skill_not_found(name, available_skill_names(context))
 
       {:error, {:body_load_failed, reason}} ->
         skill_body_unavailable(name, reason)
@@ -125,10 +128,31 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
     end
   end
 
+  defp activation_target(name, context) do
+    case agent_skill_specs(context) do
+      {:scoped, specs} ->
+        case Map.fetch(specs, name) do
+          {:ok, %Spec{} = spec} -> {:ok, spec}
+          _ -> skill_not_found(name, specs |> Map.keys() |> Enum.sort())
+        end
+
+      :unscoped ->
+        {:ok, name}
+    end
+  end
+
   defp agent_skill_specs(context) do
-    case Map.get(context, @context_skills_key, Map.get(context, Atom.to_string(@context_skills_key), %{})) do
-      %{} = specs -> specs
-      _ -> %{}
+    case fetch_agent_skill_specs(context) do
+      {:ok, %{} = specs} -> {:scoped, specs}
+      {:ok, _invalid} -> {:scoped, %{}}
+      :error -> :unscoped
+    end
+  end
+
+  defp fetch_agent_skill_specs(context) do
+    case Map.fetch(context, @context_skills_key) do
+      {:ok, specs} -> {:ok, specs}
+      :error -> Map.fetch(context, Atom.to_string(@context_skills_key))
     end
   end
 
@@ -138,21 +162,20 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
       context[:request_id] || context["request_id"] || self()
   end
 
-  defp skill_not_found(name, context) do
-    available_skills =
-      context
-      |> agent_skill_specs()
-      |> Map.keys()
-      |> Kernel.++(Registry.list())
-      |> Enum.uniq()
-      |> Enum.sort()
-
+  defp skill_not_found(name, available_skills) do
     {:error,
      %{
        type: :skill_not_found,
        message: "Unknown skill '#{name}'",
        available_skills: available_skills
      }}
+  end
+
+  defp available_skill_names(context) do
+    case agent_skill_specs(context) do
+      {:scoped, specs} -> specs |> Map.keys() |> Enum.sort()
+      :unscoped -> Registry.list() |> Enum.sort()
+    end
   end
 
   defp skill_body_unavailable(name, reason) do

--- a/lib/jido_ai/actions/skill/load_skill.ex
+++ b/lib/jido_ai/actions/skill/load_skill.ex
@@ -1,15 +1,20 @@
 defmodule Jido.AI.Actions.Skill.LoadSkill do
   @moduledoc """
-  A Jido.Action for lazily loading registered skill instructions.
+  A Jido.Action for lazily loading available skill instructions.
 
   Pair this action with `Jido.AI.Skill.Prompt.render_registry_index/1` to expose
   a compact skill index in an agent prompt. The model can call `load_skill` only
   after selecting a relevant skill, keeping full skill bodies out of the prompt
   until they are needed.
 
+  The action routes through `Jido.AI.Skill.Activation`, returning the skill root
+  and a bounded resource listing with the instructions. It scopes activation
+  from `session_id`, `agent_id`, or `request_id` in the runtime context and tags
+  the resulting tool message as durable for ReAct compaction.
+
   ## Parameters
 
-  * `name` (required) - Registered skill name to load.
+  * `name` (required) - Available skill name to load.
   * `include_metadata` (optional) - Include skill metadata in the response
     (default: `true`).
 
@@ -25,7 +30,7 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
   use Jido.Action,
     name: "load_skill",
     description: """
-    Loads the full instructions for a registered skill by name. Call this after
+    Loads the full instructions for an available skill by name. Call this after
     selecting a skill from a compact skill index.
     """,
     category: "ai",
@@ -33,30 +38,34 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
     vsn: "1.0.0",
     schema:
       Zoi.object(%{
-        name: Zoi.string(description: "The registered skill name to load"),
+        name: Zoi.string(description: "The available skill name to load"),
         include_metadata:
           Zoi.boolean(description: "Include metadata such as tags and allowed tools")
           |> Zoi.default(true)
           |> Zoi.optional()
       })
 
-  alias Jido.AI.Skill
-  alias Jido.AI.Skill.{Registry, Spec}
+  alias Jido.AI.Skill.{Activation, Registry, Spec}
   alias Jido.AI.Validation
 
   @name_regex ~r/^[a-z0-9]+(-[a-z0-9]+)*$/
   @max_name_length 64
+  @context_skills_key :__jido_ai_agent_skills__
+
+  @doc false
+  def context_skills_key, do: @context_skills_key
 
   @doc """
-  Loads the requested skill body from the registry.
+  Loads and activates the requested skill from the agent catalog or registry.
   """
   @impl Jido.Action
-  def run(params, _context) when is_map(params) do
+  def run(params, context) when is_map(params) do
+    context = if is_map(context), do: context, else: %{}
+
     with {:ok, name} <- validate_name(param(params, :name)),
          {:ok, include_metadata?} <- validate_include_metadata(param(params, :include_metadata, true)),
-         {:ok, %Spec{} = spec} <- resolve_skill(name),
-         {:ok, instructions} <- load_instructions(spec) do
-      {:ok, payload(spec, instructions, include_metadata?)}
+         {:ok, activation} <- activate_skill(name, context) do
+      {:ok, payload(activation, include_metadata?)}
     end
   end
 
@@ -95,42 +104,69 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
      }}
   end
 
-  defp resolve_skill(name) do
-    case Skill.resolve(name) do
-      {:ok, %Spec{} = spec} ->
-        {:ok, spec}
+  defp activate_skill(name, context) do
+    skill = Map.get(agent_skill_specs(context), name, name)
+    opts = [session_id: activation_session_id(context)]
 
-      {:error, _reason} ->
-        {:error,
-         %{
-           type: :skill_not_found,
-           message: "Unknown skill '#{name}'",
-           available_skills: Registry.list() |> Enum.sort()
-         }}
-    end
-  end
+    case Activation.activate(skill, opts) do
+      {:ok, activation} ->
+        with :ok <- Registry.mark_durable(name, opts) do
+          {:ok, activation}
+        end
 
-  defp load_instructions(%Spec{body_ref: {:inline, instructions}}) when is_binary(instructions), do: {:ok, instructions}
-  defp load_instructions(%Spec{body_ref: nil}), do: {:ok, ""}
+      {:error, :skill_not_found} ->
+        skill_not_found(name, context)
 
-  defp load_instructions(%Spec{name: name, body_ref: {:file, path}}) when is_binary(path) do
-    case File.read(path) do
-      {:ok, instructions} ->
-        {:ok, instructions}
+      {:error, {:body_load_failed, reason}} ->
+        skill_body_unavailable(name, reason)
 
       {:error, reason} ->
-        {:error,
-         %{
-           type: :skill_body_unavailable,
-           message: "Could not load skill body for '#{name}'",
-           reason: reason
-         }}
+        {:error, %{type: :skill_activation_failed, message: "Could not activate '#{name}'", reason: reason}}
     end
   end
 
-  defp payload(%Spec{} = spec, instructions, true) do
-    spec
-    |> payload(instructions, false)
+  defp agent_skill_specs(context) do
+    case Map.get(context, @context_skills_key, Map.get(context, Atom.to_string(@context_skills_key), %{})) do
+      %{} = specs -> specs
+      _ -> %{}
+    end
+  end
+
+  defp activation_session_id(context) do
+    context[:session_id] || context["session_id"] ||
+      context[:agent_id] || context["agent_id"] ||
+      context[:request_id] || context["request_id"] || self()
+  end
+
+  defp skill_not_found(name, context) do
+    available_skills =
+      context
+      |> agent_skill_specs()
+      |> Map.keys()
+      |> Kernel.++(Registry.list())
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    {:error,
+     %{
+       type: :skill_not_found,
+       message: "Unknown skill '#{name}'",
+       available_skills: available_skills
+     }}
+  end
+
+  defp skill_body_unavailable(name, reason) do
+    {:error,
+     %{
+       type: :skill_body_unavailable,
+       message: "Could not load skill body for '#{name}'",
+       reason: reason
+     }}
+  end
+
+  defp payload(%{skill: %Spec{} = spec} = activation, true) do
+    activation
+    |> payload(false)
     |> Map.merge(%{
       allowed_tools: spec.allowed_tools,
       tags: spec.tags,
@@ -141,11 +177,13 @@ defmodule Jido.AI.Actions.Skill.LoadSkill do
     })
   end
 
-  defp payload(%Spec{} = spec, instructions, false) do
+  defp payload(%{skill: %Spec{} = spec} = activation, false) do
     %{
       name: spec.name,
       description: spec.description,
-      instructions: instructions
+      instructions: activation.skill_body,
+      root_dir: activation.root_dir,
+      resources: activation.resources
     }
   end
 end

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -58,7 +58,7 @@ defmodule Jido.AI.Agent do
   - `:agent_skills` - Agent Skills (`SKILL.md`) integration. Pass `true` to trust
     and discover standard roots, a list of trusted roots, or discovery options
     with an explicit `:trust` policy. The agent automatically receives the compact
-    catalog and `load_skill` tool.
+    catalog and `load_skill` tool after strict validation at initialization.
   - `:signal_routes` - Additional agent-level signal routes forwarded to `Jido.Agent`.
     ReAct routes are still provided by the default strategy.
 
@@ -297,9 +297,6 @@ defmodule Jido.AI.Agent do
       opts
       |> Keyword.get(:agent_skills, false)
       |> __MODULE__.expand_and_eval_literal_option(__CALLER__)
-      |> Jido.AI.Skill.AgentIntegration.prepare!()
-
-    tools = Enum.uniq(tools ++ agent_skills.tools)
 
     description = Keyword.get(opts, :description, "AI agent #{name}")
     tags = Keyword.get(opts, :tags, [])
@@ -324,14 +321,6 @@ defmodule Jido.AI.Agent do
               file: __CALLER__.file,
               line: system_prompt_line
           end
-      end
-
-    system_prompt =
-      case {system_prompt, agent_skills.index} do
-        {prompt, ""} -> prompt
-        {:absent, index} -> {:resolved, index}
-        {{:resolved, prompt}, index} -> {:resolved, append_system_prompt(prompt, index)}
-        {{:deferred, _attr_ast} = deferred, _index} -> deferred
       end
 
     model =
@@ -420,11 +409,10 @@ defmodule Jido.AI.Agent do
           other
       end
 
-    tool_context = Map.merge(tool_context, agent_skills.tool_context)
-
     strategy_opts =
       [
         tools: tools,
+        agent_skills: agent_skills,
         model: model,
         streaming: streaming,
         max_iterations: max_iterations,
@@ -464,17 +452,10 @@ defmodule Jido.AI.Agent do
                    unquote(system_prompt_line)
                  ) do
               :absent ->
-                case unquote(agent_skills.index) do
-                  "" -> unquote(Macro.escape(strategy_opts))
-                  index -> Keyword.put(unquote(Macro.escape(strategy_opts)), :system_prompt, index)
-                end
+                unquote(Macro.escape(strategy_opts))
 
               {:resolved, value} ->
-                Keyword.put(
-                  unquote(Macro.escape(strategy_opts)),
-                  :system_prompt,
-                  unquote(__MODULE__).append_system_prompt(value, unquote(agent_skills.index))
-                )
+                Keyword.put(unquote(Macro.escape(strategy_opts)), :system_prompt, value)
             end
           end
 
@@ -915,13 +896,6 @@ defmodule Jido.AI.Agent do
                      inject: 3
     end
   end
-
-  @doc false
-  def append_system_prompt(prompt, "") when is_binary(prompt), do: prompt
-  def append_system_prompt("", addition) when is_binary(addition), do: addition
-
-  def append_system_prompt(prompt, addition) when is_binary(prompt) and is_binary(addition),
-    do: prompt <> "\n\n" <> addition
 
   @doc false
   @spec compatibility_overrides_ast() :: Macro.t()

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -55,6 +55,10 @@ defmodule Jido.AI.Agent do
     Runtime reserves `:state` (core Jido-compatible) for tool execution snapshots.
     User-provided values for that key are overwritten per request.
   - `:skills` - Additional skills to attach to the agent (TaskSupervisorSkill is auto-included)
+  - `:agent_skills` - Agent Skills (`SKILL.md`) integration. Pass `true` to trust
+    and discover standard roots, a list of trusted roots, or discovery options
+    with an explicit `:trust` policy. The agent automatically receives the compact
+    catalog and `load_skill` tool.
   - `:signal_routes` - Additional agent-level signal routes forwarded to `Jido.Agent`.
     ReAct routes are still provided by the default strategy.
 
@@ -289,6 +293,14 @@ defmodule Jido.AI.Agent do
         mod when is_atom(mod) -> mod
       end)
 
+    agent_skills =
+      opts
+      |> Keyword.get(:agent_skills, false)
+      |> __MODULE__.expand_and_eval_literal_option(__CALLER__)
+      |> Jido.AI.Skill.AgentIntegration.prepare!()
+
+    tools = Enum.uniq(tools ++ agent_skills.tools)
+
     description = Keyword.get(opts, :description, "AI agent #{name}")
     tags = Keyword.get(opts, :tags, [])
     system_prompt_raw = Keyword.get(opts, :system_prompt)
@@ -312,6 +324,14 @@ defmodule Jido.AI.Agent do
               file: __CALLER__.file,
               line: system_prompt_line
           end
+      end
+
+    system_prompt =
+      case {system_prompt, agent_skills.index} do
+        {prompt, ""} -> prompt
+        {:absent, index} -> {:resolved, index}
+        {{:resolved, prompt}, index} -> {:resolved, append_system_prompt(prompt, index)}
+        {{:deferred, _attr_ast} = deferred, _index} -> deferred
       end
 
     model =
@@ -400,6 +420,8 @@ defmodule Jido.AI.Agent do
           other
       end
 
+    tool_context = Map.merge(tool_context, agent_skills.tool_context)
+
     strategy_opts =
       [
         tools: tools,
@@ -442,10 +464,17 @@ defmodule Jido.AI.Agent do
                    unquote(system_prompt_line)
                  ) do
               :absent ->
-                unquote(Macro.escape(strategy_opts))
+                case unquote(agent_skills.index) do
+                  "" -> unquote(Macro.escape(strategy_opts))
+                  index -> Keyword.put(unquote(Macro.escape(strategy_opts)), :system_prompt, index)
+                end
 
               {:resolved, value} ->
-                Keyword.put(unquote(Macro.escape(strategy_opts)), :system_prompt, value)
+                Keyword.put(
+                  unquote(Macro.escape(strategy_opts)),
+                  :system_prompt,
+                  unquote(__MODULE__).append_system_prompt(value, unquote(agent_skills.index))
+                )
             end
           end
 
@@ -886,6 +915,13 @@ defmodule Jido.AI.Agent do
                      inject: 3
     end
   end
+
+  @doc false
+  def append_system_prompt(prompt, "") when is_binary(prompt), do: prompt
+  def append_system_prompt("", addition) when is_binary(addition), do: addition
+
+  def append_system_prompt(prompt, addition) when is_binary(prompt) and is_binary(addition),
+    do: prompt <> "\n\n" <> addition
 
   @doc false
   @spec compatibility_overrides_ast() :: Macro.t()

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -1647,12 +1647,25 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     PendingInputServer.seal_if_empty(server)
   end
 
+  defp normalize_optional_refs(refs) when refs == %{}, do: nil
   defp normalize_optional_refs(%{} = refs), do: refs
   defp normalize_optional_refs(_), do: nil
 
-  defp durable_tool_result_refs("load_skill", {:ok, result, _effects}) when is_map(result) do
-    name = Map.get(result, :name, Map.get(result, "name"))
-    instructions = Map.get(result, :instructions, Map.get(result, "instructions"))
+  defp durable_tool_result_refs("load_skill", result) do
+    case Effects.normalize_result(result) do
+      {:ok, payload, _effects} when is_map(payload) ->
+        durable_skill_refs(payload)
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp durable_tool_result_refs(_tool_name, _result), do: %{}
+
+  defp durable_skill_refs(payload) do
+    name = Map.get(payload, :name, Map.get(payload, "name"))
+    instructions = Map.get(payload, :instructions, Map.get(payload, "instructions"))
 
     if is_binary(name) and is_binary(instructions) do
       %{durable: true, kind: :skill_activation, skill_name: name}
@@ -1660,8 +1673,6 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
       %{}
     end
   end
-
-  defp durable_tool_result_refs(_tool_name, _result), do: %{}
 
   defp fetch_extra(extra, key, default \\ nil)
 

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -9,6 +9,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   alias Jido.AI.Output
   alias Jido.AI.PendingInputServer
   alias Jido.AI.Query
+  alias Jido.AI.Actions.Skill.LoadSkill
   alias Jido.AI.Reasoning.ReAct.{Config, PendingToolCall, State, Token, ToolSelection}
   alias Jido.AI.Runtime.Event
   alias Jido.AI.Test.ReActScript
@@ -731,7 +732,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
           Enum.reduce(results, {state, state.context}, fn
             {pending_call, result, attempts, duration_ms}, {acc, context_acc} ->
               completed = PendingToolCall.complete(pending_call, result, attempts, duration_ms)
-              refs = durable_tool_result_refs(completed.name, result)
+              refs = durable_tool_result_refs(completed.name, result, tool_config.tools)
 
               {acc, _} =
                 emit_event(
@@ -1651,7 +1652,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   defp normalize_optional_refs(%{} = refs), do: refs
   defp normalize_optional_refs(_), do: nil
 
-  defp durable_tool_result_refs("load_skill", result) do
+  defp durable_tool_result_refs("load_skill", result, %{"load_skill" => LoadSkill}) do
     case Effects.normalize_result(result) do
       {:ok, payload, _effects} when is_map(payload) ->
         durable_skill_refs(payload)
@@ -1661,7 +1662,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     end
   end
 
-  defp durable_tool_result_refs(_tool_name, _result), do: %{}
+  defp durable_tool_result_refs(_tool_name, _result, _tools), do: %{}
 
   defp durable_skill_refs(payload) do
     name = Map.get(payload, :name, Map.get(payload, "name"))

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -731,6 +731,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
           Enum.reduce(results, {state, state.context}, fn
             {pending_call, result, attempts, duration_ms}, {acc, context_acc} ->
               completed = PendingToolCall.complete(pending_call, result, attempts, duration_ms)
+              refs = durable_tool_result_refs(completed.name, result)
 
               {acc, _} =
                 emit_event(
@@ -743,14 +744,20 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
                     tool_name: completed.name,
                     result: result,
                     attempts: attempts,
-                    duration_ms: duration_ms
+                    duration_ms: duration_ms,
+                    refs: refs
                   },
                   tool_call_id: completed.id,
                   tool_name: completed.name
                 )
 
               content = Turn.format_tool_result_content(result)
-              context_acc = AIContext.append_tool_result(context_acc, completed.id, completed.name, content)
+
+              context_acc =
+                AIContext.append_tool_result(context_acc, completed.id, completed.name, content,
+                  refs: normalize_optional_refs(refs)
+                )
+
               {acc, context_acc}
 
             {:error, reason}, {acc, context_acc} ->
@@ -1642,6 +1649,19 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
 
   defp normalize_optional_refs(%{} = refs), do: refs
   defp normalize_optional_refs(_), do: nil
+
+  defp durable_tool_result_refs("load_skill", {:ok, result, _effects}) when is_map(result) do
+    name = Map.get(result, :name, Map.get(result, "name"))
+    instructions = Map.get(result, :instructions, Map.get(result, "instructions"))
+
+    if is_binary(name) and is_binary(instructions) do
+      %{durable: true, kind: :skill_activation, skill_name: name}
+    else
+      %{}
+    end
+  end
+
+  defp durable_tool_result_refs(_tool_name, _result), do: %{}
 
   defp fetch_extra(extra, key, default \\ nil)
 

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -51,6 +51,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   alias Jido.AI.Error
   alias Jido.AI.Reasoning.Helpers
   alias Jido.AI.Context, as: AIContext
+  alias Jido.AI.Skill.AgentIntegration
   alias Jido.AI.ToolAdapter
   alias Jido.AI.Turn
   alias Jido.Thread
@@ -2285,22 +2286,31 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   defp durable_skill_name(entry) do
     refs = fetch_map_value(entry, :refs)
     durable? = fetch_map_value(refs, :durable) == true
+    kind = fetch_map_value(refs, :kind)
     skill_name = fetch_map_value(refs, :skill_name)
+    role = fetch_map_value(entry, :role)
+    tool_name = fetch_map_value(entry, :name)
+    tool_call_id = fetch_map_value(entry, :tool_call_id)
 
-    if durable? and is_binary(skill_name), do: skill_name, else: nil
+    if durable? and kind in [:skill_activation, "skill_activation"] and
+         role in [:tool, "tool"] and tool_name == "load_skill" and
+         is_binary(tool_call_id) and is_binary(skill_name),
+       do: skill_name,
+       else: nil
   end
 
   defp build_config(agent, ctx) do
     opts = ctx[:strategy_opts] || []
     observability_overrides = opts |> Keyword.get(:observability, %{}) |> normalize_map_opt()
     tool_context_opt = opts |> Keyword.get(:tool_context, %{}) |> normalize_map_opt()
+    skill_integration = opts |> Keyword.get(:agent_skills, false) |> AgentIntegration.prepare!()
 
     agent_effect_policy =
       Keyword.get(opts, :agent_effect_policy, Keyword.get(opts, :effect_policy, %{}))
 
     strategy_effect_policy = Keyword.get(opts, :strategy_effect_policy, %{})
 
-    tools_modules =
+    configured_tools =
       case Keyword.fetch(opts, :tools) do
         {:ok, mods} when is_list(mods) ->
           mods
@@ -2310,8 +2320,11 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
                 "Jido.AI.Reasoning.ReAct.Strategy requires :tools option (list of Jido.Action modules)"
       end
 
+    tools_modules = Enum.uniq(configured_tools ++ skill_integration.tools)
+
     actions_by_name = Map.new(tools_modules, &{&1.name(), &1})
     reqllm_tools = ToolAdapter.from_actions(tools_modules)
+    base_tool_context = Map.get(agent.state, :tool_context) || tool_context_opt
 
     raw_model = Keyword.get(opts, :model, Map.get(agent.state, :model, @default_model))
     resolved_model = resolve_model_spec(raw_model)
@@ -2325,7 +2338,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       reqllm_tools: reqllm_tools,
       actions_by_name: actions_by_name,
       request_transformer: validate_request_transformer_opt!(Keyword.get(opts, :request_transformer)),
-      system_prompt: normalize_system_prompt_opt(opts),
+      system_prompt: append_system_prompt(normalize_system_prompt_opt(opts), skill_integration.index),
       model: resolved_model,
       max_iterations: Keyword.get(opts, :max_iterations, @default_max_iterations),
       max_tokens: Keyword.get(opts, :max_tokens, @default_max_tokens),
@@ -2354,7 +2367,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           observability_overrides
         ),
       agent_id: agent.id,
-      base_tool_context: Map.get(agent.state, :tool_context) || tool_context_opt,
+      base_tool_context: Map.merge(base_tool_context, skill_integration.tool_context),
       base_req_http_options: opts |> Keyword.get(:req_http_options, []) |> normalize_req_http_options(),
       base_llm_opts: opts |> Keyword.get(:llm_opts, []) |> normalize_llm_opts(provider_opt_keys_by_string),
       output: opts |> Keyword.get(:output) |> Output.new!(),
@@ -2378,6 +2391,11 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
               "invalid system_prompt: expected binary, nil, or false, got #{inspect(other)}"
     end
   end
+
+  defp append_system_prompt(prompt, ""), do: prompt
+  defp append_system_prompt(nil, addition), do: addition
+  defp append_system_prompt("", addition), do: addition
+  defp append_system_prompt(prompt, addition), do: prompt <> "\n\n" <> addition
 
   defp resolve_model_spec(model), do: Jido.AI.resolve_model(model)
 

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -968,7 +968,8 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
          context_ref: context_ref,
          operation: %{type: :replace} = operation
        }) do
-    context = operation.result_context
+    context = preserve_durable_entries(state[:context], operation.result_context, operation.reason)
+    operation = %{operation | result_context: context}
 
     state =
       state
@@ -1193,6 +1194,11 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
         tool_result = normalize_tool_result(event_field(data, :result, {:error, :unknown, []}))
         content = Turn.format_tool_result_content(tool_result)
 
+        refs =
+          data
+          |> event_field(:refs, %{})
+          |> normalize_event_message_refs(runtime_event_refs(event, request_id))
+
         append_ai_message_event(
           agent,
           state,
@@ -1200,7 +1206,8 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           %{role: :tool, content: content, tool_call_id: tool_call_id, name: tool_name},
           request_id,
           run_id,
-          signal_id
+          signal_id,
+          refs || %{}
         )
 
       _ ->
@@ -1624,7 +1631,10 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
             }
           end)
 
-        refs = runtime_event_refs(event, request_id)
+        refs =
+          data
+          |> event_field(:refs, %{})
+          |> normalize_event_message_refs(runtime_event_refs(event, request_id))
 
         updated =
           base_state
@@ -1708,7 +1718,10 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
         tool_result = normalize_tool_result(event_field(data, :result, {:error, :unknown, []}))
         tool_result_entry = completed_tool_result_entry(base_state, tool_call_id, tool_name, tool_result)
 
-        refs = runtime_event_refs(event, request_id)
+        refs =
+          data
+          |> event_field(:refs, %{})
+          |> normalize_event_message_refs(runtime_event_refs(event, request_id))
 
         updated =
           base_state
@@ -2219,6 +2232,63 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
 
   defp normalize_event_message_refs(%{} = refs, _fallback_refs), do: refs
   defp normalize_event_message_refs(_refs, fallback_refs), do: fallback_refs
+
+  defp preserve_durable_entries(%AIContext{} = current, %AIContext{} = replacement, :compaction) do
+    existing_skill_names =
+      replacement.entries
+      |> Enum.map(&durable_skill_name/1)
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+
+    durable_tools =
+      Enum.filter(current.entries, fn entry ->
+        case durable_skill_name(entry) do
+          nil -> false
+          skill_name -> not MapSet.member?(existing_skill_names, skill_name)
+        end
+      end)
+
+    durable_tool_call_ids =
+      durable_tools
+      |> Enum.map(&fetch_map_value(&1, :tool_call_id))
+      |> Enum.filter(&is_binary/1)
+      |> MapSet.new()
+
+    preserved =
+      current.entries
+      |> Enum.flat_map(fn entry ->
+        cond do
+          entry in durable_tools ->
+            [entry]
+
+          fetch_map_value(entry, :role) in [:assistant, "assistant"] ->
+            tool_calls =
+              entry
+              |> fetch_map_value(:tool_calls)
+              |> List.wrap()
+              |> Enum.filter(fn tool_call ->
+                MapSet.member?(durable_tool_call_ids, fetch_map_value(tool_call, :id))
+              end)
+
+            if tool_calls == [], do: [], else: [Map.put(entry, :tool_calls, tool_calls)]
+
+          true ->
+            []
+        end
+      end)
+
+    %{replacement | entries: replacement.entries ++ preserved}
+  end
+
+  defp preserve_durable_entries(_current, replacement, _reason), do: replacement
+
+  defp durable_skill_name(entry) do
+    refs = fetch_map_value(entry, :refs)
+    durable? = fetch_map_value(refs, :durable) == true
+    skill_name = fetch_map_value(refs, :skill_name)
+
+    if durable? and is_binary(skill_name), do: skill_name, else: nil
+  end
 
   defp build_config(agent, ctx) do
     opts = ctx[:strategy_opts] || []

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -51,6 +51,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   alias Jido.AI.Error
   alias Jido.AI.Reasoning.Helpers
   alias Jido.AI.Context, as: AIContext
+  alias Jido.AI.Actions.Skill.LoadSkill
   alias Jido.AI.Skill.AgentIntegration
   alias Jido.AI.ToolAdapter
   alias Jido.AI.Turn
@@ -1199,6 +1200,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           data
           |> event_field(:refs, %{})
           |> normalize_event_message_refs(runtime_event_refs(event, request_id))
+          |> sanitize_skill_activation_refs(tool_name, state)
 
         append_ai_message_event(
           agent,
@@ -1208,7 +1210,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           request_id,
           run_id,
           signal_id,
-          refs || %{}
+          refs
         )
 
       _ ->
@@ -1723,6 +1725,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           data
           |> event_field(:refs, %{})
           |> normalize_event_message_refs(runtime_event_refs(event, request_id))
+          |> sanitize_skill_activation_refs(tool_name, base_state)
 
         updated =
           base_state
@@ -2234,32 +2237,32 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   defp normalize_event_message_refs(%{} = refs, _fallback_refs), do: refs
   defp normalize_event_message_refs(_refs, fallback_refs), do: fallback_refs
 
+  defp sanitize_skill_activation_refs(refs, tool_name, state) when is_map(refs) do
+    if tool_name == "load_skill" and get_in(state, [:config, :actions_by_name, "load_skill"]) == LoadSkill do
+      refs
+    else
+      Map.drop(refs, [:durable, :kind, :skill_name, "durable", "kind", "skill_name"])
+    end
+  end
+
+  defp sanitize_skill_activation_refs(_refs, _tool_name, _state), do: %{}
+
   defp preserve_durable_entries(%AIContext{} = current, %AIContext{} = replacement, :compaction) do
-    existing_skill_names =
-      replacement.entries
-      |> Enum.map(&durable_skill_name/1)
-      |> Enum.reject(&is_nil/1)
-      |> MapSet.new()
-
-    durable_tools =
-      Enum.filter(current.entries, fn entry ->
-        case durable_skill_name(entry) do
-          nil -> false
-          skill_name -> not MapSet.member?(existing_skill_names, skill_name)
-        end
-      end)
-
     durable_tool_call_ids =
-      durable_tools
+      current.entries
+      |> Enum.filter(&is_binary(durable_skill_name(&1)))
       |> Enum.map(&fetch_map_value(&1, :tool_call_id))
-      |> Enum.filter(&is_binary/1)
       |> MapSet.new()
+      |> MapSet.intersection(assistant_tool_call_ids(current.entries, "load_skill"))
+
+    replacement_tool_call_ids = assistant_tool_call_ids(replacement.entries, nil)
 
     preserved =
       current.entries
       |> Enum.flat_map(fn entry ->
         cond do
-          entry in durable_tools ->
+          fetch_map_value(entry, :role) in [:tool, "tool"] and
+              MapSet.member?(durable_tool_call_ids, fetch_map_value(entry, :tool_call_id)) ->
             [entry]
 
           fetch_map_value(entry, :role) in [:assistant, "assistant"] ->
@@ -2268,7 +2271,8 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
               |> fetch_map_value(:tool_calls)
               |> List.wrap()
               |> Enum.filter(fn tool_call ->
-                MapSet.member?(durable_tool_call_ids, fetch_map_value(tool_call, :id))
+                id = fetch_map_value(tool_call, :id)
+                MapSet.member?(durable_tool_call_ids, id) and not MapSet.member?(replacement_tool_call_ids, id)
               end)
 
             if tool_calls == [], do: [], else: [Map.put(entry, :tool_calls, tool_calls)]
@@ -2278,7 +2282,13 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
         end
       end)
 
-    %{replacement | entries: replacement.entries ++ preserved}
+    replacement_entries =
+      Enum.reject(replacement.entries, fn entry ->
+        fetch_map_value(entry, :role) in [:tool, "tool"] and
+          MapSet.member?(durable_tool_call_ids, fetch_map_value(entry, :tool_call_id))
+      end)
+
+    %{replacement | entries: replacement_entries ++ preserved}
   end
 
   defp preserve_durable_entries(_current, replacement, _reason), do: replacement
@@ -2297,6 +2307,17 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
          is_binary(tool_call_id) and is_binary(skill_name),
        do: skill_name,
        else: nil
+  end
+
+  defp assistant_tool_call_ids(entries, required_name) do
+    for entry <- entries,
+        fetch_map_value(entry, :role) in [:assistant, "assistant"],
+        tool_call <- List.wrap(fetch_map_value(entry, :tool_calls)),
+        id = fetch_map_value(tool_call, :id),
+        name = fetch_map_value(tool_call, :name),
+        is_binary(id) and (is_nil(required_name) or name == required_name),
+        into: MapSet.new(),
+        do: id
   end
 
   defp build_config(agent, ctx) do

--- a/lib/jido_ai/skill/activation.ex
+++ b/lib/jido_ai/skill/activation.ex
@@ -14,7 +14,7 @@ defmodule Jido.AI.Skill.Activation do
   - `skill` - The full `Jido.AI.Skill.Spec`
   - `skill_body` - The rendered skill body text
   - `root_dir` - Skill root directory for resource resolution
-  - `resources` - Bounded listing of bundled resources
+  - `resources` - Listing of bundled resources
 
   ## Usage
 
@@ -22,7 +22,8 @@ defmodule Jido.AI.Skill.Activation do
       {:ok, context} = Jido.AI.Skill.Activation.activate("code-review")
 
       # Activate a spec directly
-      {:ok, spec} = Jido.AI.Skill.Discovery.find("code-review") |> Jido.AI.Skill.Discovery.to_spec()
+      {:ok, metadata} = Jido.AI.Skill.Discovery.find("code-review")
+      {:ok, spec} = Jido.AI.Skill.Discovery.to_spec(metadata)
       {:ok, context} = Jido.AI.Skill.Activation.activate(spec)
 
       # Check if already activated
@@ -164,6 +165,15 @@ defmodule Jido.AI.Skill.Activation do
       {:error, :not_activated}
     end
   end
+
+  @doc """
+  Clears all activations for the selected session.
+
+  Pass the same `:session_id` used for activation. Without one, the caller
+  process is used.
+  """
+  @spec clear(keyword()) :: :ok | {:error, term()}
+  def clear(opts \\ []), do: Registry.clear_activations(opts)
 
   # Private functions
 

--- a/lib/jido_ai/skill/activation.ex
+++ b/lib/jido_ai/skill/activation.ex
@@ -4,6 +4,7 @@ defmodule Jido.AI.Skill.Activation do
 
   Manages skill activation lifecycle:
   - Prevents duplicate activation (idempotent within session)
+  - Scopes activation by an explicit session ID or the caller process
   - Returns activation context for host/client injection
   - Tracks activated skills for session management
 
@@ -41,7 +42,8 @@ defmodule Jido.AI.Skill.Activation do
   Activates a skill by name, spec, or module.
 
   Returns activation context for use in host/client injection.
-  Prevents duplicate activation within the same session.
+  Prevents duplicate activation within the same session. Pass `:session_id`
+  when the session spans processes; otherwise the caller process is used.
 
   ## Returns
 
@@ -53,29 +55,32 @@ defmodule Jido.AI.Skill.Activation do
       {:ok, context} = Jido.AI.Skill.Activation.activate("code-review")
       IO.puts(context.skill_body)
   """
-  @spec activate(String.t() | Spec.t() | module()) :: {:ok, activation_context()} | {:error, term()}
-  def activate(name) when is_binary(name) do
+  @spec activate(String.t() | Spec.t() | module(), keyword()) ::
+          {:ok, activation_context()} | {:error, term()}
+  def activate(skill, opts \\ [])
+
+  def activate(name, opts) when is_binary(name) do
     # First check if already activated
-    if Registry.activated?(name) do
+    if Registry.activated?(name, opts) do
       # Return existing activation context
-      build_context_from_registry(name)
+      build_context_from_registry(name, opts)
     else
       # Try to resolve the skill
       with {:ok, spec} <- resolve_skill(name) do
-        do_activate(spec)
+        do_activate(spec, opts)
       end
     end
   end
 
-  def activate(%Spec{} = spec) do
-    activate_spec(spec)
+  def activate(%Spec{} = spec, opts) do
+    activate_spec(spec, opts)
   end
 
-  def activate(mod) when is_atom(mod) do
+  def activate(mod, opts) when is_atom(mod) do
     # Module-based skills
     if function_exported?(mod, :manifest, 0) do
       case mod.manifest() do
-        %Spec{} = spec -> activate_spec(spec)
+        %Spec{} = spec -> activate_spec(spec, opts)
         _other -> {:error, :invalid_skill_module}
       end
     else
@@ -86,9 +91,9 @@ defmodule Jido.AI.Skill.Activation do
   @doc """
   Activates a skill, raising on error.
   """
-  @spec activate!(String.t() | Spec.t() | module()) :: activation_context()
-  def activate!(skill) do
-    case activate(skill) do
+  @spec activate!(String.t() | Spec.t() | module(), keyword()) :: activation_context()
+  def activate!(skill, opts \\ []) do
+    case activate(skill, opts) do
       {:ok, context} -> context
       {:error, reason} -> raise "Skill activation failed: #{inspect(reason)}"
     end
@@ -104,11 +109,11 @@ defmodule Jido.AI.Skill.Activation do
       results = Jido.AI.Skill.Activation.activate_batch(["code-review", "testing"])
       # Returns: [{:ok, context1}, {:ok, context2}] or with errors
   """
-  @spec activate_batch([String.t() | Spec.t() | module()]) ::
+  @spec activate_batch([String.t() | Spec.t() | module()], keyword()) ::
           [{:ok, activation_context()} | {:error, term()}]
-  def activate_batch(skills) do
+  def activate_batch(skills, opts \\ []) do
     Enum.map(skills, fn skill ->
-      case activate(skill) do
+      case activate(skill, opts) do
         {:ok, context} -> {:ok, context}
         {:error, reason} -> {:error, reason}
       end
@@ -116,27 +121,27 @@ defmodule Jido.AI.Skill.Activation do
   end
 
   @doc """
-  Lists all currently activated skills.
+  Lists all activated skills in the selected session.
 
   ## Examples
 
       ["code-review", "testing"] = Jido.AI.Skill.Activation.list_activated()
   """
-  @spec list_activated() :: [String.t()]
-  def list_activated do
-    Registry.list_activated()
+  @spec list_activated(keyword()) :: [String.t()]
+  def list_activated(opts \\ []) do
+    Registry.list_activated(opts)
   end
 
   @doc """
-  Returns true if the named skill is activated in the current session.
+  Returns true if the named skill is activated in the selected session.
 
   ## Examples
 
       Jido.AI.Skill.Activation.activated?("code-review")
   """
-  @spec activated?(String.t()) :: boolean()
-  def activated?(name) when is_binary(name) do
-    Registry.activated?(name)
+  @spec activated?(String.t(), keyword()) :: boolean()
+  def activated?(name, opts \\ []) when is_binary(name) do
+    Registry.activated?(name, opts)
   end
 
   @doc """
@@ -151,10 +156,10 @@ defmodule Jido.AI.Skill.Activation do
 
       {:ok, context} = Jido.AI.Skill.Activation.get_context("code-review")
   """
-  @spec get_context(String.t()) :: {:ok, activation_context()} | {:error, :not_activated}
-  def get_context(name) when is_binary(name) do
-    if Registry.activated?(name) do
-      build_context_from_registry(name)
+  @spec get_context(String.t(), keyword()) :: {:ok, activation_context()} | {:error, :not_activated}
+  def get_context(name, opts \\ []) when is_binary(name) do
+    if Registry.activated?(name, opts) do
+      build_context_from_registry(name, opts)
     else
       {:error, :not_activated}
     end
@@ -162,15 +167,15 @@ defmodule Jido.AI.Skill.Activation do
 
   # Private functions
 
-  defp activate_spec(%Spec{name: name} = spec) when is_binary(name) do
-    if Registry.activated?(name) do
-      build_context_from_registry(spec.name)
+  defp activate_spec(%Spec{name: name} = spec, opts) when is_binary(name) do
+    if Registry.activated?(name, opts) do
+      build_context_from_registry(spec.name, opts)
     else
-      do_activate(spec)
+      do_activate(spec, opts)
     end
   end
 
-  defp activate_spec(%Spec{}), do: {:error, :invalid_skill_spec}
+  defp activate_spec(%Spec{}, _opts), do: {:error, :invalid_skill_spec}
 
   defp resolve_skill(name) when is_binary(name) do
     # Try registry first
@@ -187,17 +192,17 @@ defmodule Jido.AI.Skill.Activation do
     end
   end
 
-  defp do_activate(%Spec{} = spec) do
+  defp do_activate(%Spec{} = spec, opts) do
     with {:ok, skill_body} <- load_skill_body(spec),
-         :ok <- Registry.mark_activated(spec.name, activation_context(spec, skill_body)) do
+         :ok <- Registry.mark_activated(spec.name, activation_context(spec, skill_body), opts) do
       # Return the registry's canonical context so the first activation and any
       # subsequent (idempotent) activations yield an identical result.
-      build_context_from_registry(spec.name)
+      build_context_from_registry(spec.name, opts)
     end
   end
 
-  defp build_context_from_registry(name) do
-    Registry.get_activation_context(name)
+  defp build_context_from_registry(name, opts) do
+    Registry.get_activation_context(name, opts)
   end
 
   defp activation_context(%Spec{} = spec, skill_body) do

--- a/lib/jido_ai/skill/agent_integration.ex
+++ b/lib/jido_ai/skill/agent_integration.ex
@@ -1,0 +1,105 @@
+defmodule Jido.AI.Skill.AgentIntegration do
+  @moduledoc """
+  Builds the Agent Skills catalog, loading tool, and reserved tool context for a
+  `Jido.AI.Agent` at agent module compilation time.
+
+  Discovery is explicit because scanning a project loads instructions from its
+  filesystem. Passing `true` trusts the standard project and user skill roots;
+  passing a list trusts only those roots. Keyword options expose the discovery
+  bounds and a custom trust predicate. Keyword options do not trust any root
+  unless `:trust` is explicitly set.
+  """
+
+  alias Jido.AI.Actions.Skill.LoadSkill
+  alias Jido.AI.Skill.{Discovery, Prompt, Spec}
+
+  @type t :: %{
+          specs: [Spec.t()],
+          index: String.t(),
+          tools: [module()],
+          tool_context: map()
+        }
+
+  @doc """
+  Prepares Agent Skills integration data.
+
+  Accepted values:
+
+  - `false` or `nil` - disable Agent Skills integration
+  - `true` - trust and discover the standard project and user roots
+  - a list of paths - trust and discover only those roots
+  - keyword options - accepts `:paths`, `:trust`, `:max_depth`,
+    `:max_directories`, and `:exclude_directories`
+  """
+  @spec prepare(false | nil | true | [String.t()] | keyword()) :: {:ok, t()} | {:error, term()}
+  def prepare(value \\ false)
+
+  def prepare(value) when value in [false, nil], do: {:ok, empty()}
+
+  def prepare(true), do: prepare(paths: :default, trust: true)
+
+  def prepare([]), do: {:ok, empty()}
+
+  def prepare(paths) when is_list(paths) do
+    cond do
+      Keyword.keyword?(paths) ->
+        prepare_options(paths)
+
+      Enum.all?(paths, &is_binary/1) ->
+        prepare_options(paths: paths, trust: true)
+
+      true ->
+        {:error, {:invalid_agent_skills_option, :paths}}
+    end
+  end
+
+  def prepare(_value), do: {:error, {:invalid_agent_skills_option, :expected_boolean_paths_or_keyword}}
+
+  @doc false
+  @spec prepare!(false | nil | true | [String.t()] | keyword()) :: t()
+  def prepare!(value \\ false) do
+    case prepare(value) do
+      {:ok, integration} -> integration
+      {:error, reason} -> raise ArgumentError, "invalid agent_skills configuration: #{inspect(reason)}"
+    end
+  end
+
+  defp prepare_options(opts) do
+    paths = Keyword.get(opts, :paths, :default)
+
+    discovery_opts =
+      opts
+      |> Keyword.take([:trust, :max_depth, :max_directories, :exclude_directories])
+      |> Keyword.put_new(:trust, false)
+
+    with {:ok, metadata} <- discover(paths, discovery_opts),
+         {:ok, specs} <- load_specs(metadata) do
+      specs = Enum.sort_by(specs, & &1.name)
+
+      {:ok,
+       %{
+         specs: specs,
+         index: Prompt.render_index(specs),
+         tools: if(specs == [], do: [], else: [LoadSkill]),
+         tool_context: %{LoadSkill.context_skills_key() => Map.new(specs, &{&1.name, &1})}
+       }}
+    end
+  end
+
+  defp discover(:default, opts), do: Discovery.discover(opts)
+  defp discover(paths, opts) when is_list(paths), do: Discovery.discover_from(paths, opts)
+  defp discover(_paths, _opts), do: {:error, {:invalid_agent_skills_option, :paths}}
+
+  defp load_specs(metadata) do
+    Enum.reduce_while(metadata, {:ok, []}, fn item, {:ok, specs} ->
+      case Discovery.to_spec(item) do
+        {:ok, spec} -> {:cont, {:ok, [spec | specs]}}
+        {:error, reason} -> {:halt, {:error, {:skill_load_failed, item.skill_md_path, reason}}}
+      end
+    end)
+  end
+
+  defp empty do
+    %{specs: [], index: "", tools: [], tool_context: %{}}
+  end
+end

--- a/lib/jido_ai/skill/agent_integration.ex
+++ b/lib/jido_ai/skill/agent_integration.ex
@@ -1,7 +1,7 @@
 defmodule Jido.AI.Skill.AgentIntegration do
   @moduledoc """
   Builds the Agent Skills catalog, loading tool, and reserved tool context for a
-  `Jido.AI.Agent` at agent module compilation time.
+  `Jido.AI.Agent` when the agent instance initializes.
 
   Discovery is explicit because scanning a project loads instructions from its
   filesystem. Passing `true` trusts the standard project and user skill roots;
@@ -92,7 +92,7 @@ defmodule Jido.AI.Skill.AgentIntegration do
 
   defp load_specs(metadata) do
     Enum.reduce_while(metadata, {:ok, []}, fn item, {:ok, specs} ->
-      case Discovery.to_spec(item) do
+      case Discovery.to_spec(item, lenient: false) do
         {:ok, spec} -> {:cont, {:ok, [spec | specs]}}
         {:error, reason} -> {:halt, {:error, {:skill_load_failed, item.skill_md_path, reason}}}
       end

--- a/lib/jido_ai/skill/discovery.ex
+++ b/lib/jido_ai/skill/discovery.ex
@@ -36,6 +36,9 @@ defmodule Jido.AI.Skill.Discovery do
   alias Jido.AI.Skill.{Spec, Loader}
 
   @project_path ".agents/skills"
+  @default_max_depth 6
+  @default_max_directories 2_000
+  @default_excluded_directories [".git", "node_modules"]
 
   @type scope :: :project | :user | :custom
   @type discovery_metadata :: %{
@@ -63,10 +66,10 @@ defmodule Jido.AI.Skill.Discovery do
       {:ok, skills} = Jido.AI.Skill.Discovery.discover()
       # skills will have project-level skills overriding user-level
   """
-  @spec discover() :: {:ok, [discovery_metadata()]} | {:error, term()}
-  def discover do
-    with {:ok, project_skills} <- discover_from_project(),
-         {:ok, user_skills} <- discover_from_user() do
+  @spec discover(keyword()) :: {:ok, [discovery_metadata()]} | {:error, term()}
+  def discover(opts \\ []) do
+    with {:ok, project_skills} <- discover_from_project(@project_path, opts),
+         {:ok, user_skills} <- discover_from_user(default_user_path(), opts) do
       # Merge with precedence: project > user
       merged =
         (project_skills ++ user_skills)
@@ -85,6 +88,10 @@ defmodule Jido.AI.Skill.Discovery do
   ## Options
 
   - `:scope` - Assign scope metadata (`:project` or `:user`), defaults to `:custom`
+  - `:max_depth` - Maximum directory depth to scan (default: `6`)
+  - `:max_directories` - Maximum directories visited across all paths (default: `2000`)
+  - `:exclude_directories` - Directory basenames to skip (default: `.git` and `node_modules`)
+  - `:trust` - `true`, `false`, or a one-argument function that approves each root path
 
   ## Examples
 
@@ -93,15 +100,19 @@ defmodule Jido.AI.Skill.Discovery do
   """
   @spec discover_from([String.t()], keyword()) :: {:ok, [discovery_metadata()]} | {:error, term()}
   def discover_from(paths, opts \\ []) do
-    scope = Keyword.get(opts, :scope, :custom)
+    with :ok <- validate_arguments(paths, opts),
+         :ok <- validate_options(opts),
+         :ok <- validate_trusted_paths(paths, opts),
+         {:ok, files} <- scan_paths(paths, opts) do
+      scope = Keyword.get(opts, :scope, :custom)
 
-    skills =
-      paths
-      |> Enum.flat_map(&scan_directory/1)
-      |> Enum.map(&build_metadata(&1, scope))
-      |> Enum.reject(&is_nil/1)
+      skills =
+        files
+        |> Enum.map(&build_metadata(&1, scope))
+        |> Enum.reject(&is_nil/1)
 
-    {:ok, skills}
+      {:ok, skills}
+    end
   end
 
   @doc """
@@ -113,10 +124,11 @@ defmodule Jido.AI.Skill.Discovery do
   - `{:ok, []}` - Directory doesn't exist or is empty
   - `{:error, reason}` - Discovery failed
   """
-  @spec discover_from_project(String.t()) :: {:ok, [discovery_metadata()]} | {:error, term()}
-  def discover_from_project(base_path \\ @project_path) do
+  @spec discover_from_project(String.t(), keyword()) ::
+          {:ok, [discovery_metadata()]} | {:error, term()}
+  def discover_from_project(base_path \\ @project_path, opts \\ []) do
     if File.dir?(base_path) do
-      discover_from([base_path], scope: :project)
+      discover_from([base_path], Keyword.put(opts, :scope, :project))
     else
       {:ok, []}
     end
@@ -131,10 +143,11 @@ defmodule Jido.AI.Skill.Discovery do
   - `{:ok, []}` - Directory doesn't exist or is empty
   - `{:error, reason}` - Discovery failed
   """
-  @spec discover_from_user(String.t()) :: {:ok, [discovery_metadata()]} | {:error, term()}
-  def discover_from_user(base_path \\ default_user_path()) do
+  @spec discover_from_user(String.t(), keyword()) ::
+          {:ok, [discovery_metadata()]} | {:error, term()}
+  def discover_from_user(base_path \\ default_user_path(), opts \\ []) do
     if File.dir?(base_path) do
-      discover_from([base_path], scope: :user)
+      discover_from([base_path], Keyword.put(opts, :scope, :user))
     else
       {:ok, []}
     end
@@ -154,9 +167,10 @@ defmodule Jido.AI.Skill.Discovery do
       {:error, :not_found} = Jido.AI.Skill.Discovery.find("unknown-skill")
       {:ok, metadata} = Jido.AI.Skill.Discovery.find("local-skill", ["priv/skills/"])
   """
-  @spec find(String.t(), [String.t()] | nil) :: {:ok, discovery_metadata()} | {:error, :not_found}
-  def find(name, paths \\ nil) when is_binary(name) do
-    discovery = if is_list(paths), do: discover_from(paths), else: discover()
+  @spec find(String.t(), [String.t()] | nil, keyword()) ::
+          {:ok, discovery_metadata()} | {:error, term()}
+  def find(name, paths \\ nil, opts \\ []) when is_binary(name) do
+    discovery = if is_list(paths), do: discover_from(paths, opts), else: discover(opts)
 
     case discovery do
       {:ok, skills} ->
@@ -164,6 +178,9 @@ defmodule Jido.AI.Skill.Discovery do
           nil -> {:error, :not_found}
           skill -> {:ok, skill}
         end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -192,9 +209,133 @@ defmodule Jido.AI.Skill.Discovery do
 
   # Private functions
 
-  defp scan_directory(path) do
-    skill_pattern = Path.join([path, "**", "SKILL.md"])
-    Path.wildcard(skill_pattern)
+  defp validate_arguments(paths, opts) do
+    cond do
+      not (is_list(paths) and Enum.all?(paths, &is_binary/1)) ->
+        {:error, {:invalid_discovery_option, :paths}}
+
+      not (is_list(opts) and Keyword.keyword?(opts)) ->
+        {:error, {:invalid_discovery_option, :options}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_options(opts) do
+    max_depth = Keyword.get(opts, :max_depth, @default_max_depth)
+    max_directories = Keyword.get(opts, :max_directories, @default_max_directories)
+    excluded = Keyword.get(opts, :exclude_directories, @default_excluded_directories)
+    trust = Keyword.get(opts, :trust, true)
+
+    cond do
+      not (is_integer(max_depth) and max_depth >= 0) ->
+        {:error, {:invalid_discovery_option, :max_depth}}
+
+      not (is_integer(max_directories) and max_directories > 0) ->
+        {:error, {:invalid_discovery_option, :max_directories}}
+
+      not (is_list(excluded) and Enum.all?(excluded, &is_binary/1)) ->
+        {:error, {:invalid_discovery_option, :exclude_directories}}
+
+      trust not in [true, false] and not is_function(trust, 1) ->
+        {:error, {:invalid_discovery_option, :trust}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_trusted_paths(paths, opts) do
+    trust = Keyword.get(opts, :trust, true)
+
+    Enum.reduce_while(paths, :ok, fn path, :ok ->
+      expanded = Path.expand(path)
+
+      if trusted_path?(expanded, trust) do
+        {:cont, :ok}
+      else
+        {:halt, {:error, {:untrusted_skill_path, expanded}}}
+      end
+    end)
+  end
+
+  defp trusted_path?(_path, true), do: true
+  defp trusted_path?(_path, false), do: false
+  defp trusted_path?(path, trust) when is_function(trust, 1), do: trust.(path) == true
+  defp trusted_path?(_path, _trust), do: false
+
+  defp scan_paths(paths, opts) do
+    Enum.reduce_while(paths, {:ok, [], 0}, fn path, {:ok, files, directory_count} ->
+      expanded = Path.expand(path)
+
+      cond do
+        File.regular?(expanded) and Path.basename(expanded) == "SKILL.md" ->
+          {:cont, {:ok, [expanded | files], directory_count}}
+
+        File.dir?(expanded) ->
+          case walk_directories([{expanded, 0}], files, directory_count, opts) do
+            {:ok, next_files, next_count} -> {:cont, {:ok, next_files, next_count}}
+            {:error, reason} -> {:halt, {:error, reason}}
+          end
+
+        true ->
+          {:cont, {:ok, files, directory_count}}
+      end
+    end)
+    |> case do
+      {:ok, files, _directory_count} -> {:ok, Enum.sort(files)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp walk_directories([], files, directory_count, _opts),
+    do: {:ok, files, directory_count}
+
+  defp walk_directories([{directory, depth} | rest], files, directory_count, opts) do
+    max_directories = Keyword.get(opts, :max_directories, @default_max_directories)
+
+    if directory_count >= max_directories do
+      {:error, {:discovery_limit_exceeded, :max_directories, max_directories}}
+    else
+      {files, children} = scan_one_directory(directory, depth, files, opts)
+      walk_directories(rest ++ children, files, directory_count + 1, opts)
+    end
+  end
+
+  defp scan_one_directory(directory, depth, files, opts) do
+    skill_file = Path.join(directory, "SKILL.md")
+    files = if File.regular?(skill_file), do: [skill_file | files], else: files
+    max_depth = Keyword.get(opts, :max_depth, @default_max_depth)
+
+    children =
+      if depth < max_depth do
+        excluded = Keyword.get(opts, :exclude_directories, @default_excluded_directories)
+
+        case File.ls(directory) do
+          {:ok, entries} ->
+            entries
+            |> Enum.sort()
+            |> Enum.reject(&(&1 in excluded))
+            |> Enum.map(&Path.join(directory, &1))
+            |> Enum.filter(&(File.dir?(&1) and not symlink?(&1)))
+            |> Enum.map(&{&1, depth + 1})
+
+          {:error, _reason} ->
+            []
+        end
+      else
+        []
+      end
+
+    {files, children}
+  end
+
+  defp symlink?(path) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :symlink}} -> true
+      _ -> false
+    end
   end
 
   defp default_user_path do

--- a/lib/jido_ai/skill/discovery.ex
+++ b/lib/jido_ai/skill/discovery.ex
@@ -100,10 +100,7 @@ defmodule Jido.AI.Skill.Discovery do
   """
   @spec discover_from([String.t()], keyword()) :: {:ok, [discovery_metadata()]} | {:error, term()}
   def discover_from(paths, opts \\ []) do
-    with :ok <- validate_arguments(paths, opts),
-         :ok <- validate_options(opts),
-         :ok <- validate_trusted_paths(paths, opts),
-         {:ok, files} <- scan_paths(paths, opts) do
+    with {:ok, files} <- discover_files(paths, opts) do
       scope = Keyword.get(opts, :scope, :custom)
 
       skills =
@@ -112,6 +109,21 @@ defmodule Jido.AI.Skill.Discovery do
         |> Enum.reject(&is_nil/1)
 
       {:ok, skills}
+    end
+  end
+
+  @doc """
+  Returns bounded, symlink-safe `SKILL.md` paths without parsing them.
+
+  This is the shared scanner used by discovery and registry loading. It accepts
+  the same bounds, exclusions, and trust options as `discover_from/2`.
+  """
+  @spec discover_files([String.t()], keyword()) :: {:ok, [String.t()]} | {:error, term()}
+  def discover_files(paths, opts \\ []) do
+    with :ok <- validate_arguments(paths, opts),
+         :ok <- validate_options(opts),
+         :ok <- validate_trusted_paths(paths, opts) do
+      scan_paths(paths, opts)
     end
   end
 
@@ -192,12 +204,21 @@ defmodule Jido.AI.Skill.Discovery do
       {:ok, metadata} = Jido.AI.Skill.Discovery.find("code-review")
       {:ok, spec} = Jido.AI.Skill.Discovery.to_spec(metadata)
   """
-  @spec to_spec(discovery_metadata() | map()) :: {:ok, Spec.t()} | {:error, term()}
-  def to_spec(%{skill_md_path: path, scope: scope, root_dir: _root_dir}) do
-    case Loader.load(path, lenient: true) do
+  @spec to_spec(discovery_metadata() | map(), keyword()) :: {:ok, Spec.t()} | {:error, term()}
+  def to_spec(metadata, opts \\ [])
+
+  def to_spec(%{skill_md_path: path, scope: scope, root_dir: _root_dir}, opts)
+      when scope in [:project, :user, :custom] and is_list(opts) do
+    case Loader.load(path, Keyword.put_new(opts, :lenient, true)) do
       {:ok, spec} ->
         # Enhance spec with discovery metadata
-        enhanced = %{spec | source: {:file, path}, metadata: Map.put(spec.metadata, :discovery_scope, scope)}
+        enhanced =
+          %{
+            spec
+            | source: {:file, path},
+              metadata: Map.put(spec.metadata, "jido_ai.discovery_scope", Atom.to_string(scope))
+          }
+
         {:ok, enhanced}
 
       {:error, reason} ->
@@ -205,7 +226,7 @@ defmodule Jido.AI.Skill.Discovery do
     end
   end
 
-  def to_spec(_invalid_metadata), do: {:error, :invalid_metadata}
+  def to_spec(_invalid_metadata, _opts), do: {:error, :invalid_metadata}
 
   # Private functions
 
@@ -227,6 +248,7 @@ defmodule Jido.AI.Skill.Discovery do
     max_directories = Keyword.get(opts, :max_directories, @default_max_directories)
     excluded = Keyword.get(opts, :exclude_directories, @default_excluded_directories)
     trust = Keyword.get(opts, :trust, true)
+    scope = Keyword.get(opts, :scope, :custom)
 
     cond do
       not (is_integer(max_depth) and max_depth >= 0) ->
@@ -240,6 +262,9 @@ defmodule Jido.AI.Skill.Discovery do
 
       trust not in [true, false] and not is_function(trust, 1) ->
         {:error, {:invalid_discovery_option, :trust}}
+
+      scope not in [:project, :user, :custom] ->
+        {:error, {:invalid_discovery_option, :scope}}
 
       true ->
         :ok
@@ -270,10 +295,10 @@ defmodule Jido.AI.Skill.Discovery do
       expanded = Path.expand(path)
 
       cond do
-        File.regular?(expanded) and Path.basename(expanded) == "SKILL.md" ->
+        regular_file?(expanded) and Path.basename(expanded) == "SKILL.md" ->
           {:cont, {:ok, [expanded | files], directory_count}}
 
-        File.dir?(expanded) ->
+        directory?(expanded) ->
           case walk_directories([{expanded, 0}], files, directory_count, opts) do
             {:ok, next_files, next_count} -> {:cont, {:ok, next_files, next_count}}
             {:error, reason} -> {:halt, {:error, reason}}
@@ -305,7 +330,7 @@ defmodule Jido.AI.Skill.Discovery do
 
   defp scan_one_directory(directory, depth, files, opts) do
     skill_file = Path.join(directory, "SKILL.md")
-    files = if File.regular?(skill_file), do: [skill_file | files], else: files
+    files = if regular_file?(skill_file), do: [skill_file | files], else: files
     max_depth = Keyword.get(opts, :max_depth, @default_max_depth)
 
     children =
@@ -318,7 +343,7 @@ defmodule Jido.AI.Skill.Discovery do
             |> Enum.sort()
             |> Enum.reject(&(&1 in excluded))
             |> Enum.map(&Path.join(directory, &1))
-            |> Enum.filter(&(File.dir?(&1) and not symlink?(&1)))
+            |> Enum.filter(&directory?/1)
             |> Enum.map(&{&1, depth + 1})
 
           {:error, _reason} ->
@@ -331,9 +356,16 @@ defmodule Jido.AI.Skill.Discovery do
     {files, children}
   end
 
-  defp symlink?(path) do
+  defp regular_file?(path) do
     case File.lstat(path) do
-      {:ok, %File.Stat{type: :symlink}} -> true
+      {:ok, %File.Stat{type: :regular}} -> true
+      _ -> false
+    end
+  end
+
+  defp directory?(path) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :directory}} -> true
       _ -> false
     end
   end
@@ -352,7 +384,7 @@ defmodule Jido.AI.Skill.Discovery do
       {:ok, %{"name" => name} = frontmatter} when is_binary(name) ->
         %{
           name: name,
-          description: frontmatter["description"],
+          description: binary_or_nil(frontmatter["description"]),
           skill_md_path: skill_md_path,
           root_dir: root_dir,
           scope: scope,
@@ -380,4 +412,7 @@ defmodule Jido.AI.Skill.Discovery do
         {:error, reason}
     end
   end
+
+  defp binary_or_nil(value) when is_binary(value), do: value
+  defp binary_or_nil(_value), do: nil
 end

--- a/lib/jido_ai/skill/error.ex
+++ b/lib/jido_ai/skill/error.ex
@@ -89,6 +89,25 @@ defmodule Jido.AI.Skill.Error.Validation.MissingField do
   def message(%{field: field}), do: "Missing required field: #{field}"
 end
 
+defmodule Jido.AI.Skill.Error.Validation.InvalidField do
+  @moduledoc "Invalid skill frontmatter field"
+
+  use Splode.Error,
+    fields: [:field, :reason, :value],
+    class: :validation
+
+  @impl true
+  def message(%{field: field, reason: reason}),
+    do: "Invalid #{field}: #{format_reason(reason)}"
+
+  defp format_reason(:directory_name_mismatch), do: "must match the parent directory name"
+  defp format_reason(:too_long), do: "exceeds the maximum length"
+  defp format_reason(:empty), do: "must not be empty"
+  defp format_reason(:invalid_type), do: "has an invalid type"
+  defp format_reason(:invalid_metadata), do: "must contain only string keys and string values"
+  defp format_reason(reason), do: inspect(reason)
+end
+
 defmodule Jido.AI.Skill.Error.NotFound do
   @moduledoc "Skill not found in registry"
 

--- a/lib/jido_ai/skill/loader.ex
+++ b/lib/jido_ai/skill/loader.ex
@@ -136,16 +136,19 @@ defmodule Jido.AI.Skill.Loader do
     with {:ok, name, diagnostics} <- validate_name(frontmatter["name"], diagnostics, lenient),
          {:ok, diagnostics} <- check_directory_name_match(name, path, diagnostics, lenient),
          {:ok, description, diagnostics} <- validate_description(frontmatter["description"], diagnostics, lenient),
+         {:ok, license, diagnostics} <- validate_license(frontmatter["license"], diagnostics, lenient),
          {:ok, compatibility, diagnostics} <-
            validate_compatibility(frontmatter["compatibility"], diagnostics, lenient),
-         {:ok, metadata, diagnostics} <- parse_metadata(frontmatter["metadata"], diagnostics, lenient) do
+         {:ok, metadata, diagnostics} <- parse_metadata(frontmatter["metadata"], diagnostics, lenient),
+         {:ok, allowed_tools, diagnostics} <-
+           validate_allowed_tools(frontmatter["allowed-tools"], diagnostics, lenient) do
       spec = %Spec{
         name: name,
         description: description,
-        license: optional_string(frontmatter["license"]),
+        license: license,
         compatibility: compatibility,
         metadata: metadata,
-        allowed_tools: parse_allowed_tools(frontmatter["allowed-tools"]),
+        allowed_tools: allowed_tools,
         source: {:file, path},
         body_ref: {:inline, body},
         actions: [],
@@ -174,7 +177,7 @@ defmodule Jido.AI.Skill.Loader do
   end
 
   defp do_check_directory_name_match(name, path, diagnostics, lenient) do
-    parent_dir = path |> Path.dirname() |> Path.basename()
+    parent_dir = path |> Path.expand() |> Path.dirname() |> Path.basename()
 
     if parent_dir != name do
       warning =
@@ -338,6 +341,13 @@ defmodule Jido.AI.Skill.Loader do
     end
   end
 
+  defp validate_license(nil, diagnostics, _lenient), do: {:ok, nil, diagnostics}
+  defp validate_license(license, diagnostics, _lenient) when is_binary(license), do: {:ok, license, diagnostics}
+
+  defp validate_license(license, diagnostics, lenient) do
+    invalid_optional_string(:license, license, :invalid_type, diagnostics, lenient)
+  end
+
   defp validate_compatibility(nil, diagnostics, _lenient), do: {:ok, nil, diagnostics}
 
   defp validate_compatibility(compat, diagnostics, lenient) when is_binary(compat) do
@@ -372,10 +382,35 @@ defmodule Jido.AI.Skill.Loader do
     invalid_optional_string(:compatibility, compat, :invalid_type, diagnostics, lenient)
   end
 
-  defp parse_allowed_tools(nil), do: []
-  defp parse_allowed_tools(tools) when is_list(tools), do: Enum.map(tools, &to_string/1)
-  defp parse_allowed_tools(tools) when is_binary(tools), do: String.split(tools, ~r/\s+/, trim: true)
-  defp parse_allowed_tools(_), do: []
+  defp validate_allowed_tools(nil, diagnostics, _lenient), do: {:ok, [], diagnostics}
+
+  defp validate_allowed_tools(tools, diagnostics, _lenient) when is_binary(tools) do
+    {:ok, String.split(tools, ~r/\s+/, trim: true), diagnostics}
+  end
+
+  defp validate_allowed_tools(tools, diagnostics, true) when is_list(tools) do
+    warning =
+      Diagnostics.Warning.new(
+        :invalid_allowed_tools_type,
+        "allowed-tools must be a space-separated string; list entries were normalized"
+      )
+
+    {:ok, Enum.map(tools, &metadata_string/1), Diagnostics.add_warning(diagnostics, warning)}
+  end
+
+  defp validate_allowed_tools(_tools, diagnostics, true) do
+    warning = Diagnostics.Warning.new(:invalid_allowed_tools_type, "Invalid allowed-tools; field omitted")
+    {:ok, [], Diagnostics.add_warning(diagnostics, warning)}
+  end
+
+  defp validate_allowed_tools(tools, _diagnostics, false) do
+    {:error,
+     %Error.Validation.InvalidField{
+       field: :allowed_tools,
+       reason: :invalid_type,
+       value: tools
+     }}
+  end
 
   defp parse_metadata(nil, diagnostics, _lenient), do: {:ok, %{}, diagnostics}
 
@@ -443,7 +478,7 @@ defmodule Jido.AI.Skill.Loader do
   defp metadata_string(value), do: inspect(value)
 
   defp invalid_field_warning(:compatibility), do: :invalid_compatibility
-  defp invalid_field_warning(_field), do: :invalid_optional_field
+  defp invalid_field_warning(:license), do: :invalid_license
 
   defp parse_tags(nil), do: []
   defp parse_tags(tags) when is_list(tags), do: Enum.map(tags, &to_string/1)

--- a/lib/jido_ai/skill/loader.ex
+++ b/lib/jido_ai/skill/loader.ex
@@ -132,19 +132,18 @@ defmodule Jido.AI.Skill.Loader do
   end
 
   defp build_spec(frontmatter, body, path, diagnostics, lenient) do
-    # Check for parent directory name mismatch (non-fatal warning)
-    diagnostics = check_directory_name_match(frontmatter["name"], path, diagnostics, lenient)
-
     # Validate fields, allowing lenient mode to proceed with defaults
     with {:ok, name, diagnostics} <- validate_name(frontmatter["name"], diagnostics, lenient),
-         {:ok, description, diagnostics} <- validate_description(frontmatter["description"], diagnostics, lenient) do
-      {metadata, diagnostics} = parse_metadata(frontmatter["metadata"], diagnostics)
-
+         {:ok, diagnostics} <- check_directory_name_match(name, path, diagnostics, lenient),
+         {:ok, description, diagnostics} <- validate_description(frontmatter["description"], diagnostics, lenient),
+         {:ok, compatibility, diagnostics} <-
+           validate_compatibility(frontmatter["compatibility"], diagnostics, lenient),
+         {:ok, metadata, diagnostics} <- parse_metadata(frontmatter["metadata"], diagnostics, lenient) do
       spec = %Spec{
         name: name,
         description: description,
         license: optional_string(frontmatter["license"]),
-        compatibility: validate_compatibility(frontmatter["compatibility"]),
+        compatibility: compatibility,
         metadata: metadata,
         allowed_tools: parse_allowed_tools(frontmatter["allowed-tools"]),
         source: {:file, path},
@@ -160,25 +159,24 @@ defmodule Jido.AI.Skill.Loader do
     end
   end
 
-  # Check if the directory name matches the declared skill name.
-  #
-  # Only binary names can be compared. A nil or non-binary name (e.g.
-  # `name: 123` in the YAML) is left for validate_name/3 to handle —
-  # either as a strict validation error or a lenient fallback name.
-  # Comparing here first would call String.downcase/1 on a non-binary
-  # and raise before validation ever runs.
-  defp check_directory_name_match(name, _path, diagnostics, _lenient)
-       when not is_binary(name),
-       do: diagnostics
+  # Check if the directory name exactly matches the validated skill name.
+  # Inline parse sources do not have a filesystem directory to compare.
+  defp check_directory_name_match(_name, path, diagnostics, _lenient)
+       when not is_binary(path),
+       do: {:ok, diagnostics}
 
   defp check_directory_name_match(name, path, diagnostics, lenient) when is_binary(name) do
+    if Path.basename(path) != "SKILL.md" do
+      {:ok, diagnostics}
+    else
+      do_check_directory_name_match(name, path, diagnostics, lenient)
+    end
+  end
+
+  defp do_check_directory_name_match(name, path, diagnostics, lenient) do
     parent_dir = path |> Path.dirname() |> Path.basename()
 
-    # Normalize for comparison (kebab-case variations allowed)
-    normalized_dir = String.downcase(parent_dir) |> String.replace("_", "-")
-    normalized_name = String.downcase(name)
-
-    if normalized_dir != normalized_name do
+    if parent_dir != name do
       warning =
         Diagnostics.Warning.new(
           :directory_name_mismatch,
@@ -186,13 +184,17 @@ defmodule Jido.AI.Skill.Loader do
         )
 
       if lenient do
-        Diagnostics.add_warning(diagnostics, warning)
+        {:ok, Diagnostics.add_warning(diagnostics, warning)}
       else
-        # In strict mode, this could still be a warning but not fatal
-        Diagnostics.add_warning(diagnostics, warning)
+        {:error,
+         %Error.Validation.InvalidField{
+           field: :name,
+           reason: :directory_name_mismatch,
+           value: name
+         }}
       end
     else
-      diagnostics
+      {:ok, diagnostics}
     end
   end
 
@@ -300,17 +302,25 @@ defmodule Jido.AI.Skill.Loader do
         end
 
       String.length(desc) > @max_description_length ->
-        # Always truncate long descriptions as a warning
-        truncated = String.slice(desc, 0, @max_description_length)
+        if lenient do
+          truncated = String.slice(desc, 0, @max_description_length)
 
-        warning =
-          Diagnostics.Warning.new(
-            :description_too_long,
-            "Description exceeds #{@max_description_length} chars, truncated"
-          )
+          warning =
+            Diagnostics.Warning.new(
+              :description_too_long,
+              "Description exceeds #{@max_description_length} chars, truncated"
+            )
 
-        diagnostics = Diagnostics.add_warning(diagnostics, warning)
-        {:ok, truncated, diagnostics}
+          diagnostics = Diagnostics.add_warning(diagnostics, warning)
+          {:ok, truncated, diagnostics}
+        else
+          {:error,
+           %Error.Validation.InvalidField{
+             field: :description,
+             reason: :too_long,
+             value: desc
+           }}
+        end
 
       true ->
         {:ok, desc, diagnostics}
@@ -328,35 +338,112 @@ defmodule Jido.AI.Skill.Loader do
     end
   end
 
-  defp validate_compatibility(nil), do: nil
+  defp validate_compatibility(nil, diagnostics, _lenient), do: {:ok, nil, diagnostics}
 
-  defp validate_compatibility(compat) when is_binary(compat) do
-    if String.length(compat) > @max_compatibility_length do
-      String.slice(compat, 0, @max_compatibility_length)
-    else
-      compat
+  defp validate_compatibility(compat, diagnostics, lenient) when is_binary(compat) do
+    cond do
+      String.trim(compat) == "" ->
+        invalid_optional_string(:compatibility, compat, :empty, diagnostics, lenient)
+
+      String.length(compat) > @max_compatibility_length ->
+        if lenient do
+          warning =
+            Diagnostics.Warning.new(
+              :compatibility_too_long,
+              "Compatibility exceeds #{@max_compatibility_length} chars, truncated"
+            )
+
+          {:ok, String.slice(compat, 0, @max_compatibility_length), Diagnostics.add_warning(diagnostics, warning)}
+        else
+          {:error,
+           %Error.Validation.InvalidField{
+             field: :compatibility,
+             reason: :too_long,
+             value: compat
+           }}
+        end
+
+      true ->
+        {:ok, compat, diagnostics}
     end
   end
 
-  defp validate_compatibility(_), do: nil
+  defp validate_compatibility(compat, diagnostics, lenient) do
+    invalid_optional_string(:compatibility, compat, :invalid_type, diagnostics, lenient)
+  end
 
   defp parse_allowed_tools(nil), do: []
   defp parse_allowed_tools(tools) when is_list(tools), do: Enum.map(tools, &to_string/1)
   defp parse_allowed_tools(tools) when is_binary(tools), do: String.split(tools, ~r/\s+/, trim: true)
   defp parse_allowed_tools(_), do: []
 
-  defp parse_metadata(nil, diagnostics), do: {%{}, diagnostics}
-  defp parse_metadata(metadata, diagnostics) when is_map(metadata), do: {metadata, diagnostics}
+  defp parse_metadata(nil, diagnostics, _lenient), do: {:ok, %{}, diagnostics}
 
-  defp parse_metadata(_metadata, diagnostics) do
+  defp parse_metadata(metadata, diagnostics, _lenient)
+       when is_map(metadata) and map_size(metadata) == 0,
+       do: {:ok, metadata, diagnostics}
+
+  defp parse_metadata(metadata, diagnostics, lenient) when is_map(metadata) do
+    if Enum.all?(metadata, fn {key, value} -> is_binary(key) and is_binary(value) end) do
+      {:ok, metadata, diagnostics}
+    else
+      if lenient do
+        warning =
+          Diagnostics.Warning.new(
+            :invalid_metadata_entries,
+            "Metadata keys and values must be strings; invalid entries were normalized"
+          )
+
+        {:ok, normalize_metadata(metadata), Diagnostics.add_warning(diagnostics, warning)}
+      else
+        {:error,
+         %Error.Validation.InvalidField{
+           field: :metadata,
+           reason: :invalid_metadata,
+           value: metadata
+         }}
+      end
+    end
+  end
+
+  defp parse_metadata(_metadata, diagnostics, true) do
     diagnostics =
       Diagnostics.add_warning(
         diagnostics,
         Diagnostics.Warning.new(:invalid_metadata_type, "Invalid metadata type, using empty metadata")
       )
 
-    {%{}, diagnostics}
+    {:ok, %{}, diagnostics}
   end
+
+  defp parse_metadata(metadata, _diagnostics, false) do
+    {:error,
+     %Error.Validation.InvalidField{
+       field: :metadata,
+       reason: :invalid_type,
+       value: metadata
+     }}
+  end
+
+  defp invalid_optional_string(field, _value, _reason, diagnostics, true) do
+    warning = Diagnostics.Warning.new(invalid_field_warning(field), "Invalid #{field}; field omitted")
+    {:ok, nil, Diagnostics.add_warning(diagnostics, warning)}
+  end
+
+  defp invalid_optional_string(field, value, reason, _diagnostics, false) do
+    {:error, %Error.Validation.InvalidField{field: field, reason: reason, value: value}}
+  end
+
+  defp normalize_metadata(metadata) do
+    Map.new(metadata, fn {key, value} -> {metadata_string(key), metadata_string(value)} end)
+  end
+
+  defp metadata_string(value) when is_binary(value), do: value
+  defp metadata_string(value) when is_atom(value) or is_number(value), do: to_string(value)
+  defp metadata_string(value), do: inspect(value)
+
+  defp invalid_field_warning(:compatibility), do: :invalid_compatibility
+  defp invalid_field_warning(_field), do: :invalid_optional_field
 
   defp parse_tags(nil), do: []
   defp parse_tags(tags) when is_list(tags), do: Enum.map(tags, &to_string/1)

--- a/lib/jido_ai/skill/prompt.ex
+++ b/lib/jido_ai/skill/prompt.ex
@@ -20,7 +20,8 @@ defmodule Jido.AI.Skill.Prompt do
 
   ## Options
 
-  - `:include_body` - Include skill body content (default: true)
+  - `:include_body` - Include skill body content (default: false). Prefer
+    `render_index/2` plus `Jido.AI.Actions.Skill.LoadSkill` for progressive disclosure.
   - `:header` - Custom header text (default: "You have access to the following skills:")
 
   ## Example
@@ -31,7 +32,7 @@ defmodule Jido.AI.Skill.Prompt do
   """
   @spec render([module() | Spec.t() | String.t()], keyword()) :: String.t()
   def render(skills, opts \\ []) do
-    include_body = Keyword.get(opts, :include_body, true)
+    include_body = Keyword.get(opts, :include_body, false)
     header = Keyword.get(opts, :header, "You have access to the following skills:")
 
     skill_sections =

--- a/lib/jido_ai/skill/registry.ex
+++ b/lib/jido_ai/skill/registry.ex
@@ -18,12 +18,10 @@ defmodule Jido.AI.Skill.Registry do
 
   use GenServer
 
-  alias Jido.AI.Skill.{Spec, Loader, Error}
+  alias Jido.AI.Skill.{Discovery, Spec, Loader, Error}
 
   @table_name :jido_skill_registry
   @activation_table :jido_skill_activations
-
-  @type session_id :: term()
 
   # Client API
 
@@ -274,6 +272,22 @@ defmodule Jido.AI.Skill.Registry do
     |> unwrap_or_error()
   end
 
+  @doc """
+  Removes every activation for the selected session, including durable entries.
+
+  Use this when a conversation or agent session ends. The optional `:session_id`
+  defaults to the caller process.
+  """
+  @spec clear_activations(keyword()) :: :ok | {:error, term()}
+  def clear_activations(opts \\ []) do
+    selected_session = session_id(opts)
+
+    with_started_registry(fn ->
+      GenServer.call(__MODULE__, {:clear_activations, selected_session})
+    end)
+    |> unwrap_or_error()
+  end
+
   # Server callbacks
 
   @impl true
@@ -348,17 +362,22 @@ defmodule Jido.AI.Skill.Registry do
     end
   end
 
+  def handle_call({:clear_activations, session_id}, _from, state) do
+    :ets.select_delete(@activation_table, [{{{session_id, :_}, :_}, [], [true]}])
+    {:reply, :ok, state}
+  end
+
   # Private functions
 
   defp do_load_paths(paths) do
-    paths
-    |> Enum.flat_map(&find_skill_files/1)
-    |> Enum.reduce_while({:ok, 0}, fn path, {:ok, count} ->
-      case load_and_register(path) do
-        :ok -> {:cont, {:ok, count + 1}}
-        {:error, _} = error -> {:halt, error}
-      end
-    end)
+    with {:ok, files} <- Discovery.discover_files(paths, trust: true) do
+      Enum.reduce_while(files, {:ok, 0}, fn path, {:ok, count} ->
+        case load_and_register(path) do
+          :ok -> {:cont, {:ok, count + 1}}
+          {:error, _} = error -> {:halt, error}
+        end
+      end)
+    end
   end
 
   defp load_and_register(path) do
@@ -369,19 +388,6 @@ defmodule Jido.AI.Skill.Registry do
 
       {:error, _reason} = error ->
         error
-    end
-  end
-
-  defp find_skill_files(path) do
-    cond do
-      File.regular?(path) and String.ends_with?(path, "SKILL.md") ->
-        [path]
-
-      File.dir?(path) ->
-        Path.wildcard(Path.join([path, "**", "SKILL.md"]))
-
-      true ->
-        []
     end
   end
 

--- a/lib/jido_ai/skill/registry.ex
+++ b/lib/jido_ai/skill/registry.ex
@@ -23,6 +23,8 @@ defmodule Jido.AI.Skill.Registry do
   @table_name :jido_skill_registry
   @activation_table :jido_skill_activations
 
+  @type session_id :: term()
+
   # Client API
 
   @doc """
@@ -142,34 +144,45 @@ defmodule Jido.AI.Skill.Registry do
   @doc """
   Marks a skill as activated with its activation context.
 
-  Used by `Jido.AI.Skill.Activation` to track activated skills.
+  Used by `Jido.AI.Skill.Activation` to track activated skills. The optional
+  `:session_id` defaults to the caller process.
   """
-  @spec mark_activated(String.t(), map()) :: :ok | {:error, term()}
-  def mark_activated(name, context) when is_binary(name) and is_map(context) do
+  @spec mark_activated(String.t(), map(), keyword()) :: :ok | {:error, term()}
+  def mark_activated(name, context, opts \\ []) when is_binary(name) and is_map(context) do
+    session_id = session_id(opts)
+
     with_started_registry(fn ->
-      GenServer.call(__MODULE__, {:mark_activated, name, context})
+      GenServer.call(__MODULE__, {:mark_activated, session_id, name, context})
     end)
     |> unwrap_or_error()
   end
 
   @doc """
-  Checks if a skill has been activated in this session.
+  Checks if a skill has been activated in the selected session.
+
+  The optional `:session_id` defaults to the caller process.
   """
-  @spec activated?(String.t()) :: boolean()
-  def activated?(name) when is_binary(name) do
+  @spec activated?(String.t(), keyword()) :: boolean()
+  def activated?(name, opts \\ []) when is_binary(name) do
+    session_id = session_id(opts)
+
     with_started_registry(fn ->
-      :ets.lookup(@activation_table, name) != []
+      :ets.lookup(@activation_table, {session_id, name}) != []
     end)
     |> unwrap_or_false()
   end
 
   @doc """
-  Lists all activated skill names in the current session.
+  Lists all activated skill names in the selected session.
+
+  The optional `:session_id` defaults to the caller process.
   """
-  @spec list_activated() :: [String.t()]
-  def list_activated do
+  @spec list_activated(keyword()) :: [String.t()]
+  def list_activated(opts \\ []) do
+    session_id = session_id(opts)
+
     with_started_registry(fn ->
-      :ets.select(@activation_table, [{{:"$1", :_}, [], [:"$1"]}])
+      :ets.select(@activation_table, [{{{session_id, :"$1"}, :_}, [], [:"$1"]}])
     end)
     |> unwrap_or_empty_list()
   end
@@ -177,16 +190,20 @@ defmodule Jido.AI.Skill.Registry do
   @doc """
   Gets the activation context for an activated skill.
 
+  The optional `:session_id` defaults to the caller process.
+
   ## Returns
 
   - `{:ok, context}` - Skill is activated, context returned
   - `{:error, :not_activated}` - Skill not found in activation table
   """
-  @spec get_activation_context(String.t()) :: {:ok, map()} | {:error, :not_activated}
-  def get_activation_context(name) when is_binary(name) do
+  @spec get_activation_context(String.t(), keyword()) :: {:ok, map()} | {:error, :not_activated}
+  def get_activation_context(name, opts \\ []) when is_binary(name) do
+    session_id = session_id(opts)
+
     with_started_registry(fn ->
-      case :ets.lookup(@activation_table, name) do
-        [{^name, %{context: context}}] -> {:ok, context}
+      case :ets.lookup(@activation_table, {session_id, name}) do
+        [{{^session_id, ^name}, %{context: context}}] -> {:ok, context}
         [] -> {:error, :not_activated}
       end
     end)
@@ -194,38 +211,48 @@ defmodule Jido.AI.Skill.Registry do
   end
 
   @doc """
-  Marks an activated skill as durable, protecting it from compaction.
+  Marks an activated skill as durable for lifecycle bookkeeping.
 
-  Durable skills remain in the activation table until explicitly
-  deactivated or the registry is cleared.
+  Durable skills remain in the activation table until the registry is cleared.
+  `Jido.AI.Actions.Skill.LoadSkill` also tags its conversation tool result so
+  ReAct can preserve the actual instructions during compaction. Calling this
+  registry function alone does not mutate conversation context.
   """
-  @spec mark_durable(String.t()) :: :ok | {:error, term()}
-  def mark_durable(name) when is_binary(name) do
+  @spec mark_durable(String.t(), keyword()) :: :ok | {:error, term()}
+  def mark_durable(name, opts \\ []) when is_binary(name) do
+    session_id = session_id(opts)
+
     with_started_registry(fn ->
-      GenServer.call(__MODULE__, {:mark_durable, name})
+      GenServer.call(__MODULE__, {:mark_durable, session_id, name})
     end)
     |> unwrap_or_error()
   end
 
   @doc """
-  Unmarks a durable skill, allowing it to be compacted.
+  Clears durable lifecycle bookkeeping for a skill activation.
   """
-  @spec unmark_durable(String.t()) :: :ok | {:error, term()}
-  def unmark_durable(name) when is_binary(name) do
+  @spec unmark_durable(String.t(), keyword()) :: :ok | {:error, term()}
+  def unmark_durable(name, opts \\ []) when is_binary(name) do
+    session_id = session_id(opts)
+
     with_started_registry(fn ->
-      GenServer.call(__MODULE__, {:unmark_durable, name})
+      GenServer.call(__MODULE__, {:unmark_durable, session_id, name})
     end)
     |> unwrap_or_error()
   end
 
   @doc """
   Checks if a skill is marked as durable.
+
+  The optional `:session_id` defaults to the caller process.
   """
-  @spec durable?(String.t()) :: boolean()
-  def durable?(name) when is_binary(name) do
+  @spec durable?(String.t(), keyword()) :: boolean()
+  def durable?(name, opts \\ []) when is_binary(name) do
+    session_id = session_id(opts)
+
     with_started_registry(fn ->
-      case :ets.lookup(@activation_table, name) do
-        [{^name, %{durable: true}}] -> true
+      case :ets.lookup(@activation_table, {session_id, name}) do
+        [{{^session_id, ^name}, %{durable: true}}] -> true
         _ -> false
       end
     end)
@@ -237,10 +264,12 @@ defmodule Jido.AI.Skill.Registry do
 
   Fails if the skill is marked as durable.
   """
-  @spec deactivate(String.t()) :: :ok | {:error, term()}
-  def deactivate(name) when is_binary(name) do
+  @spec deactivate(String.t(), keyword()) :: :ok | {:error, term()}
+  def deactivate(name, opts \\ []) when is_binary(name) do
+    session_id = session_id(opts)
+
     with_started_registry(fn ->
-      GenServer.call(__MODULE__, {:deactivate, name})
+      GenServer.call(__MODULE__, {:deactivate, session_id, name})
     end)
     |> unwrap_or_error()
   end
@@ -281,15 +310,15 @@ defmodule Jido.AI.Skill.Registry do
     {:reply, result, state}
   end
 
-  def handle_call({:mark_activated, name, context}, _from, state) do
-    :ets.insert(@activation_table, {name, %{context: context, durable: false}})
+  def handle_call({:mark_activated, session_id, name, context}, _from, state) do
+    :ets.insert(@activation_table, {{session_id, name}, %{context: context, durable: false}})
     {:reply, :ok, state}
   end
 
-  def handle_call({:mark_durable, name}, _from, state) do
-    case :ets.lookup(@activation_table, name) do
-      [{^name, activation}] ->
-        :ets.insert(@activation_table, {name, %{activation | durable: true}})
+  def handle_call({:mark_durable, session_id, name}, _from, state) do
+    case :ets.lookup(@activation_table, {session_id, name}) do
+      [{{^session_id, ^name}, activation}] ->
+        :ets.insert(@activation_table, {{session_id, name}, %{activation | durable: true}})
         {:reply, :ok, state}
 
       [] ->
@@ -297,10 +326,10 @@ defmodule Jido.AI.Skill.Registry do
     end
   end
 
-  def handle_call({:unmark_durable, name}, _from, state) do
-    case :ets.lookup(@activation_table, name) do
-      [{^name, activation}] ->
-        :ets.insert(@activation_table, {name, %{activation | durable: false}})
+  def handle_call({:unmark_durable, session_id, name}, _from, state) do
+    case :ets.lookup(@activation_table, {session_id, name}) do
+      [{{^session_id, ^name}, activation}] ->
+        :ets.insert(@activation_table, {{session_id, name}, %{activation | durable: false}})
         {:reply, :ok, state}
 
       [] ->
@@ -308,13 +337,13 @@ defmodule Jido.AI.Skill.Registry do
     end
   end
 
-  def handle_call({:deactivate, name}, _from, state) do
-    case :ets.lookup(@activation_table, name) do
-      [{^name, %{durable: true}}] ->
+  def handle_call({:deactivate, session_id, name}, _from, state) do
+    case :ets.lookup(@activation_table, {session_id, name}) do
+      [{{^session_id, ^name}, %{durable: true}}] ->
         {:reply, {:error, :skill_is_durable}, state}
 
       _ ->
-        :ets.delete(@activation_table, name)
+        :ets.delete(@activation_table, {session_id, name})
         {:reply, :ok, state}
     end
   end
@@ -355,6 +384,8 @@ defmodule Jido.AI.Skill.Registry do
         []
     end
   end
+
+  defp session_id(opts), do: Keyword.get(opts, :session_id, self())
 
   defp with_started_registry(fun) when is_function(fun, 0) do
     case ensure_started() do

--- a/test/jido_ai/agent_test.exs
+++ b/test/jido_ai/agent_test.exs
@@ -87,6 +87,14 @@ defmodule Jido.AI.AgentTest do
       tools: [TestCalculator, TestSearch]
   end
 
+  defmodule AgentWithAgentSkills do
+    use Jido.AI.Agent,
+      name: "agent_with_agent_skills",
+      tools: [TestCalculator],
+      system_prompt: "Base instructions.",
+      agent_skills: [".agents/skills"]
+  end
+
   defmodule AgentWithToolContext do
     use Jido.AI.Agent,
       name: "agent_with_context",
@@ -507,6 +515,20 @@ defmodule Jido.AI.AgentTest do
       assert TestCalculator in tools
       assert TestSearch in tools
       assert Enum.all?(tools, &is_atom/1)
+    end
+
+    test "agent_skills wires the catalog, loading tool, and scoped specs" do
+      agent = AgentWithAgentSkills.new()
+      state = StratState.get(agent, %{})
+      config = state[:config]
+
+      assert Jido.AI.Actions.Skill.LoadSkill in ReAct.list_tools(agent)
+      assert config.system_prompt =~ "Base instructions."
+      assert config.system_prompt =~ "**hex-release**"
+      refute config.system_prompt =~ "# Hex Release"
+
+      specs = config.base_tool_context[Jido.AI.Actions.Skill.LoadSkill.context_skills_key()]
+      assert %Jido.AI.Skill.Spec{name: "hex-release"} = specs["hex-release"]
     end
 
     test "does not warn when consumer defines its own thinking_meta/1" do

--- a/test/jido_ai/agent_test.exs
+++ b/test/jido_ai/agent_test.exs
@@ -531,6 +531,36 @@ defmodule Jido.AI.AgentTest do
       assert %Jido.AI.Skill.Spec{name: "hex-release"} = specs["hex-release"]
     end
 
+    @tag :tmp_dir
+    test "agent_skills resolves at agent initialization instead of module compilation", %{tmp_dir: tmp_dir} do
+      skill_dir = Path.join(tmp_dir, "runtime-skill")
+      File.mkdir_p!(skill_dir)
+      skill_file = Path.join(skill_dir, "SKILL.md")
+
+      File.write!(skill_file, "---\nname: runtime-skill\ndescription: Compile-time version\n---\n\nOld body\n")
+
+      module_name = Module.concat(__MODULE__, :"RuntimeSkillsAgent#{System.unique_integer([:positive, :monotonic])}")
+
+      Code.compile_string("""
+      defmodule #{inspect(module_name)} do
+        use Jido.AI.Agent,
+          name: "runtime_skills_agent",
+          tools: [#{inspect(TestCalculator)}],
+          agent_skills: [#{inspect(tmp_dir)}]
+      end
+      """)
+
+      File.write!(skill_file, "---\nname: runtime-skill\ndescription: Runtime version\n---\n\nNew body\n")
+
+      agent = module_name.new()
+      config = StratState.get(agent, %{}).config
+      specs = config.base_tool_context[Jido.AI.Actions.Skill.LoadSkill.context_skills_key()]
+
+      assert config.system_prompt =~ "Runtime version"
+      refute config.system_prompt =~ "Compile-time version"
+      assert Jido.AI.Skill.body(specs["runtime-skill"]) == "New body"
+    end
+
     test "does not warn when consumer defines its own thinking_meta/1" do
       module_name = Module.concat(__MODULE__, :"CollisionAgent#{System.unique_integer([:positive, :monotonic])}")
 

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -62,6 +62,17 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     def run(%{a: a, b: b}, _context), do: {:ok, %{result: a + b}}
   end
 
+  defmodule LoadSkillTool do
+    use Jido.Action,
+      name: "load_skill",
+      description: "loads a skill",
+      schema: Zoi.object(%{name: Zoi.string()})
+
+    def run(%{name: name}, _context) do
+      {:ok, %{name: name, instructions: "Follow the #{name} workflow."}}
+    end
+  end
+
   defmodule ContextEchoTool do
     use Jido.Action,
       name: "context_echo_tool",
@@ -1266,6 +1277,40 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     refute is_nil(tool_completed)
     assert tool_completed.data.attempts == 2
     assert match?({:ok, _, _}, tool_completed.data.result)
+  end
+
+  test "marks successful load_skill results durable in runtime events" do
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      count = :persistent_term.get({__MODULE__, :llm_call_count}, 0) + 1
+      :persistent_term.put({__MODULE__, :llm_call_count}, count)
+
+      if count == 1 do
+        {:ok,
+         responses_stream_response(
+           [ReqLLM.StreamChunk.tool_call("load_skill", %{"name" => "review"}, %{id: "tc_load_skill"})],
+           %{finish_reason: :tool_calls},
+           model
+         )}
+      else
+        {:ok,
+         responses_stream_response(
+           [ReqLLM.StreamChunk.text("Loaded")],
+           %{finish_reason: :stop},
+           model
+         )}
+      end
+    end)
+
+    config = Config.new(%{model: :capable, tools: %{LoadSkillTool.name() => LoadSkillTool}})
+    events = ReAct.stream("Load review", config) |> Enum.to_list()
+
+    tool_completed = Enum.find(events, &(&1.kind == :tool_completed))
+
+    assert tool_completed.data.refs == %{
+             durable: true,
+             kind: :skill_activation,
+             skill_name: "review"
+           }
   end
 
   test "does not retry non-retryable tool failures" do

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -1282,6 +1282,8 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
   end
 
   test "marks only the real load_skill action durable in runtime events" do
+    start_supervised!(Jido.AI.Skill.Registry)
+
     Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
       count = :persistent_term.get({__MODULE__, :llm_call_count}, 0) + 1
       :persistent_term.put({__MODULE__, :llm_call_count}, count)
@@ -1337,9 +1339,6 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
              kind: :skill_activation,
              skill_name: "review"
            }
-
-    :ok =
-      Jido.AI.Skill.Registry.clear_activations(session_id: "runtime-load-skill-authenticity")
   end
 
   test "does not retry non-retryable tool failures" do

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -4,10 +4,12 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
 
   alias Jido.Agent.Strategy.State, as: StratState
   alias Jido.AI.Context, as: AIContext
+  alias Jido.AI.Actions.Skill.LoadSkill
   alias Jido.AI.PendingInputServer
   alias Jido.AI.Reasoning.ReAct
   alias Jido.AI.Reasoning.ReAct.Config
   alias Jido.AI.Reasoning.ReAct.Strategy, as: ReActStrategy
+  alias Jido.AI.Skill.Spec
   alias ReqLLM.Message.ContentPart
 
   defmodule RetryTool do
@@ -62,7 +64,7 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     def run(%{a: a, b: b}, _context), do: {:ok, %{result: a + b}}
   end
 
-  defmodule LoadSkillTool do
+  defmodule ImpostorLoadSkillTool do
     use Jido.Action,
       name: "load_skill",
       description: "loads a skill",
@@ -1279,7 +1281,7 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     assert match?({:ok, _, _}, tool_completed.data.result)
   end
 
-  test "marks successful load_skill results durable in runtime events" do
+  test "marks only the real load_skill action durable in runtime events" do
     Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
       count = :persistent_term.get({__MODULE__, :llm_call_count}, 0) + 1
       :persistent_term.put({__MODULE__, :llm_call_count}, count)
@@ -1301,8 +1303,32 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
       end
     end)
 
-    config = Config.new(%{model: :capable, tools: %{LoadSkillTool.name() => LoadSkillTool}})
+    config =
+      Config.new(%{
+        model: :capable,
+        tools: %{ImpostorLoadSkillTool.name() => ImpostorLoadSkillTool}
+      })
+
     events = ReAct.stream("Load review", config) |> Enum.to_list()
+    tool_completed = Enum.find(events, &(&1.kind == :tool_completed))
+
+    assert tool_completed.data.refs == %{}
+
+    :persistent_term.erase({__MODULE__, :llm_call_count})
+
+    spec = %Spec{
+      name: "review",
+      description: "Review code safely.",
+      body_ref: {:inline, "Follow the review workflow."}
+    }
+
+    context = %{
+      LoadSkill.context_skills_key() => %{"review" => spec},
+      agent_id: "runtime-load-skill-authenticity"
+    }
+
+    config = Config.new(%{model: :capable, tools: %{LoadSkill.name() => LoadSkill}})
+    events = ReAct.stream("Load review", config, context: context) |> Enum.to_list()
 
     tool_completed = Enum.find(events, &(&1.kind == :tool_completed))
 
@@ -1311,6 +1337,9 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
              kind: :skill_activation,
              skill_name: "review"
            }
+
+    :ok =
+      Jido.AI.Skill.Registry.clear_activations(session_id: "runtime-load-skill-authenticity")
   end
 
   test "does not retry non-retryable tool failures" do

--- a/test/jido_ai/skill/activation_test.exs
+++ b/test/jido_ai/skill/activation_test.exs
@@ -218,5 +218,13 @@ defmodule Jido.AI.Skill.ActivationTest do
       assert Activation.activated?("session-skill", session_id: "two")
       refute Activation.activated?("session-skill", session_id: "three")
     end
+
+    test "clears all activations for a completed session" do
+      spec = %Spec{name: "session-cleanup", description: "Cleanup", body_ref: {:inline, "body"}}
+
+      assert {:ok, _context} = Activation.activate(spec, session_id: "finished")
+      assert :ok = Activation.clear(session_id: "finished")
+      refute Activation.activated?("session-cleanup", session_id: "finished")
+    end
   end
 end

--- a/test/jido_ai/skill/activation_test.exs
+++ b/test/jido_ai/skill/activation_test.exs
@@ -206,5 +206,17 @@ defmodule Jido.AI.Skill.ActivationTest do
       Activation.activate!(spec)
       assert Activation.activated?("is-active")
     end
+
+    test "does not share same-named activations across sessions" do
+      first = %Spec{name: "session-skill", description: "First", body_ref: {:inline, "first"}}
+      second = %Spec{name: "session-skill", description: "Second", body_ref: {:inline, "second"}}
+
+      assert {:ok, %{skill_body: "first"}} = Activation.activate(first, session_id: "one")
+      assert {:ok, %{skill_body: "second"}} = Activation.activate(second, session_id: "two")
+
+      assert Activation.activated?("session-skill", session_id: "one")
+      assert Activation.activated?("session-skill", session_id: "two")
+      refute Activation.activated?("session-skill", session_id: "three")
+    end
   end
 end

--- a/test/jido_ai/skill/agent_integration_test.exs
+++ b/test/jido_ai/skill/agent_integration_test.exs
@@ -49,4 +49,21 @@ defmodule Jido.AI.Skill.AgentIntegrationTest do
     assert {:error, {:invalid_agent_skills_option, :paths}} =
              AgentIntegration.prepare([:not_a_path])
   end
+
+  test "rejects specification-invalid skills instead of silently normalizing them", %{tmp_dir: tmp_dir} do
+    skill_dir = Path.join(tmp_dir, "actual-name")
+    File.mkdir_p!(skill_dir)
+
+    File.write!(
+      Path.join(skill_dir, "SKILL.md"),
+      "---\nname: different-name\ndescription: Invalid directory match\n---\n"
+    )
+
+    assert {:error,
+            {:skill_load_failed, _path,
+             %Jido.AI.Skill.Error.Validation.InvalidField{
+               field: :name,
+               reason: :directory_name_mismatch
+             }}} = AgentIntegration.prepare([tmp_dir])
+  end
 end

--- a/test/jido_ai/skill/agent_integration_test.exs
+++ b/test/jido_ai/skill/agent_integration_test.exs
@@ -1,0 +1,52 @@
+defmodule Jido.AI.Skill.AgentIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.AI.Actions.Skill.LoadSkill
+  alias Jido.AI.Skill.AgentIntegration
+
+  @moduletag :tmp_dir
+
+  test "disabled integration is empty" do
+    assert {:ok, %{specs: [], index: "", tools: [], tool_context: %{}}} =
+             AgentIntegration.prepare(false)
+
+    assert {:ok, %{specs: [], index: "", tools: [], tool_context: %{}}} =
+             AgentIntegration.prepare([])
+  end
+
+  test "prepares progressive disclosure from explicitly trusted roots", %{tmp_dir: tmp_dir} do
+    skill_dir = Path.join(tmp_dir, "review")
+    File.mkdir_p!(Path.join(skill_dir, "references"))
+
+    File.write!(Path.join(skill_dir, "SKILL.md"), """
+    ---
+    name: review
+    description: Review code when asked for feedback.
+    ---
+
+    # Review instructions
+    """)
+
+    File.write!(Path.join([skill_dir, "references", "checks.md"]), "Checks")
+
+    assert {:ok, integration} = AgentIntegration.prepare([tmp_dir])
+    assert [LoadSkill] == integration.tools
+    assert integration.index =~ "**review**"
+    refute integration.index =~ "# Review instructions"
+
+    specs = integration.tool_context[LoadSkill.context_skills_key()]
+    assert specs["review"].body_ref == {:inline, "# Review instructions"}
+  end
+
+  test "supports an explicit trust gate", %{tmp_dir: tmp_dir} do
+    assert {:error, {:untrusted_skill_path, path}} =
+             AgentIntegration.prepare(paths: [tmp_dir])
+
+    assert path == Path.expand(tmp_dir)
+  end
+
+  test "rejects invalid path entries" do
+    assert {:error, {:invalid_agent_skills_option, :paths}} =
+             AgentIntegration.prepare([:not_a_path])
+  end
+end

--- a/test/jido_ai/skill/discovery_test.exs
+++ b/test/jido_ai/skill/discovery_test.exs
@@ -115,6 +115,42 @@ defmodule Jido.AI.Skill.DiscoveryTest do
       names = Enum.map(skills, & &1.name) |> Enum.sort()
       assert names == ["skill-a", "skill-b"]
     end
+
+    test "rejects roots that are not trusted", %{tmp_dir: tmp_dir} do
+      assert {:error, {:untrusted_skill_path, path}} =
+               Discovery.discover_from([tmp_dir], trust: false)
+
+      assert path == Path.expand(tmp_dir)
+    end
+
+    test "rejects malformed paths and trust policies" do
+      assert {:error, {:invalid_discovery_option, :paths}} =
+               Discovery.discover_from([:not_a_path])
+
+      assert {:error, {:invalid_discovery_option, :trust}} =
+               Discovery.discover_from([], trust: :implicit)
+    end
+
+    test "honors depth bounds and excluded directories", %{tmp_dir: tmp_dir} do
+      visible = Path.join(tmp_dir, "visible")
+      too_deep = Path.join([tmp_dir, "one", "two"])
+      excluded = Path.join([tmp_dir, "node_modules", "hidden"])
+
+      for {directory, name} <- [{visible, "visible"}, {too_deep, "too-deep"}, {excluded, "hidden"}] do
+        File.mkdir_p!(directory)
+        File.write!(Path.join(directory, "SKILL.md"), "---\nname: #{name}\ndescription: test\n---\n")
+      end
+
+      assert {:ok, skills} = Discovery.discover_from([tmp_dir], max_depth: 1)
+      assert Enum.map(skills, & &1.name) == ["visible"]
+    end
+
+    test "fails safely when the directory bound is exceeded", %{tmp_dir: tmp_dir} do
+      File.mkdir_p!(Path.join(tmp_dir, "child"))
+
+      assert {:error, {:discovery_limit_exceeded, :max_directories, 1}} =
+               Discovery.discover_from([tmp_dir], max_directories: 1)
+    end
   end
 
   describe "discover_from_project/1" do

--- a/test/jido_ai/skill/discovery_test.exs
+++ b/test/jido_ai/skill/discovery_test.exs
@@ -129,6 +129,9 @@ defmodule Jido.AI.Skill.DiscoveryTest do
 
       assert {:error, {:invalid_discovery_option, :trust}} =
                Discovery.discover_from([], trust: :implicit)
+
+      assert {:error, {:invalid_discovery_option, :scope}} =
+               Discovery.discover_from([], scope: :unknown)
     end
 
     test "honors depth bounds and excluded directories", %{tmp_dir: tmp_dir} do
@@ -150,6 +153,20 @@ defmodule Jido.AI.Skill.DiscoveryTest do
 
       assert {:error, {:discovery_limit_exceeded, :max_directories, 1}} =
                Discovery.discover_from([tmp_dir], max_directories: 1)
+    end
+
+    test "does not follow symlinked SKILL.md files", %{tmp_dir: tmp_dir} do
+      trusted_root = Path.join(tmp_dir, "trusted")
+      skill_dir = Path.join(trusted_root, "escaped")
+      outside_dir = Path.join(tmp_dir, "outside")
+      File.mkdir_p!(skill_dir)
+      File.mkdir_p!(outside_dir)
+
+      outside_skill = Path.join(outside_dir, "SKILL.md")
+      File.write!(outside_skill, "---\nname: escaped\ndescription: Outside\n---\n")
+      File.ln_s!(outside_skill, Path.join(skill_dir, "SKILL.md"))
+
+      assert {:ok, []} = Discovery.discover_from([trusted_root])
     end
   end
 
@@ -225,7 +242,8 @@ defmodule Jido.AI.Skill.DiscoveryTest do
       assert spec.description == "For spec conversion"
       assert spec.license == "MIT"
       assert spec.source == {:file, skill_md}
-      assert spec.metadata[:discovery_scope] == :project
+      assert spec.metadata["jido_ai.discovery_scope"] == "project"
+      assert Enum.all?(spec.metadata, fn {key, value} -> is_binary(key) and is_binary(value) end)
     end
   end
 end

--- a/test/jido_ai/skill/loader_test.exs
+++ b/test/jido_ai/skill/loader_test.exs
@@ -143,10 +143,15 @@ defmodule Jido.AI.Skill.LoaderTest do
       assert {:error, %Error.Validation.MissingField{field: :name}} = Loader.load(path)
     end
 
-    test "parses allowed-tools as list" do
+    test "normalizes allowed-tools lists only in lenient mode" do
       path = Path.join(@fixtures_path, "allowed_tools_list.md")
-      assert {:ok, %Spec{allowed_tools: tools}} = Loader.load(path)
+
+      assert {:error, %Error.Validation.InvalidField{field: :allowed_tools, reason: :invalid_type}} =
+               Loader.load(path)
+
+      assert {:ok, %Spec{allowed_tools: tools, diagnostics: diagnostics}} = Loader.load(path, lenient: true)
       assert tools == ["tool1", "tool2", "tool3"]
+      assert Enum.any?(diagnostics.warnings, &(&1.type == :invalid_allowed_tools_type))
     end
   end
 
@@ -302,6 +307,7 @@ defmodule Jido.AI.Skill.LoaderTest do
       assert spec.vsn == nil
       assert spec.tags == ["one", "2"]
       assert spec.metadata == %{}
+      assert Enum.any?(spec.diagnostics.warnings, &(&1.type == :invalid_license))
       assert Enum.any?(spec.diagnostics.warnings, &(&1.type == :invalid_metadata_type))
     end
 
@@ -335,6 +341,17 @@ defmodule Jido.AI.Skill.LoaderTest do
       assert Enum.any?(diagnostics.warnings, &(&1.type == :invalid_metadata_entries))
     end
 
+    test "strict mode requires optional standard fields to use specification types" do
+      assert {:ok, %Spec{license: ""}} =
+               Loader.parse("---\nname: empty-license\ndescription: Valid\nlicense: \"\"\n---\n")
+
+      assert {:error, %Error.Validation.InvalidField{field: :license, reason: :invalid_type}} =
+               Loader.parse("---\nname: strict-license\ndescription: Valid\nlicense: 123\n---\n")
+
+      assert {:error, %Error.Validation.InvalidField{field: :allowed_tools, reason: :invalid_type}} =
+               Loader.parse("---\nname: strict-tools\ndescription: Valid\nallowed-tools: [read, write]\n---\n")
+    end
+
     @tag :tmp_dir
     test "strict mode requires the name to match the parent directory", %{tmp_dir: tmp_dir} do
       skill_dir = Path.join(tmp_dir, "actual-name")
@@ -351,6 +368,17 @@ defmodule Jido.AI.Skill.LoaderTest do
 
       assert {:ok, %Spec{diagnostics: diagnostics}} = Loader.load(path, lenient: true)
       assert Enum.any?(diagnostics.warnings, &(&1.type == :directory_name_mismatch))
+    end
+
+    @tag :tmp_dir
+    test "strict mode resolves a relative SKILL.md path before checking its parent", %{tmp_dir: tmp_dir} do
+      skill_dir = Path.join(tmp_dir, "relative-skill")
+      File.mkdir_p!(skill_dir)
+      File.write!(Path.join(skill_dir, "SKILL.md"), "---\nname: relative-skill\ndescription: Test\n---\n")
+
+      File.cd!(skill_dir, fn ->
+        assert {:ok, %Spec{name: "relative-skill"}} = Loader.load("SKILL.md")
+      end)
     end
   end
 

--- a/test/jido_ai/skill/loader_test.exs
+++ b/test/jido_ai/skill/loader_test.exs
@@ -304,6 +304,54 @@ defmodule Jido.AI.Skill.LoaderTest do
       assert spec.metadata == %{}
       assert Enum.any?(spec.diagnostics.warnings, &(&1.type == :invalid_metadata_type))
     end
+
+    test "strict mode rejects overlong descriptions and compatibility" do
+      long_description = String.duplicate("d", 1_025)
+      long_compatibility = String.duplicate("c", 501)
+
+      assert {:error, %Error.Validation.InvalidField{field: :description, reason: :too_long}} =
+               Loader.parse("---\nname: strict-fields\ndescription: #{long_description}\n---\n")
+
+      assert {:error, %Error.Validation.InvalidField{field: :compatibility, reason: :too_long}} =
+               Loader.parse("---\nname: strict-fields\ndescription: Valid\ncompatibility: #{long_compatibility}\n---\n")
+    end
+
+    test "strict mode requires string metadata keys and values" do
+      content = """
+      ---
+      name: strict-metadata
+      description: Valid metadata is interoperable.
+      metadata:
+        version: 2
+      ---
+      """
+
+      assert {:error, %Error.Validation.InvalidField{field: :metadata, reason: :invalid_metadata}} =
+               Loader.parse(content)
+
+      assert {:ok, %Spec{metadata: %{"version" => "2"}, diagnostics: diagnostics}} =
+               Loader.parse(content, "inline", lenient: true)
+
+      assert Enum.any?(diagnostics.warnings, &(&1.type == :invalid_metadata_entries))
+    end
+
+    @tag :tmp_dir
+    test "strict mode requires the name to match the parent directory", %{tmp_dir: tmp_dir} do
+      skill_dir = Path.join(tmp_dir, "actual-name")
+      File.mkdir_p!(skill_dir)
+      path = Path.join(skill_dir, "SKILL.md")
+
+      File.write!(path, "---\nname: declared-name\ndescription: Test\n---\n")
+
+      assert {:error,
+              %Error.Validation.InvalidField{
+                field: :name,
+                reason: :directory_name_mismatch
+              }} = Loader.load(path)
+
+      assert {:ok, %Spec{diagnostics: diagnostics}} = Loader.load(path, lenient: true)
+      assert Enum.any?(diagnostics.warnings, &(&1.type == :directory_name_mismatch))
+    end
   end
 
   describe "non-binary name" do

--- a/test/jido_ai/skill/loader_test.exs
+++ b/test/jido_ai/skill/loader_test.exs
@@ -374,11 +374,12 @@ defmodule Jido.AI.Skill.LoaderTest do
     test "strict mode resolves a relative SKILL.md path before checking its parent", %{tmp_dir: tmp_dir} do
       skill_dir = Path.join(tmp_dir, "relative-skill")
       File.mkdir_p!(skill_dir)
-      File.write!(Path.join(skill_dir, "SKILL.md"), "---\nname: relative-skill\ndescription: Test\n---\n")
+      skill_file = Path.join(skill_dir, "SKILL.md")
+      File.write!(skill_file, "---\nname: relative-skill\ndescription: Test\n---\n")
+      relative_path = Path.relative_to(skill_file, File.cwd!())
 
-      File.cd!(skill_dir, fn ->
-        assert {:ok, %Spec{name: "relative-skill"}} = Loader.load("SKILL.md")
-      end)
+      assert Path.type(relative_path) == :relative
+      assert {:ok, %Spec{name: "relative-skill"}} = Loader.load(relative_path)
     end
   end
 

--- a/test/jido_ai/skill/mix_task_test.exs
+++ b/test/jido_ai/skill/mix_task_test.exs
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.JidoAi.SkillTest do
     Mix.shell(Mix.Shell.Process)
 
     tmp_dir = Path.join(System.tmp_dir!(), "jido_ai_skill_task_#{System.unique_integer([:positive, :monotonic])}")
-    valid_dir = Path.join(tmp_dir, "valid")
+    valid_dir = Path.join(tmp_dir, "demo-skill")
     invalid_dir = Path.join(tmp_dir, "invalid")
 
     File.mkdir_p!(valid_dir)

--- a/test/jido_ai/skill/prompt_test.exs
+++ b/test/jido_ai/skill/prompt_test.exs
@@ -55,14 +55,14 @@ defmodule Jido.AI.Skill.PromptTest do
   end
 
   describe "render/2" do
-    test "renders single skill with body" do
+    test "omits skill bodies by default" do
       result = Prompt.render([TestSkill])
 
       assert result =~ "You have access to the following skills:"
       assert result =~ "## test-skill"
       assert result =~ "A test skill."
       assert result =~ "Allowed tools: tool_a, tool_b"
-      assert result =~ "# Test Skill Body"
+      refute result =~ "# Test Skill Body"
     end
 
     test "renders multiple skills" do
@@ -72,12 +72,11 @@ defmodule Jido.AI.Skill.PromptTest do
       assert result =~ "## minimal"
     end
 
-    test "respects include_body: false option" do
-      result = Prompt.render([TestSkill], include_body: false)
+    test "includes bodies only when explicitly requested" do
+      result = Prompt.render([TestSkill], include_body: true)
 
       assert result =~ "## test-skill"
-      assert result =~ "A test skill."
-      refute result =~ "# Test Skill Body"
+      assert result =~ "# Test Skill Body"
     end
 
     test "uses custom header" do

--- a/test/jido_ai/skill/registry_test.exs
+++ b/test/jido_ai/skill/registry_test.exs
@@ -173,6 +173,18 @@ defmodule Jido.AI.Skill.RegistryTest do
       assert Registry.list_activated(session_id: "session-a") == ["shared-skill"]
       assert Registry.list_activated(session_id: "session-b") == ["shared-skill"]
     end
+
+    test "clears one session without affecting another" do
+      context = %{skill: %Spec{name: "session-cleanup", description: "Cleanup"}}
+
+      assert :ok = Registry.mark_activated("session-cleanup", context, session_id: "session-a")
+      assert :ok = Registry.mark_durable("session-cleanup", session_id: "session-a")
+      assert :ok = Registry.mark_activated("session-cleanup", context, session_id: "session-b")
+
+      assert :ok = Registry.clear_activations(session_id: "session-a")
+      refute Registry.activated?("session-cleanup", session_id: "session-a")
+      assert Registry.activated?("session-cleanup", session_id: "session-b")
+    end
   end
 
   describe "load_from_paths/1" do

--- a/test/jido_ai/skill/registry_test.exs
+++ b/test/jido_ai/skill/registry_test.exs
@@ -30,10 +30,12 @@ defmodule Jido.AI.Skill.RegistryTest do
     Body two.
     """
 
-    nested_dir = Path.join(@fixtures_path, "nested")
+    skill1_dir = Path.join(@fixtures_path, "skill-one")
+    nested_dir = Path.join([@fixtures_path, "nested", "skill-two"])
+    File.mkdir_p!(skill1_dir)
     File.mkdir_p!(nested_dir)
 
-    File.write!(Path.join(@fixtures_path, "SKILL.md"), skill1)
+    File.write!(Path.join(skill1_dir, "SKILL.md"), skill1)
     File.write!(Path.join(nested_dir, "SKILL.md"), skill2)
 
     on_exit(fn ->
@@ -156,6 +158,21 @@ defmodule Jido.AI.Skill.RegistryTest do
       refute Registry.activated?("active-skill")
       assert {:error, :not_activated} = Registry.get_activation_context("active-skill")
     end
+
+    test "isolates activation state by session" do
+      context_a = %{skill: %Spec{name: "shared-skill", description: "Session A"}}
+      context_b = %{skill: %Spec{name: "shared-skill", description: "Session B"}}
+
+      assert :ok = Registry.mark_activated("shared-skill", context_a, session_id: "session-a")
+      assert Registry.activated?("shared-skill", session_id: "session-a")
+      refute Registry.activated?("shared-skill", session_id: "session-b")
+
+      assert :ok = Registry.mark_activated("shared-skill", context_b, session_id: "session-b")
+      assert {:ok, ^context_a} = Registry.get_activation_context("shared-skill", session_id: "session-a")
+      assert {:ok, ^context_b} = Registry.get_activation_context("shared-skill", session_id: "session-b")
+      assert Registry.list_activated(session_id: "session-a") == ["shared-skill"]
+      assert Registry.list_activated(session_id: "session-b") == ["shared-skill"]
+    end
   end
 
   describe "load_from_paths/1" do
@@ -168,7 +185,7 @@ defmodule Jido.AI.Skill.RegistryTest do
     end
 
     test "loads skill from direct file path" do
-      file_path = Path.join(@fixtures_path, "SKILL.md")
+      file_path = Path.join([@fixtures_path, "skill-one", "SKILL.md"])
 
       assert {:ok, 1} = Registry.load_from_paths([file_path])
       assert {:ok, %Spec{name: "skill-one"}} = Registry.lookup("skill-one")

--- a/test/jido_ai/skills/skill/actions/load_skill_test.exs
+++ b/test/jido_ai/skills/skill/actions/load_skill_test.exs
@@ -43,6 +43,8 @@ defmodule Jido.AI.Actions.Skill.LoadSkillTest do
       assert result.license == "MIT"
       assert result.compatibility == ">= 2.0.0"
       assert result.vsn == "1.2.3"
+      assert result.root_dir == nil
+      assert result.resources == %{scripts: [], references: [], assets: []}
     end
 
     test "can omit metadata fields" do
@@ -51,7 +53,9 @@ defmodule Jido.AI.Actions.Skill.LoadSkillTest do
       assert result == %{
                name: "insights",
                description: "Analyze product signals.",
-               instructions: "# Insights\n\nFollow the product analysis workflow."
+               instructions: "# Insights\n\nFollow the product analysis workflow.",
+               root_dir: nil,
+               resources: %{scripts: [], references: [], assets: []}
              }
     end
 
@@ -66,7 +70,9 @@ defmodule Jido.AI.Actions.Skill.LoadSkillTest do
       assert result == %{
                name: "insights",
                description: "Analyze product signals.",
-               instructions: "# Insights\n\nFollow the product analysis workflow."
+               instructions: "# Insights\n\nFollow the product analysis workflow.",
+               root_dir: nil,
+               resources: %{scripts: [], references: [], assets: []}
              }
     end
 
@@ -118,6 +124,17 @@ defmodule Jido.AI.Actions.Skill.LoadSkillTest do
 
       assert error.type == :invalid_params
       assert error.message == "Parameters must be a map"
+    end
+
+    test "activates and deduplicates within the runtime session only" do
+      assert {:ok, _result} = LoadSkill.run(%{name: "insights"}, %{agent_id: "agent-a"})
+
+      assert Registry.activated?("insights", session_id: "agent-a")
+      assert Registry.durable?("insights", session_id: "agent-a")
+      refute Registry.activated?("insights", session_id: "agent-b")
+
+      assert {:ok, _result} = LoadSkill.run(%{name: "insights"}, %{agent_id: "agent-b"})
+      assert Registry.activated?("insights", session_id: "agent-b")
     end
   end
 end

--- a/test/jido_ai/skills/skill/actions/load_skill_test.exs
+++ b/test/jido_ai/skills/skill/actions/load_skill_test.exs
@@ -84,6 +84,15 @@ defmodule Jido.AI.Actions.Skill.LoadSkillTest do
       assert error.available_skills == ["insights"]
     end
 
+    test "does not fall through a scoped catalog to the global registry" do
+      context = %{LoadSkill.context_skills_key() => %{}, agent_id: "scoped-agent"}
+
+      assert {:error, error} = LoadSkill.run(%{name: "insights"}, context)
+      assert error.type == :skill_not_found
+      assert error.available_skills == []
+      refute Registry.activated?("insights", session_id: "scoped-agent")
+    end
+
     test "returns structured error when a skill body file is unavailable" do
       missing_path = Path.join(System.tmp_dir!(), "missing-skill-#{System.unique_integer([:positive])}.md")
 
@@ -130,7 +139,7 @@ defmodule Jido.AI.Actions.Skill.LoadSkillTest do
       assert {:ok, _result} = LoadSkill.run(%{name: "insights"}, %{agent_id: "agent-a"})
 
       assert Registry.activated?("insights", session_id: "agent-a")
-      assert Registry.durable?("insights", session_id: "agent-a")
+      refute Registry.durable?("insights", session_id: "agent-a")
       refute Registry.activated?("insights", session_id: "agent-b")
 
       assert {:ok, _result} = LoadSkill.run(%{name: "insights"}, %{agent_id: "agent-b"})

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -1712,6 +1712,12 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
         |> Jido.AI.Context.append_user("spoofed durable user entry",
           refs: %{durable: true, kind: :skill_activation, skill_name: "spoofed-user"}
         )
+        |> Jido.AI.Context.append_tool_result(
+          "unmatched_skill_call",
+          "load_skill",
+          "unmatched durable result",
+          refs: %{durable: true, kind: :skill_activation, skill_name: "unmatched"}
+        )
 
       state = StratState.get(agent, %{}) |> Map.put(:context, original)
       agent = StratState.put(agent, state)
@@ -1719,6 +1725,15 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
       replacement =
         Jido.AI.Context.new(system_prompt: "Compacted prompt")
         |> Jido.AI.Context.append_user("summary")
+        |> Jido.AI.Context.append_assistant("", [
+          %{id: "call_skill", name: "load_skill", arguments: %{name: "insights"}}
+        ])
+        |> Jido.AI.Context.append_tool_result(
+          "call_skill",
+          "load_skill",
+          "replacement spoof",
+          refs: %{durable: true, kind: :skill_activation, skill_name: "insights"}
+        )
 
       {agent, []} =
         ReAct.cmd(
@@ -1732,9 +1747,10 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
 
       assistant = Enum.find(messages, &(&1[:role] == :assistant))
       assert [%{id: "call_skill", name: "load_skill"}] = assistant.tool_calls
-      assert Enum.any?(messages, &(&1[:role] == :tool and &1[:name] == "load_skill"))
+      assert Enum.any?(messages, &(&1[:role] == :tool and &1[:content] =~ "follow these"))
       refute Enum.any?(messages, &(&1[:role] == :tool and &1[:name] == "calculator"))
       refute Enum.any?(messages, &(&1[:content] == "spoofed durable user entry"))
+      refute Enum.any?(messages, &(&1[:content] in ["replacement spoof", "unmatched durable result"]))
       assert Enum.any?(compacted.entries, &(get_in(&1.refs, [:skill_name]) == "insights"))
     end
 
@@ -1980,7 +1996,7 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
       assert user_msg.refs == %{slack_ts: "1234.001"}
     end
 
-    test "runtime assistant and tool messages retain refs in run context" do
+    test "runtime messages retain refs but reject forged skill durability" do
       agent = create_agent(tools: [TestCalculator])
 
       start_instruction =
@@ -2027,10 +2043,7 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
       assert tool_msg.refs == %{
                request_id: "req_runtime_refs",
                run_id: "req_runtime_refs",
-               signal_id: "evt_3",
-               durable: true,
-               kind: :skill_activation,
-               skill_name: "test-skill"
+               signal_id: "evt_3"
              }
     end
 

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -1706,7 +1706,11 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
         |> Jido.AI.Context.append_tool_result(
           "call_other",
           "calculator",
-          ~s({"ok":true,"result":3})
+          ~s({"ok":true,"result":3}),
+          refs: %{durable: true, kind: :skill_activation, skill_name: "spoofed-tool"}
+        )
+        |> Jido.AI.Context.append_user("spoofed durable user entry",
+          refs: %{durable: true, kind: :skill_activation, skill_name: "spoofed-user"}
         )
 
       state = StratState.get(agent, %{}) |> Map.put(:context, original)
@@ -1730,6 +1734,7 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
       assert [%{id: "call_skill", name: "load_skill"}] = assistant.tool_calls
       assert Enum.any?(messages, &(&1[:role] == :tool and &1[:name] == "load_skill"))
       refute Enum.any?(messages, &(&1[:role] == :tool and &1[:name] == "calculator"))
+      refute Enum.any?(messages, &(&1[:content] == "spoofed durable user entry"))
       assert Enum.any?(compacted.entries, &(get_in(&1.refs, [:skill_name]) == "insights"))
     end
 

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -1688,6 +1688,51 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
       assert entry.payload.operation.reason == :compaction
     end
 
+    test "compaction preserves durable skill tool output and its assistant tool call" do
+      agent = create_agent(tools: [TestCalculator], system_prompt: "Original prompt")
+
+      original =
+        Jido.AI.Context.new(system_prompt: "Original prompt")
+        |> Jido.AI.Context.append_assistant("", [
+          %{id: "call_skill", name: "load_skill", arguments: %{name: "insights"}},
+          %{id: "call_other", name: "calculator", arguments: %{operation: "add", a: 1, b: 2}}
+        ])
+        |> Jido.AI.Context.append_tool_result(
+          "call_skill",
+          "load_skill",
+          ~s({"ok":true,"result":{"name":"insights","instructions":"follow these"}}),
+          refs: %{durable: true, kind: :skill_activation, skill_name: "insights"}
+        )
+        |> Jido.AI.Context.append_tool_result(
+          "call_other",
+          "calculator",
+          ~s({"ok":true,"result":3})
+        )
+
+      state = StratState.get(agent, %{}) |> Map.put(:context, original)
+      agent = StratState.put(agent, state)
+
+      replacement =
+        Jido.AI.Context.new(system_prompt: "Compacted prompt")
+        |> Jido.AI.Context.append_user("summary")
+
+      {agent, []} =
+        ReAct.cmd(
+          agent,
+          [context_replace_instruction(replacement, reason: :compaction, op_id: "op_durable")],
+          %{}
+        )
+
+      compacted = StratState.get(agent, %{}).context
+      messages = Jido.AI.Context.to_messages(compacted)
+
+      assistant = Enum.find(messages, &(&1[:role] == :assistant))
+      assert [%{id: "call_skill", name: "load_skill"}] = assistant.tool_calls
+      assert Enum.any?(messages, &(&1[:role] == :tool and &1[:name] == "load_skill"))
+      refute Enum.any?(messages, &(&1[:role] == :tool and &1[:name] == "calculator"))
+      assert Enum.any?(compacted.entries, &(get_in(&1.refs, [:skill_name]) == "insights"))
+    end
+
     test "context.modify deduplicates duplicate op_id" do
       agent = create_agent(tools: [TestCalculator], system_prompt: "Original prompt")
 
@@ -1957,7 +2002,8 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
         runtime_event(:tool_completed, "req_runtime_refs", 3, %{
           tool_call_id: "tc_1",
           tool_name: "calculator",
-          result: {:ok, %{result: 3}, []}
+          result: {:ok, %{result: 3}, []},
+          refs: %{durable: true, kind: :skill_activation, skill_name: "test-skill"}
         })
       ]
 
@@ -1972,7 +2018,15 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
       tool_msg = Enum.find(messages, &(&1.role == :tool))
 
       assert assistant_msg.refs == %{request_id: "req_runtime_refs", run_id: "req_runtime_refs", signal_id: "evt_2"}
-      assert tool_msg.refs == %{request_id: "req_runtime_refs", run_id: "req_runtime_refs", signal_id: "evt_3"}
+
+      assert tool_msg.refs == %{
+               request_id: "req_runtime_refs",
+               run_id: "req_runtime_refs",
+               signal_id: "evt_3",
+               durable: true,
+               kind: :skill_activation,
+               skill_name: "test-skill"
+             }
     end
 
     test "extra_refs cannot override reserved thread entry refs" do


### PR DESCRIPTION
Closes #323

## Summary

- add an opt-in, trust-gated `agent_skills` lifecycle that resolves on agent initialization, avoiding build-host paths in compiled modules
- inject a compact catalog, `load_skill`, and an agent-scoped closed catalog only after strict Agent Skills validation
- scope activations by session, expose explicit session cleanup, and route `load_skill` through activation without conflating registry bookkeeping with conversation durability
- preserve only tool results produced by the concrete `LoadSkill` action and their matching assistant tool calls across ReAct compaction; reject forged durability refs and conflicting compacted copies
- share one bounded, deterministic, symlink-safe scanner between discovery and registry loading
- enforce strict directory/name, description, license, compatibility, metadata, and `allowed-tools` contracts while retaining lenient diagnostics
- keep discovery metadata string-to-string and reject invalid scope options

## Trust model

Skill instructions are executable model context, so integration remains disabled by default. `agent_skills: true` explicitly trusts the standard project/user roots, a direct path list trusts exactly those roots, and keyword discovery options require an explicit `:trust` policy. A configured agent catalog is a closed set: `load_skill` cannot fall through to unrelated globally registered skills.

## Compatibility notes

- `Prompt.render/2` no longer includes skill bodies unless `include_body: true` is passed.
- Agent Skills discovery now runs when each agent instance initializes, not when its module is compiled.
- Turnkey agent integration rejects invalid skill files strictly; `Discovery.to_spec/1` remains lenient by default for compatibility and accepts `lenient: false` when strict conversion is required.
- Activation bookkeeping is isolated by session; callers spanning processes should pass a stable `:session_id` and call `Activation.clear/1` when that session ends.

## Validation

- `mix test` — 2,332 passed, 1 excluded
- `mix precommit`
- `mix q`
- `mix docs`