### PR TITLE
fix(tool-exec): thread the directive timeout_ms through to Turn execu…

### DIFF
--- a/lib/jido_ai/directive/tool_exec.ex
+++ b/lib/jido_ai/directive/tool_exec.ex
@@ -330,7 +330,7 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
     if is_integer(timeout_ms) and timeout_ms > 0 do
       task =
         Task.Supervisor.async_nolink(task_supervisor, fn ->
-          execute_action(action_module, tool_name, arguments, context, tools, event_meta)
+          execute_action(action_module, tool_name, arguments, context, tools, event_meta, timeout_ms)
         end)
 
       try do
@@ -348,21 +348,28 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.ToolExec do
         Process.demonitor(task.ref, [:flush])
       end
     else
-      execute_action(action_module, tool_name, arguments, context, tools, event_meta)
+      execute_action(action_module, tool_name, arguments, context, tools, event_meta, timeout_ms)
       |> normalize_result(tool_name)
     end
   end
 
-  defp execute_action(action_module, tool_name, arguments, context, tools, event_meta) do
+  defp execute_action(action_module, tool_name, arguments, context, tools, event_meta, timeout_ms) do
+    timeout_opts = if is_integer(timeout_ms) and timeout_ms > 0, do: [timeout: timeout_ms], else: []
+
     try do
       telemetry_metadata = turn_telemetry_metadata(event_meta)
 
       case action_module do
         nil ->
-          Turn.execute(tool_name, arguments, context, tools: tools, telemetry_metadata: telemetry_metadata)
+          Turn.execute(
+            tool_name,
+            arguments,
+            context,
+            [tools: tools, telemetry_metadata: telemetry_metadata] ++ timeout_opts
+          )
 
         module when is_atom(module) ->
-          Turn.execute_module(module, arguments, context, telemetry_metadata: telemetry_metadata)
+          Turn.execute_module(module, arguments, context, [telemetry_metadata: telemetry_metadata] ++ timeout_opts)
       end
     rescue
       e ->

--- a/test/jido_ai/directive/exec_runtime_test.exs
+++ b/test/jido_ai/directive/exec_runtime_test.exs
@@ -461,6 +461,32 @@ defmodule Jido.AI.Directive.ExecRuntimeTest do
              }
     end
 
+    test "passes the directive timeout_ms through to Turn execution" do
+      supervisor = DirectiveSupport.start_task_supervisor!()
+      on_exit(fn -> DirectiveSupport.stop_task_supervisor(supervisor) end)
+
+      Mimic.stub(Jido.AI.Turn, :execute_module, fn _module, _params, _context, opts ->
+        # Without threading, Turn falls back to its own 30s default and can
+        # kill an action whose directive granted a larger budget.
+        assert Keyword.get(opts, :timeout) == 120_000
+        {:ok, %{value: :ok}}
+      end)
+
+      directive =
+        ToolExec.new!(%{
+          id: "tool_timeout_threaded",
+          tool_name: "dummy",
+          action_module: DummyAction,
+          timeout_ms: 120_000
+        })
+
+      state = DirectiveSupport.state_with_supervisor(supervisor)
+      assert {:async, nil, ^state} = DirectiveExec.exec(directive, nil, state)
+
+      signal = DirectiveSupport.assert_signal_cast("ai.tool.result")
+      assert signal.data.result == {:ok, %{value: :ok}, []}
+    end
+
     test "emits timeout error when execution exceeds timeout_ms" do
       supervisor = DirectiveSupport.start_task_supervisor!()
       on_exit(fn -> DirectiveSupport.stop_task_supervisor(supervisor) end)


### PR DESCRIPTION
Hope this is a welcome contribution!

## Problem

`ToolExec` documents `timeout_ms` as the per-attempt timeout and honors it in the outer `Task.yield` wrapper — but `execute_action` calls `Turn.execute` / `Turn.execute_module` without passing `:timeout`, so `Turn`'s hard-coded `@default_timeout 30_000` wins on the inner path. Any tool action that legitimately runs longer than 30s (image generation, long-running external calls) is killed with `Action X timed out after 30000ms` even when its directive granted a larger budget.

This is easy to miss in test suites because mocked tools return instantly; we hit it on the first live call of a tool that declares a 6-minute budget.

## Fix

Thread `timeout_ms` from `execute_attempt` into `execute_action` and pass it to `Turn` as `:timeout` when it is a positive integer. When the directive sets no `timeout_ms`, nothing is passed and `Turn`'s existing default applies, so behavior is unchanged for existing callers.

## Test

Adds a regression test asserting the directive's `timeout_ms` reaches `Turn.execute_module`'s opts. Full suite: 2,336 passed / 0 failed (main baseline plus the new test); `mix quality` (format, warnings-as-errors, strict Credo, Doctor, Dialyzer) passes.