### PR TITLE
fix(context): preserve string-keyed assistant content

### DIFF
--- a/lib/jido_ai/context.ex
+++ b/lib/jido_ai/context.ex
@@ -599,22 +599,12 @@ defmodule Jido.AI.Context do
     thinking =
       content
       |> Enum.filter(&(content_part_type(&1) in [:thinking, "thinking"]))
-      |> Enum.map_join("", fn part ->
-        case get_field(part, :thinking) || get_field(part, :text) do
-          text when is_binary(text) -> text
-          _other -> ""
-        end
-      end)
+      |> Enum.map_join("", &content_part_text(&1, [:thinking, :text]))
 
     text =
       content
       |> Enum.filter(&(content_part_type(&1) in [:text, "text"]))
-      |> Enum.map_join("", fn part ->
-        case get_field(part, :text) do
-          text when is_binary(text) -> text
-          _other -> ""
-        end
-      end)
+      |> Enum.map_join("", &content_part_text(&1, [:text]))
 
     thinking = if thinking == "", do: nil, else: thinking
     {text, thinking}
@@ -624,6 +614,15 @@ defmodule Jido.AI.Context do
 
   defp content_part_type(part) when is_map(part), do: get_field(part, :type)
   defp content_part_type(_part), do: nil
+
+  defp content_part_text(part, fields) do
+    Enum.find_value(fields, "", fn field ->
+      case get_field(part, field) do
+        text when is_binary(text) -> text
+        _other -> nil
+      end
+    end)
+  end
 
   # Helper to get a field from either atom or string key
   defp get_field(map, key) do

--- a/lib/jido_ai/context.ex
+++ b/lib/jido_ai/context.ex
@@ -598,27 +598,22 @@ defmodule Jido.AI.Context do
   defp extract_entry_thinking(content) when is_list(content) do
     thinking =
       content
-      |> Enum.filter(fn
-        %{type: :thinking} -> true
-        %{type: "thinking"} -> true
-        _ -> false
-      end)
-      |> Enum.map_join("", fn
-        %{thinking: t} when is_binary(t) -> t
-        %{text: t} when is_binary(t) -> t
-        _ -> ""
+      |> Enum.filter(&(content_part_type(&1) in [:thinking, "thinking"]))
+      |> Enum.map_join("", fn part ->
+        case get_field(part, :thinking) || get_field(part, :text) do
+          text when is_binary(text) -> text
+          _other -> ""
+        end
       end)
 
     text =
       content
-      |> Enum.filter(fn
-        %{type: :text} -> true
-        %{type: "text"} -> true
-        _ -> false
-      end)
-      |> Enum.map_join("", fn
-        %{text: t} when is_binary(t) -> t
-        _ -> ""
+      |> Enum.filter(&(content_part_type(&1) in [:text, "text"]))
+      |> Enum.map_join("", fn part ->
+        case get_field(part, :text) do
+          text when is_binary(text) -> text
+          _other -> ""
+        end
       end)
 
     thinking = if thinking == "", do: nil, else: thinking
@@ -626,6 +621,9 @@ defmodule Jido.AI.Context do
   end
 
   defp extract_entry_thinking(content), do: {content, nil}
+
+  defp content_part_type(part) when is_map(part), do: get_field(part, :type)
+  defp content_part_type(_part), do: nil
 
   # Helper to get a field from either atom or string key
   defp get_field(map, key) do

--- a/test/jido_ai/thread_test.exs
+++ b/test/jido_ai/thread_test.exs
@@ -719,6 +719,25 @@ defmodule Jido.AI.ContextTest do
       assert entry.thinking == "Some reasoning"
     end
 
+    test "uses text fallback when a thinking field is not a string" do
+      messages = [
+        %{
+          role: :assistant,
+          content: [
+            %{type: :thinking, thinking: 123, text: "Atom fallback"},
+            %{"type" => "thinking", "thinking" => 456, "text" => "String fallback"},
+            %{type: :text, text: "The result"}
+          ]
+        }
+      ]
+
+      thread = AIContext.new() |> AIContext.append_messages(messages)
+
+      [entry] = thread.entries
+      assert entry.content == "The result"
+      assert entry.thinking == "Atom fallbackString fallback"
+    end
+
     test "preserves assistant content through a JSON round-trip" do
       original =
         AIContext.new()

--- a/test/jido_ai/thread_test.exs
+++ b/test/jido_ai/thread_test.exs
@@ -719,6 +719,25 @@ defmodule Jido.AI.ContextTest do
       assert entry.thinking == "Some reasoning"
     end
 
+    test "preserves assistant content through a JSON round-trip" do
+      original =
+        AIContext.new()
+        |> AIContext.append_assistant("Here is my answer", nil, thinking: "Some reasoning")
+
+      messages =
+        original
+        |> AIContext.to_messages()
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      rebuilt = AIContext.new() |> AIContext.append_messages(messages)
+
+      [entry] = rebuilt.entries
+      assert entry.content == "Here is my answer"
+      assert entry.thinking == "Some reasoning"
+      assert AIContext.to_messages(rebuilt) == AIContext.to_messages(original)
+    end
+
     test "ignores malformed thinking and text blocks" do
       messages = [
         %{
@@ -845,6 +864,38 @@ defmodule Jido.AI.ContextTest do
                %ContentPart{type: :text, text: ~s({"result": 42})},
                %ContentPart{type: :image_url, url: "https://example.com/chart.png"}
              ] = projected.content
+    end
+
+    test "preserves string-keyed assistant content parts from raw context maps" do
+      raw = %{
+        "id" => "ctx",
+        "entries" => [
+          %{
+            "role" => "assistant",
+            "content" => [
+              %{"type" => "thinking", "thinking" => "Some reasoning"},
+              %{"type" => "text", "text" => "Here is my answer"}
+            ]
+          }
+        ],
+        "system_prompt" => nil
+      }
+
+      assert {:ok, %AIContext{} = coerced} = AIContext.coerce(raw)
+
+      [entry] = coerced.entries
+      assert entry.content == "Here is my answer"
+      assert entry.thinking == "Some reasoning"
+
+      assert [
+               %{
+                 role: :assistant,
+                 content: [
+                   %{type: :thinking, thinking: "Some reasoning"},
+                   %{type: :text, text: "Here is my answer"}
+                 ]
+               }
+             ] = AIContext.to_messages(coerced)
     end
 
     test "rejects Jido.Thread structs" do


### PR DESCRIPTION
## Summary

- preserve assistant text and thinking content after JSON serialization
- use the existing atom-or-string field lookup for assistant content parts
- preserve valid `text` fallback data when a `thinking` field is present but malformed
- add regression coverage for `append_messages/2` and `coerce/1`

## Root cause

`extract_entry_thinking/1` matched only atom-keyed content-part maps. A JSON round-trip changes keys such as `:type`, `:thinking`, and `:text` to strings. The extractor then ignored all assistant content parts and stored an empty message.

## Impact

Applications can persist and restore thinking-model conversations without losing assistant text or thinking content. Malformed thinking fields also cannot hide a valid text fallback.

## Validation

- `mix test test/jido_ai/thread_test.exs` — 69 passed
- `mix test` — 2,335 passed, 1 excluded
- `mix precommit` — passed
- `mix dialyzer` — passed

Fixes #328