### PR TITLE
fix(request): keep stream sink pids out of durable checkpoints

### DIFF
--- a/guides/user/request_lifecycle_and_concurrency.md
+++ b/guides/user/request_lifecycle_and_concurrency.md
@@ -63,6 +63,47 @@ Pid sinks are request-scoped and use the calling process mailbox. They do not
 provide backpressure; keep handlers lightweight and always consume terminal
 events so request streams close cleanly.
 
+### Stream Sinks And Durable Checkpoints
+
+A stream sink is a live pid, so it is process-local by definition. It is held on
+the request record only while the request is in flight:
+
+- Reaching a terminal state (completed, failed, or cancelled) drops the sink.
+- Checkpoints never contain it, including while a request is still active.
+
+This matters because checkpoints outlive the VM that wrote them. An encoded pid
+carries its node atom, and storage adapters decode with
+`:erlang.binary_to_term/2` `[:safe]`, which refuses to create that atom in a VM
+that has never seen it. A persisted sink would make the checkpoint permanently
+undecodable after a distribution config change — for example moving from long
+names to short names. See `Jido.AI.Checkpoint` for the full list of runtime
+handles that are stripped.
+
+Cancelling a streamed request emits `:request_cancelled` to the sink before the
+sink is dropped, so a consumer's enumerable always halts on a terminal event.
+
+### Restoring An Interrupted Streamed Request
+
+A sink cannot be re-attached after a thaw: the consumer process is gone. A
+request that was still running when the checkpoint was written is restored with
+deterministic, inspectable state:
+
+```elixir
+{:ok, agent} = MyApp.MathAgent.restore(checkpoint, %{})
+
+agent.state.requests[request_id]
+#=> %{status: :pending, stream_interrupted: true, query: "Show your work", ...}
+```
+
+- `:status` stays `:pending` — the request is not silently reported as completed.
+- `:stream_to` is absent — nothing is delivered to the original consumer.
+- `stream_interrupted: true` records that a consumer was attached and lost.
+
+Use `Jido.AI.Checkpoint.interrupted_request?/1` to detect these. The underlying
+ReAct run does not survive the thaw, so re-issue the query to get an answer;
+`await/2` on an interrupted request returns `{:error, :timeout}` rather than
+blocking on a run that no longer exists.
+
 ## Steering An Active ReAct Run
 
 `ask/await` remains the request API. Mid-run steering is a separate control path:

--- a/guides/user/request_lifecycle_and_concurrency.md
+++ b/guides/user/request_lifecycle_and_concurrency.md
@@ -65,50 +65,31 @@ events so request streams close cleanly.
 
 ### Stream Sinks And Durable Checkpoints
 
-A stream sink is a live pid, so it is process-local by definition. It is held on
-the request record only while the request is in flight:
+A stream sink is a live pid. It is kept on the request only while the request is
+active:
 
 - Reaching a terminal state (completed, failed, or cancelled) drops the sink.
 - Checkpoints never contain it, including while a request is still active.
 
-This matters because checkpoints outlive the VM that wrote them. An encoded pid
-carries its node atom, and storage adapters decode with
-`:erlang.binary_to_term/2` `[:safe]`, which refuses to create that atom in a VM
-that has never seen it. A persisted sink would make the checkpoint permanently
-undecodable after a distribution config change — for example moving from long
-names to short names. See `Jido.AI.Checkpoint` for the full list of runtime
-handles that are stripped.
-
 Cancelling a streamed request emits `:request_cancelled` to the sink before the
-sink is dropped, so a consumer's enumerable always halts on a terminal event.
+sink is dropped.
 
 ### Restoring An Interrupted Streamed Request
 
-A sink cannot be re-attached after a thaw: the consumer process is gone. A
-request that was still running when the checkpoint was written is restored with
-deterministic, inspectable state:
+A stream cannot continue after restore. A request that was active when the
+checkpoint was written is restored as:
 
 ```elixir
-{:ok, agent} = MyApp.MathAgent.restore(checkpoint, %{})
-
-agent.state.requests[request_id]
-#=> %{
-#     status: :failed,
-#     error: :stream_interrupted,
-#     stream_interrupted: true,
-#     query: "Show your work",
-#     ...
-#   }
+%{
+  status: :failed,
+  error: :stream_interrupted,
+  stream_interrupted: true
+}
 ```
 
-- `:status` is `:failed` with `error: :stream_interrupted`.
-- `:stream_to` is absent — nothing is delivered to the original consumer.
-- `stream_interrupted: true` records that a consumer was attached and lost.
-
-Use `Jido.AI.Checkpoint.interrupted_request?/1` to detect these. The underlying
-ReAct run does not survive the thaw, so re-issue the query to get an answer;
-`await/2` on the old request returns `{:error, :stream_interrupted}`
-immediately.
+The restored request has no `:stream_to`. `await/2` returns
+`{:error, :stream_interrupted}` for its old handle. Send a new request to start
+a new stream.
 
 ## Steering An Active ReAct Run
 

--- a/guides/user/request_lifecycle_and_concurrency.md
+++ b/guides/user/request_lifecycle_and_concurrency.md
@@ -92,17 +92,23 @@ deterministic, inspectable state:
 {:ok, agent} = MyApp.MathAgent.restore(checkpoint, %{})
 
 agent.state.requests[request_id]
-#=> %{status: :pending, stream_interrupted: true, query: "Show your work", ...}
+#=> %{
+#     status: :failed,
+#     error: :stream_interrupted,
+#     stream_interrupted: true,
+#     query: "Show your work",
+#     ...
+#   }
 ```
 
-- `:status` stays `:pending` — the request is not silently reported as completed.
+- `:status` is `:failed` with `error: :stream_interrupted`.
 - `:stream_to` is absent — nothing is delivered to the original consumer.
 - `stream_interrupted: true` records that a consumer was attached and lost.
 
 Use `Jido.AI.Checkpoint.interrupted_request?/1` to detect these. The underlying
 ReAct run does not survive the thaw, so re-issue the query to get an answer;
-`await/2` on an interrupted request returns `{:error, :timeout}` rather than
-blocking on a run that no longer exists.
+`await/2` on the old request returns `{:error, :stream_interrupted}`
+immediately.
 
 ## Steering An Active ReAct Run
 

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -913,22 +913,13 @@ defmodule Jido.AI.Agent do
       @doc """
       Builds a durable checkpoint payload for this agent.
 
-      Strips process-local runtime handles — request stream sinks, the ReAct
-      worker pid, the steering queue, and the `ReqLLM.Tool` callbacks — before
-      delegating to the default implementation, so the payload survives
-      `:erlang.binary_to_term/2` with `[:safe]` on another node.
-
-      See `Jido.AI.Checkpoint` for the full list and the restore contract.
+      Removes request stream sinks and ReAct process handles before storage.
       """
       @impl true
       @spec checkpoint(Jido.Agent.t(), map()) :: {:ok, map()} | {:error, term()}
       def checkpoint(agent, ctx) do
         sanitized = %{agent | state: Jido.AI.Checkpoint.sanitize_state(agent.state)}
-
-        with {:ok, payload} <- super(sanitized, ctx) do
-          Jido.AI.Checkpoint.warn_on_residual_handles(__MODULE__, payload)
-          {:ok, payload}
-        end
+        super(sanitized, ctx)
       end
 
       @impl true

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -968,6 +968,8 @@ defmodule Jido.AI.Agent do
       end
 
       def restore(_data, _ctx), do: {:error, :invalid_checkpoint_payload}
+
+      defoverridable checkpoint: 2
     end
   end
 

--- a/lib/jido_ai/agent.ex
+++ b/lib/jido_ai/agent.ex
@@ -666,7 +666,7 @@ defmodule Jido.AI.Agent do
             {:ai_react_request_error, %{request_id: request_id, reason: reason, message: message}} = action
           ) do
         error = {:rejected, reason, message}
-        stream_to = get_in(agent.state, [:requests, request_id, :stream_to])
+        stream_to = Request.stream_sink(agent, request_id)
 
         agent = Request.fail_request(agent, request_id, error)
         Request.Stream.send_event(stream_to, Request.Stream.failed_event(request_id, error, reason: reason))
@@ -720,7 +720,12 @@ defmodule Jido.AI.Agent do
         agent =
           if is_binary(request_id) and request_pending?(agent, request_id) do
             failure = {:cancelled, reason}
+            # Read the sink before the terminal transition drops it, and emit the
+            # terminal event here so the consumer's stream halts on the cancel
+            # rather than on a worker acknowledgement that may never arrive.
+            stream_to = Request.stream_sink(agent, request_id)
             emit_request_failed_signal(agent, request_id, failure)
+            Request.Stream.send_event(stream_to, Request.Stream.cancelled_event(request_id, reason))
             Request.fail_request(agent, request_id, failure)
           else
             agent
@@ -905,11 +910,32 @@ defmodule Jido.AI.Agent do
       @spec plugin_specs() :: [map()]
       def plugin_specs, do: @plugin_specs
 
+      @doc """
+      Builds a durable checkpoint payload for this agent.
+
+      Strips process-local runtime handles — request stream sinks, the ReAct
+      worker pid, the steering queue, and the `ReqLLM.Tool` callbacks — before
+      delegating to the default implementation, so the payload survives
+      `:erlang.binary_to_term/2` with `[:safe]` on another node.
+
+      See `Jido.AI.Checkpoint` for the full list and the restore contract.
+      """
+      @impl true
+      @spec checkpoint(Jido.Agent.t(), map()) :: {:ok, map()} | {:error, term()}
+      def checkpoint(agent, ctx) do
+        sanitized = %{agent | state: Jido.AI.Checkpoint.sanitize_state(agent.state)}
+
+        with {:ok, payload} <- super(sanitized, ctx) do
+          Jido.AI.Checkpoint.warn_on_residual_handles(__MODULE__, payload)
+          {:ok, payload}
+        end
+      end
+
       @impl true
       @spec restore(map(), map()) :: {:ok, Jido.Agent.t()} | {:error, term()}
       def restore(data, ctx) when is_map(data) and is_map(ctx) do
         agent = new(id: data[:id])
-        base_state = data[:state] || %{}
+        base_state = Jido.AI.Checkpoint.rehydrate_state(data[:state] || %{})
         agent = %{agent | state: Map.merge(agent.state, base_state)}
         externalized_keys = data[:externalized_keys] || %{}
 

--- a/lib/jido_ai/checkpoint.ex
+++ b/lib/jido_ai/checkpoint.ex
@@ -30,7 +30,10 @@ defmodule Jido.AI.Checkpoint do
   | `state.__strategy__.react_worker_pid` | ReAct worker process | Reset to `nil` / `:missing` |
   | `state.__strategy__.pending_input_server` | Steering queue process | Reset to `nil` |
   | `state.__strategy__.pending_worker_start` | Queued worker payload embedding a state snapshot | Reset to `nil` |
-  | `state.__strategy__.config.reqllm_tools` | `ReqLLM.Tool` structs holding anonymous callbacks | Rebuilt from `config.tools` |
+
+  `state.__strategy__.config.reqllm_tools` stays in the payload. Its callback is
+  the durable MFA placeholder `{ReqLLM.Tool, :new}`, so an older reader still
+  receives the field and a new VM can decode it with `[:safe]`.
 
   The per-instance `Task.Supervisor` is dropped by
   `Jido.AI.Plugins.TaskSupervisor.on_checkpoint/2` and re-mounted by `new/1`
@@ -43,11 +46,12 @@ defmodule Jido.AI.Checkpoint do
 
   - no `:stream_to` — nothing will ever be delivered to the original consumer,
   - `stream_interrupted: true` — a durable marker that the run was cut short,
-  - its original `:pending` status — the request is *not* silently completed.
+  - `status: :failed` and `error: :stream_interrupted`.
 
-  Callers that need the answer must re-issue the query. `Jido.AI.Request.await/2`
-  on such a request returns `{:error, :timeout}` rather than hanging forever on a
-  run that no longer exists. Use `interrupted_request?/1` to detect them.
+  The parent strategy also restores to an idle state with no active request.
+  Callers can re-issue the query, and `Jido.AI.Request.await/2` on the old handle
+  returns `{:error, :stream_interrupted}` immediately. Use
+  `interrupted_request?/1` to detect these requests in state.
 
   ## Residual handles
 
@@ -71,11 +75,41 @@ defmodule Jido.AI.Checkpoint do
   @type handle :: {handle_path(), :pid | :port | :reference | :function}
 
   # Strategy fields holding process handles, with the value each is reset to.
-  @strategy_resets %{
+  @strategy_handle_resets %{
     react_worker_pid: nil,
     react_worker_status: :missing,
     pending_worker_start: nil,
     pending_input_server: nil
+  }
+
+  # An in-flight ReAct run cannot continue after thaw. Reset its run-local
+  # logical state while preserving durable context, request traces, and config.
+  @interrupted_run_resets %{
+    status: :idle,
+    iteration: 0,
+    run_context: nil,
+    pending_tool_calls: [],
+    tool_results: [],
+    final_answer: nil,
+    result: nil,
+    current_llm_call_id: nil,
+    termination_reason: nil,
+    run_tool_context: %{},
+    run_req_http_options: [],
+    run_llm_opts: [],
+    active_request_id: nil,
+    pending_input_server: nil,
+    last_pending_input_control: nil,
+    cancel_reason: nil,
+    usage: %{},
+    started_at: nil,
+    streaming_text: "",
+    streaming_thinking: "",
+    thinking_trace: [],
+    checkpoint_token: nil,
+    react_worker_pid: nil,
+    react_worker_status: :missing,
+    pending_worker_start: nil
   }
 
   @doc """
@@ -88,7 +122,7 @@ defmodule Jido.AI.Checkpoint do
 
       iex> state = %{requests: %{"r1" => %{status: :pending, stream_to: {:pid, self()}}}}
       iex> Jido.AI.Checkpoint.sanitize_state(state)
-      %{requests: %{"r1" => %{status: :pending, stream_interrupted: true}}}
+      %{requests: %{"r1" => %{status: :failed, error: :stream_interrupted, stream_interrupted: true}}}
   """
   @spec sanitize_state(map()) :: map()
   def sanitize_state(state) when is_map(state) do
@@ -188,14 +222,39 @@ defmodule Jido.AI.Checkpoint do
 
   defp sanitize_strategy(strategy) do
     strategy
-    |> Map.merge(@strategy_resets)
-    |> update_strategy_config(&Map.delete(&1, :reqllm_tools))
+    |> reset_interrupted_run()
+    |> reset_react_handles()
+    |> update_strategy_config(&restore_reqllm_tools/1)
   end
 
   defp rehydrate_strategy(strategy) do
     strategy
-    |> Map.merge(@strategy_resets)
+    |> reset_interrupted_run()
+    |> reset_react_handles()
     |> update_strategy_config(&restore_reqllm_tools/1)
+  end
+
+  defp reset_interrupted_run(strategy) do
+    if react_run_active?(strategy) do
+      Map.merge(strategy, @interrupted_run_resets)
+    else
+      strategy
+    end
+  end
+
+  defp react_run_active?(strategy) do
+    react_strategy_state?(strategy) and
+      (is_binary(Map.get(strategy, :active_request_id)) or
+         Map.get(strategy, :status) in [:awaiting_llm, :awaiting_tool] or
+         Map.get(strategy, :react_worker_status) in [:starting, :running])
+  end
+
+  defp reset_react_handles(strategy) do
+    if react_strategy_state?(strategy), do: Map.merge(strategy, @strategy_handle_resets), else: strategy
+  end
+
+  defp react_strategy_state?(strategy) do
+    Map.has_key?(strategy, :react_worker_pid) or Map.has_key?(strategy, :react_worker_status)
   end
 
   defp update_strategy_config(strategy, fun) do
@@ -205,8 +264,9 @@ defmodule Jido.AI.Checkpoint do
     end
   end
 
-  # `reqllm_tools` is a pure projection of `config.tools`, kept in sync by the
-  # strategy whenever tools are registered or unregistered at runtime.
+  # `reqllm_tools` is a pure projection of `config.tools`. Rebuild it to replace
+  # callbacks created by older releases and to restore payloads written by an
+  # earlier version of this checkpoint sanitizer that dropped the field.
   defp restore_reqllm_tools(%{tools: tools} = config) when is_list(tools) do
     Map.put(config, :reqllm_tools, ToolAdapter.from_actions(tools))
   end
@@ -233,13 +293,14 @@ defmodule Jido.AI.Checkpoint do
   end
 
   defp collect_handles(term, path, acc) when is_map(term) do
-    Enum.reduce(term, acc, fn {key, value}, inner -> collect_handles(value, [key | path], inner) end)
+    Enum.reduce(term, acc, fn {key, value}, inner ->
+      inner = collect_handles(key, [{:key, key} | path], inner)
+      collect_handles(value, [key | path], inner)
+    end)
   end
 
   defp collect_handles(term, path, acc) when is_list(term) do
-    term
-    |> Enum.with_index()
-    |> Enum.reduce(acc, fn {value, index}, inner -> collect_handles(value, [{:at, index} | path], inner) end)
+    collect_list_handles(term, 0, path, acc)
   end
 
   defp collect_handles(term, path, acc) when is_tuple(term) do
@@ -251,6 +312,17 @@ defmodule Jido.AI.Checkpoint do
 
   defp collect_handles(_term, _path, acc), do: acc
 
+  defp collect_list_handles([], _index, _path, acc), do: acc
+
+  defp collect_list_handles([head | tail], index, path, acc) do
+    acc = collect_handles(head, [{:at, index} | path], acc)
+    collect_list_handles(tail, index + 1, path, acc)
+  end
+
+  defp collect_list_handles(tail, index, path, acc) do
+    collect_handles(tail, [{:tail, index} | path], acc)
+  end
+
   defp external_capture?(fun) do
     Function.info(fun, :type) == {:type, :external}
   end
@@ -260,6 +332,8 @@ defmodule Jido.AI.Checkpoint do
   defp format_path(path) do
     Enum.map_join(path, ".", fn
       {:at, index} -> "[#{index}]"
+      {:tail, index} -> "[tail@#{index}]"
+      {:key, key} -> "[key #{inspect(key)}]"
       {:elem, index} -> "{#{index}}"
       segment when is_binary(segment) -> segment
       segment -> inspect(segment)

--- a/lib/jido_ai/checkpoint.ex
+++ b/lib/jido_ai/checkpoint.ex
@@ -1,0 +1,268 @@
+defmodule Jido.AI.Checkpoint do
+  @moduledoc """
+  Checkpoint sanitization and rehydration for `Jido.AI.Agent` state.
+
+  Durable checkpoints outlive the VM that wrote them. Anything process-local —
+  pids, ports, references — and any anonymous function is therefore unsafe to
+  persist: `:erlang.binary_to_term/2` with `[:safe]` refuses to decode both, so
+  a checkpoint containing them cannot be read back at all once the writing node
+  is gone.
+
+  ## Why `[:safe]` matters
+
+  Storage adapters decode untrusted bytes with `[:safe]` to avoid unbounded atom
+  creation. That option rejects:
+
+  - **Pids/ports/refs** whose node atom does not already exist in the decoding
+    VM. A checkpoint written by `app@host.example.com` becomes undecodable after
+    a switch to short names, surfacing as `{:error, :invalid_term}`.
+  - **Anonymous functions**, unconditionally — even when the defining module is
+    loaded and no new atoms are involved.
+
+  Both classes are runtime handles that are meaningless after a thaw anyway: the
+  process they point at is dead, and the function is rebuilt from compiled code.
+
+  ## What is stripped
+
+  | Path | Reason | On restore |
+  | --- | --- | --- |
+  | `state.requests[id].stream_to` | Request stream sink (`{:pid, pid}`) | Dropped; active requests are flagged `stream_interrupted: true` |
+  | `state.__strategy__.react_worker_pid` | ReAct worker process | Reset to `nil` / `:missing` |
+  | `state.__strategy__.pending_input_server` | Steering queue process | Reset to `nil` |
+  | `state.__strategy__.pending_worker_start` | Queued worker payload embedding a state snapshot | Reset to `nil` |
+  | `state.__strategy__.config.reqllm_tools` | `ReqLLM.Tool` structs holding anonymous callbacks | Rebuilt from `config.tools` |
+
+  The per-instance `Task.Supervisor` is dropped by
+  `Jido.AI.Plugins.TaskSupervisor.on_checkpoint/2` and re-mounted by `new/1`
+  during restore.
+
+  ## Restore contract for interrupted streamed requests
+
+  A stream sink is process-local, so it can never survive a thaw. A request that
+  was still in flight when the checkpoint was written is restored with:
+
+  - no `:stream_to` — nothing will ever be delivered to the original consumer,
+  - `stream_interrupted: true` — a durable marker that the run was cut short,
+  - its original `:pending` status — the request is *not* silently completed.
+
+  Callers that need the answer must re-issue the query. `Jido.AI.Request.await/2`
+  on such a request returns `{:error, :timeout}` rather than hanging forever on a
+  run that no longer exists. Use `interrupted_request?/1` to detect them.
+
+  ## Residual handles
+
+  `runtime_handles/1` walks a term and reports every remaining pid, port,
+  reference, and anonymous function with the path it was found at. `checkpoint/2`
+  logs a warning listing them, so state that a future change starts persisting is
+  reported instead of silently producing unreadable checkpoints.
+  """
+
+  require Logger
+
+  alias Jido.AI.Request
+  alias Jido.AI.ToolAdapter
+
+  @strategy_key :__strategy__
+
+  @typedoc "Location of a runtime handle inside a term, outermost segment first."
+  @type handle_path :: [term()]
+
+  @typedoc "A non-serializable value found in a term."
+  @type handle :: {handle_path(), :pid | :port | :reference | :function}
+
+  # Strategy fields holding process handles, with the value each is reset to.
+  @strategy_resets %{
+    react_worker_pid: nil,
+    react_worker_status: :missing,
+    pending_worker_start: nil,
+    pending_input_server: nil
+  }
+
+  @doc """
+  Removes every process-local runtime handle from agent state.
+
+  Operates on the checkpoint copy of the state; the live agent keeps its
+  handles.
+
+  ## Examples
+
+      iex> state = %{requests: %{"r1" => %{status: :pending, stream_to: {:pid, self()}}}}
+      iex> Jido.AI.Checkpoint.sanitize_state(state)
+      %{requests: %{"r1" => %{status: :pending, stream_interrupted: true}}}
+  """
+  @spec sanitize_state(map()) :: map()
+  def sanitize_state(state) when is_map(state) do
+    state
+    |> Request.sanitize_requests(:checkpoint)
+    |> update_strategy(&sanitize_strategy/1)
+  end
+
+  def sanitize_state(state), do: state
+
+  @doc """
+  Rebuilds derived runtime values dropped by `sanitize_state/1`.
+
+  Called on the restore path. Also scrubs stream sinks from legacy checkpoints
+  written before sanitization existed, so a decodable old payload still restores
+  without a stale pid.
+  """
+  @spec rehydrate_state(map()) :: map()
+  def rehydrate_state(state) when is_map(state) do
+    state
+    |> Request.sanitize_requests(:restore)
+    |> update_strategy(&rehydrate_strategy/1)
+  end
+
+  def rehydrate_state(state), do: state
+
+  @doc """
+  Returns true when a restored request lost its stream sink mid-flight.
+
+  ## Examples
+
+      iex> Jido.AI.Checkpoint.interrupted_request?(%{stream_interrupted: true})
+      true
+
+      iex> Jido.AI.Checkpoint.interrupted_request?(%{status: :completed})
+      false
+  """
+  @spec interrupted_request?(map() | nil) :: boolean()
+  def interrupted_request?(%{stream_interrupted: true}), do: true
+  def interrupted_request?(_request), do: false
+
+  @doc """
+  Walks `term` and returns every pid, port, reference, and anonymous function.
+
+  Paths read outermost segment first. Tuple elements appear as `{:elem, index}`,
+  list elements as `{:at, index}`, and struct contents are prefixed with the
+  struct module.
+
+  External function captures (`&Mod.fun/1`) are not reported: they encode as a
+  module/function/arity triple that `[:safe]` accepts.
+
+  ## Examples
+
+      iex> Jido.AI.Checkpoint.runtime_handles(%{a: %{b: [self()]}})
+      [{[:a, :b, {:at, 0}], :pid}]
+
+      iex> Jido.AI.Checkpoint.runtime_handles(%{ok: [1, "two", :three]})
+      []
+  """
+  @spec runtime_handles(term()) :: [handle()]
+  def runtime_handles(term), do: term |> collect_handles([], []) |> Enum.reverse()
+
+  @doc """
+  Formats `runtime_handles/1` output as a human-readable list.
+  """
+  @spec format_handles([handle()]) :: String.t()
+  def format_handles(handles) when is_list(handles) do
+    Enum.map_join(handles, ", ", fn {path, kind} -> "#{kind} at #{format_path(path)}" end)
+  end
+
+  @doc false
+  @spec warn_on_residual_handles(module(), map()) :: :ok
+  def warn_on_residual_handles(agent_module, payload) do
+    case runtime_handles(payload) do
+      [] ->
+        :ok
+
+      handles ->
+        Logger.warning(
+          "#{inspect(agent_module)} checkpoint retains non-serializable runtime handles; " <>
+            "the payload will not decode with binary_to_term/2 [:safe] on another node: " <>
+            format_handles(handles)
+        )
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Strategy state
+  # ---------------------------------------------------------------------------
+
+  defp update_strategy(state, fun) do
+    case Map.get(state, @strategy_key) do
+      strategy when is_map(strategy) -> Map.put(state, @strategy_key, fun.(strategy))
+      _absent -> state
+    end
+  end
+
+  defp sanitize_strategy(strategy) do
+    strategy
+    |> Map.merge(@strategy_resets)
+    |> update_strategy_config(&Map.delete(&1, :reqllm_tools))
+  end
+
+  defp rehydrate_strategy(strategy) do
+    strategy
+    |> Map.merge(@strategy_resets)
+    |> update_strategy_config(&restore_reqllm_tools/1)
+  end
+
+  defp update_strategy_config(strategy, fun) do
+    case Map.get(strategy, :config) do
+      config when is_map(config) -> Map.put(strategy, :config, fun.(config))
+      _absent -> strategy
+    end
+  end
+
+  # `reqllm_tools` is a pure projection of `config.tools`, kept in sync by the
+  # strategy whenever tools are registered or unregistered at runtime.
+  defp restore_reqllm_tools(%{tools: tools} = config) when is_list(tools) do
+    Map.put(config, :reqllm_tools, ToolAdapter.from_actions(tools))
+  end
+
+  defp restore_reqllm_tools(config), do: config
+
+  # ---------------------------------------------------------------------------
+  # Handle scanning
+  # ---------------------------------------------------------------------------
+
+  defp collect_handles(term, path, acc) when is_pid(term), do: [{Enum.reverse(path), :pid} | acc]
+  defp collect_handles(term, path, acc) when is_port(term), do: [{Enum.reverse(path), :port} | acc]
+
+  defp collect_handles(term, path, acc) when is_reference(term) do
+    [{Enum.reverse(path), :reference} | acc]
+  end
+
+  defp collect_handles(term, path, acc) when is_function(term) do
+    if external_capture?(term), do: acc, else: [{Enum.reverse(path), :function} | acc]
+  end
+
+  defp collect_handles(%module{} = term, path, acc) do
+    term |> Map.from_struct() |> collect_handles([module | path], acc)
+  end
+
+  defp collect_handles(term, path, acc) when is_map(term) do
+    Enum.reduce(term, acc, fn {key, value}, inner -> collect_handles(value, [key | path], inner) end)
+  end
+
+  defp collect_handles(term, path, acc) when is_list(term) do
+    term
+    |> Enum.with_index()
+    |> Enum.reduce(acc, fn {value, index}, inner -> collect_handles(value, [{:at, index} | path], inner) end)
+  end
+
+  defp collect_handles(term, path, acc) when is_tuple(term) do
+    term
+    |> Tuple.to_list()
+    |> Enum.with_index()
+    |> Enum.reduce(acc, fn {value, index}, inner -> collect_handles(value, [{:elem, index} | path], inner) end)
+  end
+
+  defp collect_handles(_term, _path, acc), do: acc
+
+  defp external_capture?(fun) do
+    Function.info(fun, :type) == {:type, :external}
+  end
+
+  defp format_path([]), do: "<root>"
+
+  defp format_path(path) do
+    Enum.map_join(path, ".", fn
+      {:at, index} -> "[#{index}]"
+      {:elem, index} -> "{#{index}}"
+      segment when is_binary(segment) -> segment
+      segment -> inspect(segment)
+    end)
+  end
+end

--- a/lib/jido_ai/checkpoint.ex
+++ b/lib/jido_ai/checkpoint.ex
@@ -1,80 +1,17 @@
 defmodule Jido.AI.Checkpoint do
   @moduledoc """
-  Checkpoint sanitization and rehydration for `Jido.AI.Agent` state.
+  Removes process-local values from `Jido.AI.Agent` checkpoints.
 
-  Durable checkpoints outlive the VM that wrote them. Anything process-local —
-  pids, ports, references — and any anonymous function is therefore unsafe to
-  persist: `:erlang.binary_to_term/2` with `[:safe]` refuses to decode both, so
-  a checkpoint containing them cannot be read back at all once the writing node
-  is gone.
-
-  ## Why `[:safe]` matters
-
-  Storage adapters decode untrusted bytes with `[:safe]` to avoid unbounded atom
-  creation. That option rejects:
-
-  - **Pids/ports/refs** whose node atom does not already exist in the decoding
-    VM. A checkpoint written by `app@host.example.com` becomes undecodable after
-    a switch to short names, surfacing as `{:error, :invalid_term}`.
-  - **Anonymous functions**, unconditionally — even when the defining module is
-    loaded and no new atoms are involved.
-
-  Both classes are runtime handles that are meaningless after a thaw anyway: the
-  process they point at is dead, and the function is rebuilt from compiled code.
-
-  ## What is stripped
-
-  | Path | Reason | On restore |
-  | --- | --- | --- |
-  | `state.requests[id].stream_to` | Request stream sink (`{:pid, pid}`) | Dropped; active requests are flagged `stream_interrupted: true` |
-  | `state.__strategy__.react_worker_pid` | ReAct worker process | Reset to `nil` / `:missing` |
-  | `state.__strategy__.pending_input_server` | Steering queue process | Reset to `nil` |
-  | `state.__strategy__.pending_worker_start` | Queued worker payload embedding a state snapshot | Reset to `nil` |
-
-  `state.__strategy__.config.reqllm_tools` stays in the payload. Its callback is
-  the durable MFA placeholder `{ReqLLM.Tool, :new}`, so an older reader still
-  receives the field and a new VM can decode it with `[:safe]`.
-
-  The per-instance `Task.Supervisor` is dropped by
-  `Jido.AI.Plugins.TaskSupervisor.on_checkpoint/2` and re-mounted by `new/1`
-  during restore.
-
-  ## Restore contract for interrupted streamed requests
-
-  A stream sink is process-local, so it can never survive a thaw. A request that
-  was still in flight when the checkpoint was written is restored with:
-
-  - no `:stream_to` — nothing will ever be delivered to the original consumer,
-  - `stream_interrupted: true` — a durable marker that the run was cut short,
-  - `status: :failed` and `error: :stream_interrupted`.
-
-  The parent strategy also restores to an idle state with no active request.
-  Callers can re-issue the query, and `Jido.AI.Request.await/2` on the old handle
-  returns `{:error, :stream_interrupted}` immediately. Use
-  `interrupted_request?/1` to detect these requests in state.
-
-  ## Residual handles
-
-  `runtime_handles/1` walks a term and reports every remaining pid, port,
-  reference, and anonymous function with the path it was found at. `checkpoint/2`
-  logs a warning listing them, so state that a future change starts persisting is
-  reported instead of silently producing unreadable checkpoints.
+  Request stream sinks and ReAct worker processes cannot survive a restore.
+  Active streamed requests are stored as failed with
+  `error: :stream_interrupted`, and the ReAct strategy is restored as idle.
   """
-
-  require Logger
 
   alias Jido.AI.Request
   alias Jido.AI.ToolAdapter
 
   @strategy_key :__strategy__
 
-  @typedoc "Location of a runtime handle inside a term, outermost segment first."
-  @type handle_path :: [term()]
-
-  @typedoc "A non-serializable value found in a term."
-  @type handle :: {handle_path(), :pid | :port | :reference | :function}
-
-  # Strategy fields holding process handles, with the value each is reset to.
   @strategy_handle_resets %{
     react_worker_pid: nil,
     react_worker_status: :missing,
@@ -82,8 +19,6 @@ defmodule Jido.AI.Checkpoint do
     pending_input_server: nil
   }
 
-  # An in-flight ReAct run cannot continue after thaw. Reset its run-local
-  # logical state while preserving durable context, request traces, and config.
   @interrupted_run_resets %{
     status: :idle,
     iteration: 0,
@@ -112,111 +47,24 @@ defmodule Jido.AI.Checkpoint do
     pending_worker_start: nil
   }
 
-  @doc """
-  Removes every process-local runtime handle from agent state.
-
-  Operates on the checkpoint copy of the state; the live agent keeps its
-  handles.
-
-  ## Examples
-
-      iex> state = %{requests: %{"r1" => %{status: :pending, stream_to: {:pid, self()}}}}
-      iex> Jido.AI.Checkpoint.sanitize_state(state)
-      %{requests: %{"r1" => %{status: :failed, error: :stream_interrupted, stream_interrupted: true}}}
-  """
+  @doc false
   @spec sanitize_state(map()) :: map()
   def sanitize_state(state) when is_map(state) do
     state
-    |> Request.sanitize_requests(:checkpoint)
+    |> Request.sanitize_requests()
     |> update_strategy(&sanitize_strategy/1)
   end
 
   def sanitize_state(state), do: state
 
-  @doc """
-  Rebuilds derived runtime values dropped by `sanitize_state/1`.
-
-  Called on the restore path. Also scrubs stream sinks from legacy checkpoints
-  written before sanitization existed, so a decodable old payload still restores
-  without a stale pid.
-  """
-  @spec rehydrate_state(map()) :: map()
-  def rehydrate_state(state) when is_map(state) do
-    state
-    |> Request.sanitize_requests(:restore)
-    |> update_strategy(&rehydrate_strategy/1)
-  end
-
-  def rehydrate_state(state), do: state
-
-  @doc """
-  Returns true when a restored request lost its stream sink mid-flight.
-
-  ## Examples
-
-      iex> Jido.AI.Checkpoint.interrupted_request?(%{stream_interrupted: true})
-      true
-
-      iex> Jido.AI.Checkpoint.interrupted_request?(%{status: :completed})
-      false
-  """
-  @spec interrupted_request?(map() | nil) :: boolean()
-  def interrupted_request?(%{stream_interrupted: true}), do: true
-  def interrupted_request?(_request), do: false
-
-  @doc """
-  Walks `term` and returns every pid, port, reference, and anonymous function.
-
-  Paths read outermost segment first. Tuple elements appear as `{:elem, index}`,
-  list elements as `{:at, index}`, and struct contents are prefixed with the
-  struct module.
-
-  External function captures (`&Mod.fun/1`) are not reported: they encode as a
-  module/function/arity triple that `[:safe]` accepts.
-
-  ## Examples
-
-      iex> Jido.AI.Checkpoint.runtime_handles(%{a: %{b: [self()]}})
-      [{[:a, :b, {:at, 0}], :pid}]
-
-      iex> Jido.AI.Checkpoint.runtime_handles(%{ok: [1, "two", :three]})
-      []
-  """
-  @spec runtime_handles(term()) :: [handle()]
-  def runtime_handles(term), do: term |> collect_handles([], []) |> Enum.reverse()
-
-  @doc """
-  Formats `runtime_handles/1` output as a human-readable list.
-  """
-  @spec format_handles([handle()]) :: String.t()
-  def format_handles(handles) when is_list(handles) do
-    Enum.map_join(handles, ", ", fn {path, kind} -> "#{kind} at #{format_path(path)}" end)
-  end
-
   @doc false
-  @spec warn_on_residual_handles(module(), map()) :: :ok
-  def warn_on_residual_handles(agent_module, payload) do
-    case runtime_handles(payload) do
-      [] ->
-        :ok
-
-      handles ->
-        Logger.warning(
-          "#{inspect(agent_module)} checkpoint retains non-serializable runtime handles; " <>
-            "the payload will not decode with binary_to_term/2 [:safe] on another node: " <>
-            format_handles(handles)
-        )
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # Strategy state
-  # ---------------------------------------------------------------------------
+  @spec rehydrate_state(map()) :: map()
+  def rehydrate_state(state), do: sanitize_state(state)
 
   defp update_strategy(state, fun) do
     case Map.get(state, @strategy_key) do
       strategy when is_map(strategy) -> Map.put(state, @strategy_key, fun.(strategy))
-      _absent -> state
+      _other -> state
     end
   end
 
@@ -224,22 +72,11 @@ defmodule Jido.AI.Checkpoint do
     strategy
     |> reset_interrupted_run()
     |> reset_react_handles()
-    |> update_strategy_config(&restore_reqllm_tools/1)
-  end
-
-  defp rehydrate_strategy(strategy) do
-    strategy
-    |> reset_interrupted_run()
-    |> reset_react_handles()
-    |> update_strategy_config(&restore_reqllm_tools/1)
+    |> rebuild_reqllm_tools()
   end
 
   defp reset_interrupted_run(strategy) do
-    if react_run_active?(strategy) do
-      Map.merge(strategy, @interrupted_run_resets)
-    else
-      strategy
-    end
+    if react_run_active?(strategy), do: Map.merge(strategy, @interrupted_run_resets), else: strategy
   end
 
   defp react_run_active?(strategy) do
@@ -257,86 +94,9 @@ defmodule Jido.AI.Checkpoint do
     Map.has_key?(strategy, :react_worker_pid) or Map.has_key?(strategy, :react_worker_status)
   end
 
-  defp update_strategy_config(strategy, fun) do
-    case Map.get(strategy, :config) do
-      config when is_map(config) -> Map.put(strategy, :config, fun.(config))
-      _absent -> strategy
-    end
+  defp rebuild_reqllm_tools(%{config: %{tools: tools} = config} = strategy) when is_list(tools) do
+    %{strategy | config: Map.put(config, :reqllm_tools, ToolAdapter.from_actions(tools))}
   end
 
-  # `reqllm_tools` is a pure projection of `config.tools`. Rebuild it to replace
-  # callbacks created by older releases and to restore payloads written by an
-  # earlier version of this checkpoint sanitizer that dropped the field.
-  defp restore_reqllm_tools(%{tools: tools} = config) when is_list(tools) do
-    Map.put(config, :reqllm_tools, ToolAdapter.from_actions(tools))
-  end
-
-  defp restore_reqllm_tools(config), do: config
-
-  # ---------------------------------------------------------------------------
-  # Handle scanning
-  # ---------------------------------------------------------------------------
-
-  defp collect_handles(term, path, acc) when is_pid(term), do: [{Enum.reverse(path), :pid} | acc]
-  defp collect_handles(term, path, acc) when is_port(term), do: [{Enum.reverse(path), :port} | acc]
-
-  defp collect_handles(term, path, acc) when is_reference(term) do
-    [{Enum.reverse(path), :reference} | acc]
-  end
-
-  defp collect_handles(term, path, acc) when is_function(term) do
-    if external_capture?(term), do: acc, else: [{Enum.reverse(path), :function} | acc]
-  end
-
-  defp collect_handles(%module{} = term, path, acc) do
-    term |> Map.from_struct() |> collect_handles([module | path], acc)
-  end
-
-  defp collect_handles(term, path, acc) when is_map(term) do
-    Enum.reduce(term, acc, fn {key, value}, inner ->
-      inner = collect_handles(key, [{:key, key} | path], inner)
-      collect_handles(value, [key | path], inner)
-    end)
-  end
-
-  defp collect_handles(term, path, acc) when is_list(term) do
-    collect_list_handles(term, 0, path, acc)
-  end
-
-  defp collect_handles(term, path, acc) when is_tuple(term) do
-    term
-    |> Tuple.to_list()
-    |> Enum.with_index()
-    |> Enum.reduce(acc, fn {value, index}, inner -> collect_handles(value, [{:elem, index} | path], inner) end)
-  end
-
-  defp collect_handles(_term, _path, acc), do: acc
-
-  defp collect_list_handles([], _index, _path, acc), do: acc
-
-  defp collect_list_handles([head | tail], index, path, acc) do
-    acc = collect_handles(head, [{:at, index} | path], acc)
-    collect_list_handles(tail, index + 1, path, acc)
-  end
-
-  defp collect_list_handles(tail, index, path, acc) do
-    collect_handles(tail, [{:tail, index} | path], acc)
-  end
-
-  defp external_capture?(fun) do
-    Function.info(fun, :type) == {:type, :external}
-  end
-
-  defp format_path([]), do: "<root>"
-
-  defp format_path(path) do
-    Enum.map_join(path, ".", fn
-      {:at, index} -> "[#{index}]"
-      {:tail, index} -> "[tail@#{index}]"
-      {:key, key} -> "[key #{inspect(key)}]"
-      {:elem, index} -> "{#{index}}"
-      segment when is_binary(segment) -> segment
-      segment -> inspect(segment)
-    end)
-  end
+  defp rebuild_reqllm_tools(strategy), do: strategy
 end

--- a/lib/jido_ai/plugins/task_supervisor.ex
+++ b/lib/jido_ai/plugins/task_supervisor.ex
@@ -58,14 +58,7 @@ defmodule Jido.AI.Plugins.TaskSupervisor do
     end
   end
 
-  @doc """
-  Drops the supervisor pid from checkpoint payloads.
-
-  The supervisor is process-local: it dies with the agent, and an encoded pid
-  makes the checkpoint undecodable by `:erlang.binary_to_term/2` with `[:safe]`
-  once the writing node is gone. Dropping the key lets `new/1` mount a fresh
-  supervisor during restore. See `Jido.AI.Checkpoint`.
-  """
+  @doc false
   @impl Jido.Plugin
   @spec on_checkpoint(term(), map()) :: :drop
   def on_checkpoint(_plugin_state, _context), do: :drop

--- a/lib/jido_ai/plugins/task_supervisor.ex
+++ b/lib/jido_ai/plugins/task_supervisor.ex
@@ -58,6 +58,18 @@ defmodule Jido.AI.Plugins.TaskSupervisor do
     end
   end
 
+  @doc """
+  Drops the supervisor pid from checkpoint payloads.
+
+  The supervisor is process-local: it dies with the agent, and an encoded pid
+  makes the checkpoint undecodable by `:erlang.binary_to_term/2` with `[:safe]`
+  once the writing node is gone. Dropping the key lets `new/1` mount a fresh
+  supervisor during restore. See `Jido.AI.Checkpoint`.
+  """
+  @impl Jido.Plugin
+  @spec on_checkpoint(term(), map()) :: :drop
+  def on_checkpoint(_plugin_state, _context), do: :drop
+
   # Starts a new anonymous Task.Supervisor.
   defp start_supervisor do
     Task.Supervisor.start_link()

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -2549,7 +2549,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
   defp normalize_tool_result(result), do: Error.normalize_result(result, :tool_error, "Tool execution failed")
 
   defp request_stream_to(agent, request_id) when is_binary(request_id) do
-    get_in(agent.state, [:requests, request_id, :stream_to])
+    Jido.AI.Request.stream_sink(agent, request_id)
   end
 
   defp request_stream_to(_agent, _request_id), do: nil

--- a/lib/jido_ai/request.ex
+++ b/lib/jido_ai/request.ex
@@ -69,6 +69,7 @@ defmodule Jido.AI.Request do
 
   @default_timeout 30_000
   @default_max_requests 100
+  @stream_interrupted_error :stream_interrupted
 
   # A request in one of these states will never emit another runtime event, so
   # its stream sink is dropped rather than carried in agent state.
@@ -511,9 +512,10 @@ defmodule Jido.AI.Request do
   that created them. They must never reach durable storage — see
   `Jido.AI.Checkpoint` for why an encoded pid makes a checkpoint undecodable.
 
-  Requests that are still in flight are additionally flagged with
-  `stream_interrupted: true`, recording that a consumer was attached and will
-  never receive the remaining events.
+  Requests that are still in flight are additionally failed with
+  `error: :stream_interrupted` and flagged with `stream_interrupted: true`.
+  The failed status lets `await/2` return immediately after restore instead of
+  waiting for a run that no longer exists.
 
   ## Modes
 
@@ -526,7 +528,7 @@ defmodule Jido.AI.Request do
 
       iex> state = %{requests: %{"r1" => %{status: :pending, stream_to: {:pid, self()}}}}
       iex> Jido.AI.Request.sanitize_requests(state, :checkpoint)
-      %{requests: %{"r1" => %{status: :pending, stream_interrupted: true}}}
+      %{requests: %{"r1" => %{status: :failed, error: :stream_interrupted, stream_interrupted: true}}}
   """
   @spec sanitize_requests(map(), :checkpoint | :restore) :: map()
   def sanitize_requests(state, mode) when is_map(state) and mode in [:checkpoint, :restore] do
@@ -547,13 +549,22 @@ defmodule Jido.AI.Request do
     |> mark_interrupted_if_active()
   end
 
+  defp sanitize_request(%{stream_interrupted: true} = request) do
+    mark_interrupted_if_active(request)
+  end
+
   defp sanitize_request(request), do: request
 
   defp mark_interrupted_if_active(%{status: status} = request) when status in @terminal_statuses do
     request
   end
 
-  defp mark_interrupted_if_active(request), do: Map.put(request, :stream_interrupted, true)
+  defp mark_interrupted_if_active(request) do
+    request
+    |> Map.put(:status, :failed)
+    |> Map.put(:error, @stream_interrupted_error)
+    |> Map.put(:stream_interrupted, true)
+  end
 
   defp drop_stream_sink(request) when is_map(request), do: Map.delete(request, :stream_to)
 

--- a/lib/jido_ai/request.ex
+++ b/lib/jido_ai/request.ex
@@ -492,12 +492,7 @@ defmodule Jido.AI.Request do
     %{agent | state: state}
   end
 
-  @doc """
-  Returns the stream sink recorded for a request, or `nil`.
-
-  Read the sink *before* moving a request to a terminal state: the terminal
-  transition drops it so no pid reaches a checkpoint.
-  """
+  @doc false
   @spec stream_sink(struct(), String.t()) :: RequestStream.sink() | nil
   def stream_sink(agent, request_id) when is_binary(request_id) do
     get_in(agent.state, [:requests, request_id, :stream_to])
@@ -505,33 +500,9 @@ defmodule Jido.AI.Request do
 
   def stream_sink(_agent, _request_id), do: nil
 
-  @doc """
-  Removes request stream sinks from agent state for persistence or restore.
-
-  Stream sinks are `{:pid, pid}` handles that are only meaningful inside the VM
-  that created them. They must never reach durable storage — see
-  `Jido.AI.Checkpoint` for why an encoded pid makes a checkpoint undecodable.
-
-  Requests that are still in flight are additionally failed with
-  `error: :stream_interrupted` and flagged with `stream_interrupted: true`.
-  The failed status lets `await/2` return immediately after restore instead of
-  waiting for a run that no longer exists.
-
-  ## Modes
-
-  - `:checkpoint` - sanitizing state on its way into a checkpoint payload
-  - `:restore` - scrubbing a payload written before sanitization existed
-
-  Both modes behave identically; the mode is kept for call-site clarity.
-
-  ## Examples
-
-      iex> state = %{requests: %{"r1" => %{status: :pending, stream_to: {:pid, self()}}}}
-      iex> Jido.AI.Request.sanitize_requests(state, :checkpoint)
-      %{requests: %{"r1" => %{status: :failed, error: :stream_interrupted, stream_interrupted: true}}}
-  """
-  @spec sanitize_requests(map(), :checkpoint | :restore) :: map()
-  def sanitize_requests(state, mode) when is_map(state) and mode in [:checkpoint, :restore] do
+  @doc false
+  @spec sanitize_requests(map()) :: map()
+  def sanitize_requests(state) when is_map(state) do
     case Map.get(state, :requests) do
       requests when is_map(requests) ->
         Map.put(state, :requests, Map.new(requests, fn {id, req} -> {id, sanitize_request(req)} end))
@@ -541,7 +512,7 @@ defmodule Jido.AI.Request do
     end
   end
 
-  def sanitize_requests(state, _mode), do: state
+  def sanitize_requests(state), do: state
 
   defp sanitize_request(%{stream_to: _sink} = request) do
     request

--- a/lib/jido_ai/request.ex
+++ b/lib/jido_ai/request.ex
@@ -70,6 +70,10 @@ defmodule Jido.AI.Request do
   @default_timeout 30_000
   @default_max_requests 100
 
+  # A request in one of these states will never emit another runtime event, so
+  # its stream sink is dropped rather than carried in agent state.
+  @terminal_statuses [:completed, :failed, :timeout]
+
   # ---------------------------------------------------------------------------
   # Handle Struct
   # ---------------------------------------------------------------------------
@@ -372,6 +376,13 @@ defmodule Jido.AI.Request do
 
   Called in `on_before_cmd/2` when a request starts.
 
+  ## Stream sinks
+
+  When `:stream_to` is given, the sink is stored on the request record so the
+  strategy can route runtime events to it. The sink is a live pid, so it is
+  dropped again as soon as the request reaches a terminal state, and it is never
+  written to a checkpoint — see `Jido.AI.Checkpoint`.
+
   ## Examples
 
       def on_before_cmd(agent, {:ai_react_start, %{query: query, request_id: req_id}} = action) do
@@ -437,6 +448,7 @@ defmodule Jido.AI.Request do
         req ->
           %{req | status: :completed, result: result, completed_at: System.system_time(:millisecond)}
           |> Map.put(:meta, Map.merge(Map.get(req, :meta, %{}), meta))
+          |> drop_stream_sink()
       end)
       |> Map.put(:last_answer, last_answer)
       |> Map.put(:completed, true)
@@ -455,7 +467,9 @@ defmodule Jido.AI.Request do
   @doc """
   Marks a request as failed with an error.
 
-  Called when a request encounters an error.
+  Called when a request encounters an error. Cancellation is recorded through
+  this function with a `{:cancelled, reason}` error, so completed, failed, and
+  cancelled requests all drop their stream sink here.
   """
   @spec fail_request(struct(), String.t(), any()) :: struct()
   def fail_request(agent, request_id, error) do
@@ -470,11 +484,78 @@ defmodule Jido.AI.Request do
 
         req ->
           %{req | status: :failed, error: error, completed_at: System.system_time(:millisecond)}
+          |> drop_stream_sink()
       end)
       |> Map.put(:completed, true)
 
     %{agent | state: state}
   end
+
+  @doc """
+  Returns the stream sink recorded for a request, or `nil`.
+
+  Read the sink *before* moving a request to a terminal state: the terminal
+  transition drops it so no pid reaches a checkpoint.
+  """
+  @spec stream_sink(struct(), String.t()) :: RequestStream.sink() | nil
+  def stream_sink(agent, request_id) when is_binary(request_id) do
+    get_in(agent.state, [:requests, request_id, :stream_to])
+  end
+
+  def stream_sink(_agent, _request_id), do: nil
+
+  @doc """
+  Removes request stream sinks from agent state for persistence or restore.
+
+  Stream sinks are `{:pid, pid}` handles that are only meaningful inside the VM
+  that created them. They must never reach durable storage — see
+  `Jido.AI.Checkpoint` for why an encoded pid makes a checkpoint undecodable.
+
+  Requests that are still in flight are additionally flagged with
+  `stream_interrupted: true`, recording that a consumer was attached and will
+  never receive the remaining events.
+
+  ## Modes
+
+  - `:checkpoint` - sanitizing state on its way into a checkpoint payload
+  - `:restore` - scrubbing a payload written before sanitization existed
+
+  Both modes behave identically; the mode is kept for call-site clarity.
+
+  ## Examples
+
+      iex> state = %{requests: %{"r1" => %{status: :pending, stream_to: {:pid, self()}}}}
+      iex> Jido.AI.Request.sanitize_requests(state, :checkpoint)
+      %{requests: %{"r1" => %{status: :pending, stream_interrupted: true}}}
+  """
+  @spec sanitize_requests(map(), :checkpoint | :restore) :: map()
+  def sanitize_requests(state, mode) when is_map(state) and mode in [:checkpoint, :restore] do
+    case Map.get(state, :requests) do
+      requests when is_map(requests) ->
+        Map.put(state, :requests, Map.new(requests, fn {id, req} -> {id, sanitize_request(req)} end))
+
+      _absent ->
+        state
+    end
+  end
+
+  def sanitize_requests(state, _mode), do: state
+
+  defp sanitize_request(%{stream_to: _sink} = request) do
+    request
+    |> drop_stream_sink()
+    |> mark_interrupted_if_active()
+  end
+
+  defp sanitize_request(request), do: request
+
+  defp mark_interrupted_if_active(%{status: status} = request) when status in @terminal_statuses do
+    request
+  end
+
+  defp mark_interrupted_if_active(request), do: Map.put(request, :stream_interrupted, true)
+
+  defp drop_stream_sink(request) when is_map(request), do: Map.delete(request, :stream_to)
 
   @doc """
   Gets a request by ID from agent state.

--- a/lib/jido_ai/request/stream.ex
+++ b/lib/jido_ai/request/stream.ex
@@ -80,10 +80,6 @@ defmodule Jido.AI.Request.Stream do
 
   @doc """
   Creates a synthetic terminal cancellation event.
-
-  Emitted by the agent when a request is cancelled, so a consumer's stream halts
-  on the cancel itself rather than waiting for a worker acknowledgement that may
-  never arrive.
   """
   @spec cancelled_event(String.t(), term(), keyword()) :: Event.t()
   def cancelled_event(request_id, reason, opts \\ []) when is_binary(request_id) do

--- a/lib/jido_ai/request/stream.ex
+++ b/lib/jido_ai/request/stream.ex
@@ -79,6 +79,18 @@ defmodule Jido.AI.Request.Stream do
   end
 
   @doc """
+  Creates a synthetic terminal cancellation event.
+
+  Emitted by the agent when a request is cancelled, so a consumer's stream halts
+  on the cancel itself rather than waiting for a worker acknowledgement that may
+  never arrive.
+  """
+  @spec cancelled_event(String.t(), term(), keyword()) :: Event.t()
+  def cancelled_event(request_id, reason, opts \\ []) when is_binary(request_id) do
+    new_event(request_id, :request_cancelled, %{reason: reason}, opts)
+  end
+
+  @doc """
   Returns true when the event kind terminates a request stream.
   """
   @spec terminal_kind?(atom()) :: boolean()

--- a/lib/jido_ai/tool_adapter.ex
+++ b/lib/jido_ai/tool_adapter.ex
@@ -141,10 +141,7 @@ defmodule Jido.AI.ToolAdapter do
       name: apply_prefix(action_module.name(), prefix),
       description: action_module.description(),
       parameter_schema: build_json_schema(action_module.schema()),
-      # Jido owns tool execution, so ReqLLM only needs a serializable callback
-      # placeholder. These atoms already exist wherever a ReqLLM.Tool struct can
-      # be decoded, which keeps old checkpoint readers compatible with [:safe].
-      callback: {ReqLLM.Tool, :new},
+      callback: {__MODULE__, :noop_callback},
       strict: strict
     )
   end
@@ -330,6 +327,10 @@ defmodule Jido.AI.ToolAdapter do
   defp infer_strict?(module) do
     if function_exported?(module, :strict?, 0), do: module.strict?(), else: false
   end
+
+  @doc false
+  @spec noop_callback(map()) :: {:ok, map()}
+  def noop_callback(_args), do: {:ok, %{}}
 
   defp apply_prefix(name, nil), do: name
   defp apply_prefix(name, prefix) when is_binary(prefix), do: prefix <> name

--- a/lib/jido_ai/tool_adapter.ex
+++ b/lib/jido_ai/tool_adapter.ex
@@ -141,7 +141,10 @@ defmodule Jido.AI.ToolAdapter do
       name: apply_prefix(action_module.name(), prefix),
       description: action_module.description(),
       parameter_schema: build_json_schema(action_module.schema()),
-      callback: &noop_callback/1,
+      # Jido owns tool execution, so ReqLLM only needs a serializable callback
+      # placeholder. These atoms already exist wherever a ReqLLM.Tool struct can
+      # be decoded, which keeps old checkpoint readers compatible with [:safe].
+      callback: {ReqLLM.Tool, :new},
       strict: strict
     )
   end
@@ -327,8 +330,6 @@ defmodule Jido.AI.ToolAdapter do
   defp infer_strict?(module) do
     if function_exported?(module, :strict?, 0), do: module.strict?(), else: false
   end
-
-  defp noop_callback(_args), do: {:ok, %{}}
 
   defp apply_prefix(name, nil), do: name
   defp apply_prefix(name, prefix) when is_binary(prefix), do: prefix <> name

--- a/test/jido_ai/checkpoint_test.exs
+++ b/test/jido_ai/checkpoint_test.exs
@@ -1,0 +1,623 @@
+defmodule Jido.AI.CheckpointTest do
+  @moduledoc """
+  Regression coverage for agentjido/jido_ai#327.
+
+  Request stream sinks (`stream_to: {:pid, pid}`) used to be written into
+  durable checkpoints. A pid encodes its node atom, and
+  `:erlang.binary_to_term/2` with `[:safe]` refuses to create that atom in a VM
+  that has never seen it — so a checkpoint became permanently undecodable after
+  a distribution config change, surfacing as `{:error, :invalid_term}`.
+  """
+
+  use Jido.AI.TestCase, async: false
+
+  alias Jido.AI.Checkpoint
+  alias Jido.AI.Request
+
+  doctest Jido.AI.Checkpoint
+  doctest Jido.AI.Request, only: [sanitize_requests: 2]
+
+  @gate_owner :jido_ai_checkpoint_test_gate_owner
+
+  # ---------------------------------------------------------------------------
+  # Fixtures
+  # ---------------------------------------------------------------------------
+
+  defmodule ReadTool do
+    @moduledoc false
+    use Jido.Action,
+      name: "read",
+      description: "Reads a test path",
+      schema: Zoi.object(%{path: Zoi.string()})
+
+    def run(%{path: path}, _context), do: {:ok, %{body: "hello from #{path}"}}
+  end
+
+  defmodule GateTool do
+    @moduledoc false
+    use Jido.Action,
+      name: "gate",
+      description: "Blocks until the test releases it",
+      schema: Zoi.object(%{token: Zoi.string()})
+
+    # Suspends the ReAct run inside tool execution so the test can take a
+    # checkpoint while the request is genuinely still in flight. The owner is
+    # reached by registered name rather than :tool_context, so no test pid is
+    # smuggled into agent state.
+    def run(%{token: token}, _context) do
+      send(Jido.AI.CheckpointTest.gate_owner(), {:gate_entered, token, self()})
+
+      receive do
+        {:gate_release, ^token} -> {:ok, %{released: true}}
+      after
+        10_000 -> {:error, :gate_timeout}
+      end
+    end
+  end
+
+  defmodule CheckpointAgent do
+    @moduledoc false
+    use Jido.AI.Agent,
+      name: "checkpoint_test_agent",
+      tools: [ReadTool, GateTool],
+      token_secret: "test-secret-that-is-long-enough-123"
+  end
+
+  @doc false
+  def gate_owner, do: @gate_owner
+
+  setup do
+    if is_nil(Process.whereis(Jido)) do
+      start_supervised!({Jido, name: Jido})
+    end
+
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp start_agent do
+    suffix = System.unique_integer([:positive, :monotonic])
+    registry = Module.concat(__MODULE__, :"Registry#{suffix}")
+    start_supervised!({Registry, keys: :unique, name: registry}, id: {:registry, suffix})
+
+    {:ok, pid} =
+      Jido.AgentServer.start_link(
+        agent: CheckpointAgent,
+        id: "checkpoint-agent-#{suffix}",
+        registry: registry
+      )
+
+    on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+    pid
+  end
+
+  defp server_agent(pid) do
+    {:ok, state} = Jido.AgentServer.state(pid)
+    if is_map(state) and Map.has_key?(state, :agent), do: state.agent, else: state
+  end
+
+  defp request_record(payload, request_id), do: get_in(payload, [:state, :requests, request_id])
+
+  # ---------------------------------------------------------------------------
+  # Acceptance criterion 1 - terminal states drop the stream sink
+  # ---------------------------------------------------------------------------
+
+  describe "terminal request states drop the stream sink" do
+    test "complete_request/4 removes stream_to" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_done", "query", stream_to: {:pid, self()})
+
+      assert agent.state.requests["req_done"].stream_to == {:pid, self()}
+
+      agent = Request.complete_request(agent, "req_done", "answer")
+
+      assert agent.state.requests["req_done"].status == :completed
+      refute Map.has_key?(agent.state.requests["req_done"], :stream_to)
+    end
+
+    test "fail_request/3 removes stream_to" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_failed", "query", stream_to: {:pid, self()})
+        |> Request.fail_request("req_failed", {:failed, :boom, nil})
+
+      assert agent.state.requests["req_failed"].status == :failed
+      refute Map.has_key?(agent.state.requests["req_failed"], :stream_to)
+    end
+
+    test "cancellation removes stream_to and emits a terminal event to the sink" do
+      tag = Request.Stream.message_tag()
+
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_cancel", "query", stream_to: {:pid, self()})
+
+      {:ok, agent, _directives} =
+        CheckpointAgent.on_after_cmd(
+          agent,
+          {:ai_react_cancel, %{request_id: "req_cancel", reason: :user_cancelled}},
+          []
+        )
+
+      assert agent.state.requests["req_cancel"].status == :failed
+      assert agent.state.requests["req_cancel"].error == {:cancelled, :user_cancelled}
+      refute Map.has_key?(agent.state.requests["req_cancel"], :stream_to)
+
+      # The consumer's enumerable halts on this event instead of waiting for a
+      # worker acknowledgement that a cancelled run may never send.
+      assert_receive {^tag,
+                      %Jido.AI.Runtime.Event{
+                        kind: :request_cancelled,
+                        request_id: "req_cancel",
+                        data: %{reason: :user_cancelled}
+                      }}
+
+      assert Request.Stream.terminal_kind?(:request_cancelled)
+    end
+
+    test "request-error rejection removes stream_to after notifying the sink" do
+      tag = Request.Stream.message_tag()
+
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_busy", "query", stream_to: {:pid, self()})
+
+      {:ok, agent, _action} =
+        CheckpointAgent.on_before_cmd(
+          agent,
+          {:ai_react_request_error, %{request_id: "req_busy", reason: :busy, message: "busy"}}
+        )
+
+      assert agent.state.requests["req_busy"].status == :failed
+      refute Map.has_key?(agent.state.requests["req_busy"], :stream_to)
+      assert_receive {^tag, %Jido.AI.Runtime.Event{kind: :request_failed, request_id: "req_busy"}}
+    end
+
+    test "failing an already-completed request leaves the completed record intact" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_done", "query", stream_to: {:pid, self()})
+        |> Request.complete_request("req_done", "answer")
+        |> Request.fail_request("req_done", {:failed, :late, nil})
+
+      assert agent.state.requests["req_done"].status == :completed
+      assert agent.state.requests["req_done"].result == "answer"
+      refute Map.has_key?(agent.state.requests["req_done"], :stream_to)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Handle scanning - the invariant the other tests rely on
+  # ---------------------------------------------------------------------------
+
+  describe "runtime_handles/1" do
+    test "reports pids, ports, references, and anonymous functions with their paths" do
+      port = Port.open({:spawn, "cat"}, [:binary])
+      on_exit(fn -> if Port.info(port), do: Port.close(port) end)
+
+      term = %{
+        sink: {:pid, self()},
+        nested: [%{ref: make_ref()}],
+        port: port,
+        fun: fn -> :anonymous end
+      }
+
+      handles = Checkpoint.runtime_handles(term)
+
+      assert {[:sink, {:elem, 1}], :pid} in handles
+      assert {[:nested, {:at, 0}, :ref], :reference} in handles
+      assert {[:port], :port} in handles
+      assert {[:fun], :function} in handles
+      assert length(handles) == 4
+    end
+
+    test "ignores plain data and external function captures" do
+      # &Mod.fun/arity encodes as a module/function/arity triple, which [:safe]
+      # accepts; only anonymous funs are rejected outright.
+      term = %{numbers: [1, 2], text: "ok", atoms: {:a, :b}, capture: &Enum.map/2}
+
+      assert Checkpoint.runtime_handles(term) == []
+    end
+
+    test "descends into structs" do
+      event =
+        Jido.AI.Runtime.Event.new(%{
+          seq: 0,
+          run_id: "run",
+          request_id: "req",
+          iteration: 0,
+          kind: :request_completed,
+          data: %{pid: self()}
+        })
+
+      assert [{[Jido.AI.Runtime.Event, :data, :pid], :pid}] = Checkpoint.runtime_handles(event)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Acceptance criterion 2 - payloads are pid-free, active requests included
+  # ---------------------------------------------------------------------------
+
+  describe "checkpoint payloads" do
+    test "an active streamed request contributes no pid and is flagged interrupted" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_active", "query", stream_to: {:pid, self()})
+
+      # The live agent keeps its sink; only the payload is sanitized.
+      assert agent.state.requests["req_active"].stream_to == {:pid, self()}
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+      record = request_record(payload, "req_active")
+
+      assert record.status == :pending
+      refute Map.has_key?(record, :stream_to)
+      assert record.stream_interrupted == true
+      assert Checkpoint.runtime_handles(payload) == []
+      assert agent.state.requests["req_active"].stream_to == {:pid, self()}
+    end
+
+    test "a completed streamed request contributes no pid and is not flagged" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_done", "query", stream_to: {:pid, self()})
+        |> Request.complete_request("req_done", "answer")
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+      record = request_record(payload, "req_done")
+
+      assert record.status == :completed
+      refute Map.has_key?(record, :stream_to)
+      refute Map.has_key?(record, :stream_interrupted)
+      assert Checkpoint.runtime_handles(payload) == []
+    end
+
+    test "strategy worker handles and task supervisor are stripped" do
+      agent = CheckpointAgent.new()
+
+      agent =
+        put_in(agent.state.__strategy__, %{
+          agent.state.__strategy__
+          | react_worker_pid: self(),
+            react_worker_status: :running,
+            pending_input_server: self(),
+            pending_worker_start: %{context: %{state: %{sink: self()}}}
+        })
+
+      assert Checkpoint.runtime_handles(agent.state) != []
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+      strategy = payload.state.__strategy__
+
+      assert strategy.react_worker_pid == nil
+      assert strategy.react_worker_status == :missing
+      assert strategy.pending_input_server == nil
+      assert strategy.pending_worker_start == nil
+      refute Map.has_key?(payload.state, :__task_supervisor_skill__)
+      assert Checkpoint.runtime_handles(payload) == []
+    end
+
+    test "the scan is not vacuous - a sink left in a payload is detected" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_leak", "query", stream_to: {:pid, self()})
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+
+      leaky = put_in(payload, [:state, :requests, "req_leak", :stream_to], {:pid, self()})
+
+      assert [{path, :pid}] = Checkpoint.runtime_handles(leaky)
+      assert path == [:state, :requests, "req_leak", :stream_to, {:elem, 1}]
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Acceptance criterion 3 - decodable in a fresh VM with [:safe]
+  # ---------------------------------------------------------------------------
+
+  describe "external term encoding" do
+    test "a pid from a vanished node is exactly what [:safe] rejects" do
+      # Reproduces the reported failure without a second VM: hand-build the
+      # external representation of a pid living on a node this VM has never
+      # seen. [:safe] refuses to create the node atom, which is how a checkpoint
+      # written before a distribution change becomes {:error, :invalid_term}.
+      # The node name must be unique per run - once the atom exists, [:safe]
+      # would happily decode the same bytes.
+      node_name = "gone#{System.unique_integer([:positive])}@nowhere"
+      size = byte_size(node_name)
+      encoded_pid = <<131, 88, 119, size, node_name::binary, 1::32, 0::32, 0::32>>
+
+      assert_raise ArgumentError, fn -> :erlang.binary_to_term(encoded_pid, [:safe]) end
+
+      # Same bytes decode once the atom exists, confirming the node atom - not
+      # the pid itself - is what makes the payload unreadable.
+      assert is_pid(:erlang.binary_to_term(encoded_pid))
+      assert is_pid(:erlang.binary_to_term(encoded_pid, [:safe]))
+    end
+
+    test "anonymous tool callbacks live in agent state but never reach the payload" do
+      # ReqLLM.Tool.callback is an anonymous fun, and [:safe] rejects anonymous
+      # funs outright in a VM that has not itself created them - no node atom
+      # involved. config.reqllm_tools is therefore dropped here and rebuilt on
+      # restore from config.tools.
+      agent = CheckpointAgent.new()
+
+      assert Enum.any?(Checkpoint.runtime_handles(agent.state), fn {_path, kind} -> kind == :function end)
+      assert agent.state.__strategy__.config.reqllm_tools != []
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+
+      assert Checkpoint.runtime_handles(payload) == []
+    end
+
+    test "a checkpoint from a streamed request round-trips through [:safe]" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_active", "query", stream_to: {:pid, self()})
+        |> Request.start_request("req_done", "query", stream_to: {:pid, self()})
+        |> Request.complete_request("req_done", "answer")
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+
+      # No pid means no foreign node atom, and no anonymous fun means nothing
+      # [:safe] rejects unconditionally - together these are what make the
+      # payload readable in a VM that never saw the writing node.
+      assert Checkpoint.runtime_handles(payload) == []
+
+      decoded = :erlang.binary_to_term(:erlang.term_to_binary(payload), [:safe])
+
+      assert decoded == payload
+      assert decoded.state.requests["req_active"].stream_interrupted == true
+      assert decoded.state.requests["req_done"].status == :completed
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Acceptance criterion 4 - restore behaviour is deterministic
+  # ---------------------------------------------------------------------------
+
+  describe "restore" do
+    test "an interrupted streamed request stays pending, unstreamable, and flagged" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_active", "query", stream_to: {:pid, self()})
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+      {:ok, restored} = CheckpointAgent.restore(payload, %{})
+
+      record = restored.state.requests["req_active"]
+
+      assert record.status == :pending
+      refute Map.has_key?(record, :stream_to)
+      assert Checkpoint.interrupted_request?(record)
+      assert Request.stream_sink(restored, "req_active") == nil
+
+      # Nothing is delivered to the original consumer after a thaw.
+      assert Request.Stream.send_event(Request.stream_sink(restored, "req_active"), %{
+               seq: 0,
+               run_id: "req_active",
+               request_id: "req_active",
+               iteration: 0,
+               kind: :request_completed,
+               data: %{}
+             }) == :ok
+
+      refute_receive {_tag, %Jido.AI.Runtime.Event{}}, 50
+    end
+
+    test "a completed request restores without an interrupted flag" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_done", "query", stream_to: {:pid, self()})
+        |> Request.complete_request("req_done", "answer")
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+      {:ok, restored} = CheckpointAgent.restore(payload, %{})
+
+      record = restored.state.requests["req_done"]
+
+      assert record.status == :completed
+      assert record.result == "answer"
+      refute Checkpoint.interrupted_request?(record)
+    end
+
+    test "a legacy payload that still carries a sink is scrubbed on restore" do
+      # Checkpoints written before this fix may already be on disk. If they are
+      # decodable at all, restore must not hand back a stale pid.
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_legacy", "query", stream_to: {:pid, self()})
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+
+      legacy =
+        payload
+        |> put_in([:state, :requests, "req_legacy", :stream_to], {:pid, self()})
+        |> update_in([:state, :requests, "req_legacy"], &Map.delete(&1, :stream_interrupted))
+
+      {:ok, restored} = CheckpointAgent.restore(legacy, %{})
+
+      assert Request.stream_sink(restored, "req_legacy") == nil
+      assert Checkpoint.interrupted_request?(restored.state.requests["req_legacy"])
+    end
+
+    test "await/2 on an interrupted request times out instead of blocking forever" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("req_interrupted", "query", stream_to: {:pid, self()})
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+
+      suffix = System.unique_integer([:positive, :monotonic])
+      {:ok, restored} = CheckpointAgent.restore(%{payload | id: "interrupted-agent-#{suffix}"}, %{})
+
+      registry = Module.concat(__MODULE__, :"InterruptedRegistry#{suffix}")
+      start_supervised!({Registry, keys: :unique, name: registry}, id: {:interrupted_registry, suffix})
+
+      {:ok, pid} =
+        Jido.AgentServer.start_link(
+          agent: restored,
+          agent_module: CheckpointAgent,
+          registry: registry
+        )
+
+      on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+
+      # The run backing this request died with the previous VM, so awaiting it
+      # resolves deterministically rather than hanging on a run that is gone.
+      handle = Request.Handle.new("req_interrupted", pid, "query")
+
+      assert {:error, :timeout} = Request.await(handle, timeout: 200)
+    end
+
+    test "derived runtime values dropped from the payload are rebuilt" do
+      agent = CheckpointAgent.new()
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+
+      refute Map.has_key?(payload.state.__strategy__.config, :reqllm_tools)
+
+      {:ok, restored} = CheckpointAgent.restore(payload, %{})
+      config = restored.state.__strategy__.config
+
+      assert length(config.reqllm_tools) == length(config.tools)
+      assert Enum.all?(config.reqllm_tools, &is_struct(&1, ReqLLM.Tool))
+      assert Enum.sort(Enum.map(config.reqllm_tools, & &1.name)) == ["gate", "read"]
+
+      # A fresh, live task supervisor replaces the one dropped at checkpoint.
+      assert is_pid(restored.state.__task_supervisor_skill__.supervisor)
+      assert Process.alive?(restored.state.__task_supervisor_skill__.supervisor)
+      assert restored.state.__strategy__.react_worker_pid == nil
+      assert restored.state.__strategy__.react_worker_status == :missing
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Acceptance criterion 5 - streaming plus checkpoint/restore, end to end
+  # ---------------------------------------------------------------------------
+
+  describe "request streaming with checkpoint and restore" do
+    test "a checkpoint taken mid-stream is pid-free while the request is in flight" do
+      Process.register(self(), @gate_owner)
+      on_exit(fn -> if Process.whereis(@gate_owner) == self(), do: Process.unregister(@gate_owner) end)
+
+      token = "gate-#{System.unique_integer([:positive])}"
+
+      script =
+        expect_react do
+          user("run the gate")
+          call("gate", %{token: token})
+          answer("gate released")
+        end
+
+      pid = start_agent()
+
+      {:ok, %{request: request, events: events}} =
+        CheckpointAgent.ask_stream(
+          pid,
+          "run the gate",
+          react_opts(script) ++ [stream_event_timeout_ms: 15_000]
+        )
+
+      # The run is now suspended inside GateTool, so the request is genuinely
+      # active with a live sink recorded in agent state.
+      assert_receive {:gate_entered, ^token, tool_pid}, 10_000
+
+      live = server_agent(pid)
+      assert Request.stream_sink(live, request.id) == {:pid, self()}
+      assert live.state.requests[request.id].status == :pending
+      assert is_pid(live.state.__strategy__.react_worker_pid)
+
+      {:ok, payload} = CheckpointAgent.checkpoint(live, %{})
+      record = request_record(payload, request.id)
+
+      assert record.status == :pending
+      refute Map.has_key?(record, :stream_to)
+      assert record.stream_interrupted == true
+      assert Checkpoint.runtime_handles(payload) == []
+      assert :erlang.binary_to_term(:erlang.term_to_binary(payload), [:safe]) == payload
+
+      send(tool_pid, {:gate_release, token})
+
+      # The live run is unaffected by taking a checkpoint.
+      kinds = events |> Enum.to_list() |> Enum.map(& &1.kind)
+      assert :request_completed in kinds
+      assert {:ok, "gate released"} = CheckpointAgent.await(request, timeout: 15_000)
+    end
+
+    test "a checkpoint after ask_stream/3 completes is pid-free and restores to a working agent" do
+      script =
+        expect_react do
+          user("summarize README")
+          call("read", %{path: "README.md"})
+          answer("README says Hello.")
+        end
+
+      pid = start_agent()
+
+      {:ok, %{request: request, events: events}} =
+        CheckpointAgent.ask_stream(
+          pid,
+          "summarize README",
+          react_opts(script) ++ [stream_event_timeout_ms: 15_000]
+        )
+
+      kinds = events |> Enum.to_list() |> Enum.map(& &1.kind)
+      assert :request_completed in kinds
+      assert {:ok, "README says Hello."} = CheckpointAgent.await(request, timeout: 15_000)
+
+      live = server_agent(pid)
+      # The bug: agent state legitimately holds the sink until the terminal
+      # transition, which now happens before any checkpoint is written.
+      assert Request.stream_sink(live, request.id) == nil
+
+      {:ok, payload} = CheckpointAgent.checkpoint(live, %{})
+
+      assert Checkpoint.runtime_handles(payload) == []
+      assert :erlang.binary_to_term(:erlang.term_to_binary(payload), [:safe]) == payload
+
+      # Production thaw replaces the original agent; this test keeps it running,
+      # so the revived copy takes a distinct id to avoid a registry collision on
+      # the spawned ReAct worker.
+      suffix = System.unique_integer([:positive, :monotonic])
+      {:ok, restored} = CheckpointAgent.restore(%{payload | id: "restored-agent-#{suffix}"}, %{})
+
+      assert restored.state.requests[request.id].status == :completed
+      assert restored.state.requests[request.id].result == "README says Hello."
+
+      # The restored agent is functional: rebuilt tools, fresh supervisor, and
+      # it can serve a new streamed request.
+      next_script =
+        expect_react do
+          user("second question")
+          answer("second answer")
+        end
+
+      registry = Module.concat(__MODULE__, :"RestoredRegistry#{suffix}")
+      start_supervised!({Registry, keys: :unique, name: registry}, id: {:restored_registry, suffix})
+
+      {:ok, restored_pid} =
+        Jido.AgentServer.start_link(
+          agent: restored,
+          agent_module: CheckpointAgent,
+          registry: registry
+        )
+
+      on_exit(fn -> if Process.alive?(restored_pid), do: Process.exit(restored_pid, :kill) end)
+
+      {:ok, %{request: next_request, events: next_events}} =
+        CheckpointAgent.ask_stream(
+          restored_pid,
+          "second question",
+          react_opts(next_script) ++ [stream_event_timeout_ms: 15_000]
+        )
+
+      next_kinds = next_events |> Enum.to_list() |> Enum.map(& &1.kind)
+      assert :request_completed in next_kinds
+      assert {:ok, "second answer"} = CheckpointAgent.await(next_request, timeout: 15_000)
+    end
+  end
+end

--- a/test/jido_ai/checkpoint_test.exs
+++ b/test/jido_ai/checkpoint_test.exs
@@ -1,27 +1,7 @@
 defmodule Jido.AI.CheckpointTest do
-  @moduledoc """
-  Regression coverage for agentjido/jido_ai#327.
-
-  Request stream sinks (`stream_to: {:pid, pid}`) used to be written into
-  durable checkpoints. A pid encodes its node atom, and
-  `:erlang.binary_to_term/2` with `[:safe]` refuses to create that atom in a VM
-  that has never seen it — so a checkpoint became permanently undecodable after
-  a distribution config change, surfacing as `{:error, :invalid_term}`.
-  """
-
   use Jido.AI.TestCase, async: false
 
-  alias Jido.AI.Checkpoint
   alias Jido.AI.Request
-
-  doctest Jido.AI.Checkpoint
-  doctest Jido.AI.Request, only: [sanitize_requests: 2]
-
-  @gate_owner :jido_ai_checkpoint_test_gate_owner
-
-  # ---------------------------------------------------------------------------
-  # Fixtures
-  # ---------------------------------------------------------------------------
 
   defmodule ReadTool do
     @moduledoc false
@@ -33,33 +13,11 @@ defmodule Jido.AI.CheckpointTest do
     def run(%{path: path}, _context), do: {:ok, %{body: "hello from #{path}"}}
   end
 
-  defmodule GateTool do
-    @moduledoc false
-    use Jido.Action,
-      name: "gate",
-      description: "Blocks until the test releases it",
-      schema: Zoi.object(%{token: Zoi.string()})
-
-    # Suspends the ReAct run inside tool execution so the test can take a
-    # checkpoint while the request is genuinely still in flight. The owner is
-    # reached by registered name rather than :tool_context, so no test pid is
-    # smuggled into agent state.
-    def run(%{token: token}, _context) do
-      send(Jido.AI.CheckpointTest.gate_owner(), {:gate_entered, token, self()})
-
-      receive do
-        {:gate_release, ^token} -> {:ok, %{released: true}}
-      after
-        10_000 -> {:error, :gate_timeout}
-      end
-    end
-  end
-
   defmodule CheckpointAgent do
     @moduledoc false
     use Jido.AI.Agent,
       name: "checkpoint_test_agent",
-      tools: [ReadTool, GateTool],
+      tools: [ReadTool],
       token_secret: "test-secret-that-is-long-enough-123"
   end
 
@@ -78,9 +36,6 @@ defmodule Jido.AI.CheckpointTest do
     end
   end
 
-  @doc false
-  def gate_owner, do: @gate_owner
-
   setup do
     if is_nil(Process.whereis(Jido)) do
       start_supervised!({Jido, name: Jido})
@@ -89,9 +44,139 @@ defmodule Jido.AI.CheckpointTest do
     :ok
   end
 
-  # ---------------------------------------------------------------------------
-  # Helpers
-  # ---------------------------------------------------------------------------
+  describe "terminal request state" do
+    test "completed, failed, and cancelled requests drop their stream sinks" do
+      completed =
+        CheckpointAgent.new()
+        |> Request.start_request("completed", "query", stream_to: {:pid, self()})
+        |> Request.complete_request("completed", "answer")
+
+      failed =
+        CheckpointAgent.new()
+        |> Request.start_request("failed", "query", stream_to: {:pid, self()})
+        |> Request.fail_request("failed", :error)
+
+      cancelling =
+        CheckpointAgent.new()
+        |> Request.start_request("cancelled", "query", stream_to: {:pid, self()})
+
+      {:ok, cancelled, _directives} =
+        CheckpointAgent.on_after_cmd(
+          cancelling,
+          {:ai_react_cancel, %{request_id: "cancelled", reason: :user_cancelled}},
+          []
+        )
+
+      refute Map.has_key?(completed.state.requests["completed"], :stream_to)
+      refute Map.has_key?(failed.state.requests["failed"], :stream_to)
+      refute Map.has_key?(cancelled.state.requests["cancelled"], :stream_to)
+
+      assert_receive {:jido_ai_request_event,
+                      %Jido.AI.Runtime.Event{
+                        kind: :request_cancelled,
+                        request_id: "cancelled"
+                      }}
+    end
+  end
+
+  describe "checkpoint and restore" do
+    test "an active streamed request is stored as interrupted without runtime handles" do
+      agent =
+        CheckpointAgent.new()
+        |> Request.start_request("active", "query", stream_to: {:pid, self()})
+        |> mark_react_run_active("active")
+
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+      request = payload.state.requests["active"]
+      strategy = payload.state.__strategy__
+
+      assert agent.state.requests["active"].stream_to == {:pid, self()}
+      assert request.status == :failed
+      assert request.error == :stream_interrupted
+      assert request.stream_interrupted == true
+      refute Map.has_key?(request, :stream_to)
+      assert strategy.status == :idle
+      assert strategy.active_request_id == nil
+      assert strategy.react_worker_pid == nil
+      assert strategy.pending_input_server == nil
+      refute Map.has_key?(payload.state, :__task_supervisor_skill__)
+      assert runtime_handles(payload) == []
+      assert :erlang.binary_to_term(:erlang.term_to_binary(payload), [:safe]) == payload
+
+      {:ok, restored} = CheckpointAgent.restore(payload, %{})
+
+      assert {:error, :stream_interrupted} = Request.get_result(restored, "active")
+      assert restored.state.__strategy__.status == :idle
+      assert is_pid(restored.state.__task_supervisor_skill__.supervisor)
+    end
+
+    test "consumer checkpoint overrides keep the sanitized payload" do
+      agent =
+        CustomCheckpointAgent.new()
+        |> Request.start_request("custom", "query", stream_to: {:pid, self()})
+
+      {:ok, payload} = CustomCheckpointAgent.checkpoint(agent, %{})
+
+      assert payload.custom_checkpoint == true
+      assert payload.state.requests["custom"].error == :stream_interrupted
+      assert runtime_handles(payload) == []
+    end
+
+    test "legacy request sinks are removed during restore" do
+      agent = CheckpointAgent.new()
+      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
+
+      legacy_request = %{
+        query: "query",
+        status: :pending,
+        error: nil,
+        stream_to: {:pid, self()}
+      }
+
+      legacy = put_in(payload, [:state, :requests, "legacy"], legacy_request)
+      {:ok, restored} = CheckpointAgent.restore(legacy, %{})
+
+      request = restored.state.requests["legacy"]
+      assert request.status == :failed
+      assert request.error == :stream_interrupted
+      assert request.stream_interrupted == true
+      refute Map.has_key?(request, :stream_to)
+    end
+  end
+
+  describe "request streaming" do
+    test "a completed stream checkpoint restores without a process-local sink" do
+      script =
+        expect_react do
+          user("summarize README")
+          call("read", %{path: "README.md"})
+          answer("README says Hello.")
+        end
+
+      pid = start_agent()
+
+      {:ok, %{request: request, events: events}} =
+        CheckpointAgent.ask_stream(
+          pid,
+          "summarize README",
+          react_opts(script) ++ [stream_event_timeout_ms: 15_000]
+        )
+
+      assert :request_completed in Enum.map(events, & &1.kind)
+      assert {:ok, "README says Hello."} = CheckpointAgent.await(request, timeout: 15_000)
+
+      live = server_agent(pid)
+      assert Request.stream_sink(live, request.id) == nil
+
+      {:ok, payload} = CheckpointAgent.checkpoint(live, %{})
+      assert runtime_handles(payload) == []
+      assert :erlang.binary_to_term(:erlang.term_to_binary(payload), [:safe]) == payload
+
+      {:ok, restored} = CheckpointAgent.restore(payload, %{})
+      assert restored.state.requests[request.id].status == :completed
+      assert restored.state.requests[request.id].result == "README says Hello."
+    end
+  end
 
   defp start_agent do
     suffix = System.unique_integer([:positive, :monotonic])
@@ -114,8 +199,6 @@ defmodule Jido.AI.CheckpointTest do
     if is_map(state) and Map.has_key?(state, :agent), do: state.agent, else: state
   end
 
-  defp request_record(payload, request_id), do: get_in(payload, [:state, :requests, request_id])
-
   defp mark_react_run_active(agent, request_id) do
     update_in(agent.state.__strategy__, fn strategy ->
       Map.merge(strategy, %{
@@ -123,614 +206,24 @@ defmodule Jido.AI.CheckpointTest do
         active_request_id: request_id,
         react_worker_pid: self(),
         react_worker_status: :running,
-        pending_input_server: self(),
-        run_tool_context: %{request: request_id},
-        run_req_http_options: [receive_timeout: 1_000],
-        run_llm_opts: [temperature: 0.1]
+        pending_input_server: self()
       })
     end)
   end
 
-  # ---------------------------------------------------------------------------
-  # Acceptance criterion 1 - terminal states drop the stream sink
-  # ---------------------------------------------------------------------------
+  defp runtime_handles(term) when is_pid(term) or is_port(term) or is_reference(term), do: [term]
 
-  describe "terminal request states drop the stream sink" do
-    test "complete_request/4 removes stream_to" do
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_done", "query", stream_to: {:pid, self()})
-
-      assert agent.state.requests["req_done"].stream_to == {:pid, self()}
-
-      agent = Request.complete_request(agent, "req_done", "answer")
-
-      assert agent.state.requests["req_done"].status == :completed
-      refute Map.has_key?(agent.state.requests["req_done"], :stream_to)
-    end
-
-    test "fail_request/3 removes stream_to" do
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_failed", "query", stream_to: {:pid, self()})
-        |> Request.fail_request("req_failed", {:failed, :boom, nil})
-
-      assert agent.state.requests["req_failed"].status == :failed
-      refute Map.has_key?(agent.state.requests["req_failed"], :stream_to)
-    end
-
-    test "cancellation removes stream_to and emits a terminal event to the sink" do
-      tag = Request.Stream.message_tag()
-
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_cancel", "query", stream_to: {:pid, self()})
-
-      {:ok, agent, _directives} =
-        CheckpointAgent.on_after_cmd(
-          agent,
-          {:ai_react_cancel, %{request_id: "req_cancel", reason: :user_cancelled}},
-          []
-        )
-
-      assert agent.state.requests["req_cancel"].status == :failed
-      assert agent.state.requests["req_cancel"].error == {:cancelled, :user_cancelled}
-      refute Map.has_key?(agent.state.requests["req_cancel"], :stream_to)
-
-      # The consumer's enumerable halts on this event instead of waiting for a
-      # worker acknowledgement that a cancelled run may never send.
-      assert_receive {^tag,
-                      %Jido.AI.Runtime.Event{
-                        kind: :request_cancelled,
-                        request_id: "req_cancel",
-                        data: %{reason: :user_cancelled}
-                      }}
-
-      assert Request.Stream.terminal_kind?(:request_cancelled)
-    end
-
-    test "request-error rejection removes stream_to after notifying the sink" do
-      tag = Request.Stream.message_tag()
-
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_busy", "query", stream_to: {:pid, self()})
-
-      {:ok, agent, _action} =
-        CheckpointAgent.on_before_cmd(
-          agent,
-          {:ai_react_request_error, %{request_id: "req_busy", reason: :busy, message: "busy"}}
-        )
-
-      assert agent.state.requests["req_busy"].status == :failed
-      refute Map.has_key?(agent.state.requests["req_busy"], :stream_to)
-      assert_receive {^tag, %Jido.AI.Runtime.Event{kind: :request_failed, request_id: "req_busy"}}
-    end
-
-    test "failing an already-completed request leaves the completed record intact" do
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_done", "query", stream_to: {:pid, self()})
-        |> Request.complete_request("req_done", "answer")
-        |> Request.fail_request("req_done", {:failed, :late, nil})
-
-      assert agent.state.requests["req_done"].status == :completed
-      assert agent.state.requests["req_done"].result == "answer"
-      refute Map.has_key?(agent.state.requests["req_done"], :stream_to)
-    end
+  defp runtime_handles(term) when is_function(term) do
+    if Function.info(term, :type) == {:type, :external}, do: [], else: [term]
   end
 
-  # ---------------------------------------------------------------------------
-  # Handle scanning - the invariant the other tests rely on
-  # ---------------------------------------------------------------------------
+  defp runtime_handles(%_{} = term), do: term |> Map.from_struct() |> runtime_handles()
 
-  describe "runtime_handles/1" do
-    test "reports pids, ports, references, and anonymous functions with their paths" do
-      port = Port.open({:spawn, "cat"}, [:binary])
-      on_exit(fn -> if Port.info(port), do: Port.close(port) end)
-
-      term = %{
-        sink: {:pid, self()},
-        nested: [%{ref: make_ref()}],
-        port: port,
-        fun: fn -> :anonymous end
-      }
-
-      handles = Checkpoint.runtime_handles(term)
-
-      assert {[:sink, {:elem, 1}], :pid} in handles
-      assert {[:nested, {:at, 0}, :ref], :reference} in handles
-      assert {[:port], :port} in handles
-      assert {[:fun], :function} in handles
-      assert length(handles) == 4
-    end
-
-    test "ignores plain data and external function captures" do
-      # &Mod.fun/arity encodes as a module/function/arity triple, which [:safe]
-      # accepts; only anonymous funs are rejected outright.
-      term = %{numbers: [1, 2], text: "ok", atoms: {:a, :b}, capture: &Enum.map/2}
-
-      assert Checkpoint.runtime_handles(term) == []
-    end
-
-    test "descends into structs" do
-      event =
-        Jido.AI.Runtime.Event.new(%{
-          seq: 0,
-          run_id: "run",
-          request_id: "req",
-          iteration: 0,
-          kind: :request_completed,
-          data: %{pid: self()}
-        })
-
-      assert [{[Jido.AI.Runtime.Event, :data, :pid], :pid}] = Checkpoint.runtime_handles(event)
-    end
-
-    test "reports runtime handles used as map keys" do
-      pid = self()
-      ref = make_ref()
-      fun = fn -> :anonymous end
-
-      handles = Checkpoint.runtime_handles(%{pid => :pid, ref => :ref, fun => :fun})
-
-      assert Enum.any?(handles, fn
-               {[{:key, ^pid}], :pid} -> true
-               _other -> false
-             end)
-
-      assert Enum.any?(handles, fn
-               {[{:key, ^ref}], :reference} -> true
-               _other -> false
-             end)
-
-      assert Enum.any?(handles, fn
-               {[{:key, ^fun}], :function} -> true
-               _other -> false
-             end)
-    end
-
-    test "descends into improper list tails" do
-      ref = make_ref()
-
-      assert [
-               {[{:at, 0}], :pid},
-               {[{:tail, 1}], :reference}
-             ] = Checkpoint.runtime_handles([self() | ref])
-    end
+  defp runtime_handles(term) when is_map(term) do
+    Enum.flat_map(term, fn {key, value} -> runtime_handles(key) ++ runtime_handles(value) end)
   end
 
-  # ---------------------------------------------------------------------------
-  # Acceptance criterion 2 - payloads are pid-free, active requests included
-  # ---------------------------------------------------------------------------
-
-  describe "checkpoint payloads" do
-    test "an active streamed request is failed in the payload and flagged interrupted" do
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_active", "query", stream_to: {:pid, self()})
-
-      # The live agent keeps its sink; only the payload is sanitized.
-      assert agent.state.requests["req_active"].stream_to == {:pid, self()}
-
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-      record = request_record(payload, "req_active")
-
-      assert record.status == :failed
-      assert record.error == :stream_interrupted
-      refute Map.has_key?(record, :stream_to)
-      assert record.stream_interrupted == true
-      assert Checkpoint.runtime_handles(payload) == []
-      assert agent.state.requests["req_active"].stream_to == {:pid, self()}
-      assert agent.state.requests["req_active"].status == :pending
-    end
-
-    test "a completed streamed request contributes no pid and is not flagged" do
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_done", "query", stream_to: {:pid, self()})
-        |> Request.complete_request("req_done", "answer")
-
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-      record = request_record(payload, "req_done")
-
-      assert record.status == :completed
-      refute Map.has_key?(record, :stream_to)
-      refute Map.has_key?(record, :stream_interrupted)
-      assert Checkpoint.runtime_handles(payload) == []
-    end
-
-    test "strategy worker handles and task supervisor are stripped" do
-      agent = CheckpointAgent.new()
-
-      agent =
-        put_in(agent.state.__strategy__, %{
-          agent.state.__strategy__
-          | react_worker_pid: self(),
-            react_worker_status: :running,
-            pending_input_server: self(),
-            pending_worker_start: %{context: %{state: %{sink: self()}}}
-        })
-
-      assert Checkpoint.runtime_handles(agent.state) != []
-
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-      strategy = payload.state.__strategy__
-
-      assert strategy.react_worker_pid == nil
-      assert strategy.react_worker_status == :missing
-      assert strategy.pending_input_server == nil
-      assert strategy.pending_worker_start == nil
-      assert strategy.status == :idle
-      assert strategy.active_request_id == nil
-      refute Map.has_key?(payload.state, :__task_supervisor_skill__)
-      assert Checkpoint.runtime_handles(payload) == []
-    end
-
-    test "consumer checkpoint overrides compose with sanitization" do
-      agent =
-        CustomCheckpointAgent.new()
-        |> Request.start_request("req_custom", "query", stream_to: {:pid, self()})
-
-      {:ok, payload} = CustomCheckpointAgent.checkpoint(agent, %{})
-
-      assert payload.custom_checkpoint == true
-      assert request_record(payload, "req_custom").error == :stream_interrupted
-      assert Checkpoint.runtime_handles(payload) == []
-    end
-
-    test "the scan is not vacuous - a sink left in a payload is detected" do
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_leak", "query", stream_to: {:pid, self()})
-
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-
-      leaky = put_in(payload, [:state, :requests, "req_leak", :stream_to], {:pid, self()})
-
-      assert [{path, :pid}] = Checkpoint.runtime_handles(leaky)
-      assert path == [:state, :requests, "req_leak", :stream_to, {:elem, 1}]
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # Acceptance criterion 3 - decodable in a fresh VM with [:safe]
-  # ---------------------------------------------------------------------------
-
-  describe "external term encoding" do
-    test "a pid from a vanished node is exactly what [:safe] rejects" do
-      # Reproduces the reported failure without a second VM: hand-build the
-      # external representation of a pid living on a node this VM has never
-      # seen. [:safe] refuses to create the node atom, which is how a checkpoint
-      # written before a distribution change becomes {:error, :invalid_term}.
-      # The node name must be unique per run - once the atom exists, [:safe]
-      # would happily decode the same bytes.
-      node_name = "gone#{System.unique_integer([:positive])}@nowhere"
-      size = byte_size(node_name)
-      encoded_pid = <<131, 88, 119, size, node_name::binary, 1::32, 0::32, 0::32>>
-
-      assert_raise ArgumentError, fn -> :erlang.binary_to_term(encoded_pid, [:safe]) end
-
-      # Same bytes decode once the atom exists, confirming the node atom - not
-      # the pid itself - is what makes the payload unreadable.
-      assert is_pid(:erlang.binary_to_term(encoded_pid))
-      assert is_pid(:erlang.binary_to_term(encoded_pid, [:safe]))
-    end
-
-    test "tool callbacks use durable MFA tuples and stay in the payload" do
-      agent = CheckpointAgent.new()
-      tools = agent.state.__strategy__.config.reqllm_tools
-
-      assert tools != []
-      assert Enum.all?(tools, &(&1.callback == {ReqLLM.Tool, :new}))
-      refute Enum.any?(Checkpoint.runtime_handles(agent.state), fn {_path, kind} -> kind == :function end)
-
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-
-      assert payload.state.__strategy__.config.reqllm_tools == tools
-      assert Checkpoint.runtime_handles(payload) == []
-    end
-
-    test "a checkpoint from a streamed request round-trips through [:safe]" do
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_active", "query", stream_to: {:pid, self()})
-        |> Request.start_request("req_done", "query", stream_to: {:pid, self()})
-        |> Request.complete_request("req_done", "answer")
-
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-
-      # No pid means no foreign node atom, and no anonymous fun means nothing
-      # [:safe] rejects unconditionally - together these are what make the
-      # payload readable in a VM that never saw the writing node.
-      assert Checkpoint.runtime_handles(payload) == []
-
-      decoded = :erlang.binary_to_term(:erlang.term_to_binary(payload), [:safe])
-
-      assert decoded == payload
-      assert decoded.state.requests["req_active"].stream_interrupted == true
-      assert decoded.state.requests["req_active"].status == :failed
-      assert decoded.state.requests["req_active"].error == :stream_interrupted
-      assert decoded.state.requests["req_done"].status == :completed
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # Acceptance criterion 4 - restore behaviour is deterministic
-  # ---------------------------------------------------------------------------
-
-  describe "restore" do
-    test "an interrupted streamed request fails, becomes unstreamable, and releases the strategy" do
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_active", "query", stream_to: {:pid, self()})
-        |> mark_react_run_active("req_active")
-
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-      {:ok, restored} = CheckpointAgent.restore(payload, %{})
-
-      record = restored.state.requests["req_active"]
-
-      assert record.status == :failed
-      assert record.error == :stream_interrupted
-      refute Map.has_key?(record, :stream_to)
-      assert Checkpoint.interrupted_request?(record)
-      assert Request.stream_sink(restored, "req_active") == nil
-      assert restored.state.__strategy__.status == :idle
-      assert restored.state.__strategy__.active_request_id == nil
-      assert restored.state.__strategy__.react_worker_pid == nil
-      assert restored.state.__strategy__.react_worker_status == :missing
-
-      # Nothing is delivered to the original consumer after a thaw.
-      assert Request.Stream.send_event(Request.stream_sink(restored, "req_active"), %{
-               seq: 0,
-               run_id: "req_active",
-               request_id: "req_active",
-               iteration: 0,
-               kind: :request_completed,
-               data: %{}
-             }) == :ok
-
-      refute_receive {_tag, %Jido.AI.Runtime.Event{}}, 50
-
-      {next_agent, directives} =
-        CheckpointAgent.cmd(
-          restored,
-          {:ai_react_start, %{query: "new query", request_id: "req_next"}}
-        )
-
-      refute Enum.any?(directives, &is_struct(&1, Jido.AI.Directive.EmitRequestError))
-      assert next_agent.state.__strategy__.active_request_id == "req_next"
-
-      pending_input_server = next_agent.state.__strategy__.pending_input_server
-
-      if is_pid(pending_input_server) do
-        Jido.AI.PendingInputServer.stop(pending_input_server)
-      end
-    end
-
-    test "a completed request restores without an interrupted flag" do
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_done", "query", stream_to: {:pid, self()})
-        |> Request.complete_request("req_done", "answer")
-
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-      {:ok, restored} = CheckpointAgent.restore(payload, %{})
-
-      record = restored.state.requests["req_done"]
-
-      assert record.status == :completed
-      assert record.result == "answer"
-      refute Checkpoint.interrupted_request?(record)
-    end
-
-    test "a legacy payload that still carries a sink is scrubbed on restore" do
-      # Checkpoints written before this fix may already be on disk. If they are
-      # decodable at all, restore must not hand back a stale pid.
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_legacy", "query", stream_to: {:pid, self()})
-
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-
-      legacy =
-        payload
-        |> put_in([:state, :requests, "req_legacy", :stream_to], {:pid, self()})
-        |> put_in([:state, :requests, "req_legacy", :status], :pending)
-        |> put_in([:state, :requests, "req_legacy", :error], nil)
-        |> update_in([:state, :requests, "req_legacy"], &Map.delete(&1, :stream_interrupted))
-
-      {:ok, restored} = CheckpointAgent.restore(legacy, %{})
-
-      assert Request.stream_sink(restored, "req_legacy") == nil
-      assert Checkpoint.interrupted_request?(restored.state.requests["req_legacy"])
-      assert restored.state.requests["req_legacy"].status == :failed
-      assert restored.state.requests["req_legacy"].error == :stream_interrupted
-    end
-
-    test "await/2 on an interrupted request returns its explicit failure" do
-      agent =
-        CheckpointAgent.new()
-        |> Request.start_request("req_interrupted", "query", stream_to: {:pid, self()})
-
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-
-      suffix = System.unique_integer([:positive, :monotonic])
-      {:ok, restored} = CheckpointAgent.restore(%{payload | id: "interrupted-agent-#{suffix}"}, %{})
-
-      registry = Module.concat(__MODULE__, :"InterruptedRegistry#{suffix}")
-      start_supervised!({Registry, keys: :unique, name: registry}, id: {:interrupted_registry, suffix})
-
-      {:ok, pid} =
-        Jido.AgentServer.start_link(
-          agent: restored,
-          agent_module: CheckpointAgent,
-          registry: registry
-        )
-
-      on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
-
-      # The run backing this request died with the previous VM, so awaiting it
-      # resolves immediately with the durable interruption error.
-      handle = Request.Handle.new("req_interrupted", pid, "query")
-
-      assert {:error, :stream_interrupted} = Request.await(handle, timeout: 5_000)
-    end
-
-    test "durable tool callbacks remain compatible and missing legacy tools are rebuilt" do
-      agent = CheckpointAgent.new()
-      {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
-
-      payload_tools = payload.state.__strategy__.config.reqllm_tools
-      assert payload_tools != []
-      assert Enum.all?(payload_tools, &(&1.callback == {ReqLLM.Tool, :new}))
-
-      {:ok, restored} = CheckpointAgent.restore(payload, %{})
-      config = restored.state.__strategy__.config
-
-      assert length(config.reqllm_tools) == length(config.tools)
-      assert Enum.all?(config.reqllm_tools, &is_struct(&1, ReqLLM.Tool))
-      assert Enum.sort(Enum.map(config.reqllm_tools, & &1.name)) == ["gate", "read"]
-
-      legacy_payload = update_in(payload.state.__strategy__.config, &Map.delete(&1, :reqllm_tools))
-      {:ok, restored_legacy} = CheckpointAgent.restore(legacy_payload, %{})
-      assert Enum.sort(Enum.map(restored_legacy.state.__strategy__.config.reqllm_tools, & &1.name)) == ["gate", "read"]
-
-      # A fresh, live task supervisor replaces the one dropped at checkpoint.
-      assert is_pid(restored.state.__task_supervisor_skill__.supervisor)
-      assert Process.alive?(restored.state.__task_supervisor_skill__.supervisor)
-      assert restored.state.__strategy__.react_worker_pid == nil
-      assert restored.state.__strategy__.react_worker_status == :missing
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # Acceptance criterion 5 - streaming plus checkpoint/restore, end to end
-  # ---------------------------------------------------------------------------
-
-  describe "request streaming with checkpoint and restore" do
-    test "a checkpoint taken mid-stream is pid-free while the request is in flight" do
-      Process.register(self(), @gate_owner)
-      on_exit(fn -> if Process.whereis(@gate_owner) == self(), do: Process.unregister(@gate_owner) end)
-
-      token = "gate-#{System.unique_integer([:positive])}"
-
-      script =
-        expect_react do
-          user("run the gate")
-          call("gate", %{token: token})
-          answer("gate released")
-        end
-
-      pid = start_agent()
-
-      {:ok, %{request: request, events: events}} =
-        CheckpointAgent.ask_stream(
-          pid,
-          "run the gate",
-          react_opts(script) ++ [stream_event_timeout_ms: 15_000]
-        )
-
-      # The run is now suspended inside GateTool, so the request is genuinely
-      # active with a live sink recorded in agent state.
-      assert_receive {:gate_entered, ^token, tool_pid}, 10_000
-
-      live = server_agent(pid)
-      assert Request.stream_sink(live, request.id) == {:pid, self()}
-      assert live.state.requests[request.id].status == :pending
-      assert is_pid(live.state.__strategy__.react_worker_pid)
-
-      {:ok, payload} = CheckpointAgent.checkpoint(live, %{})
-      record = request_record(payload, request.id)
-
-      assert record.status == :failed
-      assert record.error == :stream_interrupted
-      refute Map.has_key?(record, :stream_to)
-      assert record.stream_interrupted == true
-      assert payload.state.__strategy__.status == :idle
-      assert payload.state.__strategy__.active_request_id == nil
-      assert Checkpoint.runtime_handles(payload) == []
-      assert :erlang.binary_to_term(:erlang.term_to_binary(payload), [:safe]) == payload
-
-      send(tool_pid, {:gate_release, token})
-
-      # The live run is unaffected by taking a checkpoint.
-      kinds = events |> Enum.to_list() |> Enum.map(& &1.kind)
-      assert :request_completed in kinds
-      assert {:ok, "gate released"} = CheckpointAgent.await(request, timeout: 15_000)
-    end
-
-    test "a checkpoint after ask_stream/3 completes is pid-free and restores to a working agent" do
-      script =
-        expect_react do
-          user("summarize README")
-          call("read", %{path: "README.md"})
-          answer("README says Hello.")
-        end
-
-      pid = start_agent()
-
-      {:ok, %{request: request, events: events}} =
-        CheckpointAgent.ask_stream(
-          pid,
-          "summarize README",
-          react_opts(script) ++ [stream_event_timeout_ms: 15_000]
-        )
-
-      kinds = events |> Enum.to_list() |> Enum.map(& &1.kind)
-      assert :request_completed in kinds
-      assert {:ok, "README says Hello."} = CheckpointAgent.await(request, timeout: 15_000)
-
-      live = server_agent(pid)
-      # The bug: agent state legitimately holds the sink until the terminal
-      # transition, which now happens before any checkpoint is written.
-      assert Request.stream_sink(live, request.id) == nil
-
-      {:ok, payload} = CheckpointAgent.checkpoint(live, %{})
-
-      assert Checkpoint.runtime_handles(payload) == []
-      assert :erlang.binary_to_term(:erlang.term_to_binary(payload), [:safe]) == payload
-
-      # Production thaw replaces the original agent; this test keeps it running,
-      # so the revived copy takes a distinct id to avoid a registry collision on
-      # the spawned ReAct worker.
-      suffix = System.unique_integer([:positive, :monotonic])
-      {:ok, restored} = CheckpointAgent.restore(%{payload | id: "restored-agent-#{suffix}"}, %{})
-
-      assert restored.state.requests[request.id].status == :completed
-      assert restored.state.requests[request.id].result == "README says Hello."
-
-      # The restored agent is functional: rebuilt tools, fresh supervisor, and
-      # it can serve a new streamed request.
-      next_script =
-        expect_react do
-          user("second question")
-          answer("second answer")
-        end
-
-      registry = Module.concat(__MODULE__, :"RestoredRegistry#{suffix}")
-      start_supervised!({Registry, keys: :unique, name: registry}, id: {:restored_registry, suffix})
-
-      {:ok, restored_pid} =
-        Jido.AgentServer.start_link(
-          agent: restored,
-          agent_module: CheckpointAgent,
-          registry: registry
-        )
-
-      on_exit(fn -> if Process.alive?(restored_pid), do: Process.exit(restored_pid, :kill) end)
-
-      {:ok, %{request: next_request, events: next_events}} =
-        CheckpointAgent.ask_stream(
-          restored_pid,
-          "second question",
-          react_opts(next_script) ++ [stream_event_timeout_ms: 15_000]
-        )
-
-      next_kinds = next_events |> Enum.to_list() |> Enum.map(& &1.kind)
-      assert :request_completed in next_kinds
-      assert {:ok, "second answer"} = CheckpointAgent.await(next_request, timeout: 15_000)
-    end
-  end
+  defp runtime_handles([head | tail]), do: runtime_handles(head) ++ runtime_handles(tail)
+  defp runtime_handles(term) when is_tuple(term), do: term |> Tuple.to_list() |> runtime_handles()
+  defp runtime_handles(_term), do: []
 end

--- a/test/jido_ai/checkpoint_test.exs
+++ b/test/jido_ai/checkpoint_test.exs
@@ -63,6 +63,21 @@ defmodule Jido.AI.CheckpointTest do
       token_secret: "test-secret-that-is-long-enough-123"
   end
 
+  defmodule CustomCheckpointAgent do
+    @moduledoc false
+    use Jido.AI.Agent,
+      name: "custom_checkpoint_test_agent",
+      tools: [ReadTool],
+      token_secret: "test-secret-that-is-long-enough-123"
+
+    @impl true
+    def checkpoint(agent, ctx) do
+      with {:ok, payload} <- super(agent, ctx) do
+        {:ok, Map.put(payload, :custom_checkpoint, true)}
+      end
+    end
+  end
+
   @doc false
   def gate_owner, do: @gate_owner
 
@@ -100,6 +115,21 @@ defmodule Jido.AI.CheckpointTest do
   end
 
   defp request_record(payload, request_id), do: get_in(payload, [:state, :requests, request_id])
+
+  defp mark_react_run_active(agent, request_id) do
+    update_in(agent.state.__strategy__, fn strategy ->
+      Map.merge(strategy, %{
+        status: :awaiting_llm,
+        active_request_id: request_id,
+        react_worker_pid: self(),
+        react_worker_status: :running,
+        pending_input_server: self(),
+        run_tool_context: %{request: request_id},
+        run_req_http_options: [receive_timeout: 1_000],
+        run_llm_opts: [temperature: 0.1]
+      })
+    end)
+  end
 
   # ---------------------------------------------------------------------------
   # Acceptance criterion 1 - terminal states drop the stream sink
@@ -236,6 +266,38 @@ defmodule Jido.AI.CheckpointTest do
 
       assert [{[Jido.AI.Runtime.Event, :data, :pid], :pid}] = Checkpoint.runtime_handles(event)
     end
+
+    test "reports runtime handles used as map keys" do
+      pid = self()
+      ref = make_ref()
+      fun = fn -> :anonymous end
+
+      handles = Checkpoint.runtime_handles(%{pid => :pid, ref => :ref, fun => :fun})
+
+      assert Enum.any?(handles, fn
+               {[{:key, ^pid}], :pid} -> true
+               _other -> false
+             end)
+
+      assert Enum.any?(handles, fn
+               {[{:key, ^ref}], :reference} -> true
+               _other -> false
+             end)
+
+      assert Enum.any?(handles, fn
+               {[{:key, ^fun}], :function} -> true
+               _other -> false
+             end)
+    end
+
+    test "descends into improper list tails" do
+      ref = make_ref()
+
+      assert [
+               {[{:at, 0}], :pid},
+               {[{:tail, 1}], :reference}
+             ] = Checkpoint.runtime_handles([self() | ref])
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -243,7 +305,7 @@ defmodule Jido.AI.CheckpointTest do
   # ---------------------------------------------------------------------------
 
   describe "checkpoint payloads" do
-    test "an active streamed request contributes no pid and is flagged interrupted" do
+    test "an active streamed request is failed in the payload and flagged interrupted" do
       agent =
         CheckpointAgent.new()
         |> Request.start_request("req_active", "query", stream_to: {:pid, self()})
@@ -254,11 +316,13 @@ defmodule Jido.AI.CheckpointTest do
       {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
       record = request_record(payload, "req_active")
 
-      assert record.status == :pending
+      assert record.status == :failed
+      assert record.error == :stream_interrupted
       refute Map.has_key?(record, :stream_to)
       assert record.stream_interrupted == true
       assert Checkpoint.runtime_handles(payload) == []
       assert agent.state.requests["req_active"].stream_to == {:pid, self()}
+      assert agent.state.requests["req_active"].status == :pending
     end
 
     test "a completed streamed request contributes no pid and is not flagged" do
@@ -297,7 +361,21 @@ defmodule Jido.AI.CheckpointTest do
       assert strategy.react_worker_status == :missing
       assert strategy.pending_input_server == nil
       assert strategy.pending_worker_start == nil
+      assert strategy.status == :idle
+      assert strategy.active_request_id == nil
       refute Map.has_key?(payload.state, :__task_supervisor_skill__)
+      assert Checkpoint.runtime_handles(payload) == []
+    end
+
+    test "consumer checkpoint overrides compose with sanitization" do
+      agent =
+        CustomCheckpointAgent.new()
+        |> Request.start_request("req_custom", "query", stream_to: {:pid, self()})
+
+      {:ok, payload} = CustomCheckpointAgent.checkpoint(agent, %{})
+
+      assert payload.custom_checkpoint == true
+      assert request_record(payload, "req_custom").error == :stream_interrupted
       assert Checkpoint.runtime_handles(payload) == []
     end
 
@@ -339,18 +417,17 @@ defmodule Jido.AI.CheckpointTest do
       assert is_pid(:erlang.binary_to_term(encoded_pid, [:safe]))
     end
 
-    test "anonymous tool callbacks live in agent state but never reach the payload" do
-      # ReqLLM.Tool.callback is an anonymous fun, and [:safe] rejects anonymous
-      # funs outright in a VM that has not itself created them - no node atom
-      # involved. config.reqllm_tools is therefore dropped here and rebuilt on
-      # restore from config.tools.
+    test "tool callbacks use durable MFA tuples and stay in the payload" do
       agent = CheckpointAgent.new()
+      tools = agent.state.__strategy__.config.reqllm_tools
 
-      assert Enum.any?(Checkpoint.runtime_handles(agent.state), fn {_path, kind} -> kind == :function end)
-      assert agent.state.__strategy__.config.reqllm_tools != []
+      assert tools != []
+      assert Enum.all?(tools, &(&1.callback == {ReqLLM.Tool, :new}))
+      refute Enum.any?(Checkpoint.runtime_handles(agent.state), fn {_path, kind} -> kind == :function end)
 
       {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
 
+      assert payload.state.__strategy__.config.reqllm_tools == tools
       assert Checkpoint.runtime_handles(payload) == []
     end
 
@@ -372,6 +449,8 @@ defmodule Jido.AI.CheckpointTest do
 
       assert decoded == payload
       assert decoded.state.requests["req_active"].stream_interrupted == true
+      assert decoded.state.requests["req_active"].status == :failed
+      assert decoded.state.requests["req_active"].error == :stream_interrupted
       assert decoded.state.requests["req_done"].status == :completed
     end
   end
@@ -381,20 +460,26 @@ defmodule Jido.AI.CheckpointTest do
   # ---------------------------------------------------------------------------
 
   describe "restore" do
-    test "an interrupted streamed request stays pending, unstreamable, and flagged" do
+    test "an interrupted streamed request fails, becomes unstreamable, and releases the strategy" do
       agent =
         CheckpointAgent.new()
         |> Request.start_request("req_active", "query", stream_to: {:pid, self()})
+        |> mark_react_run_active("req_active")
 
       {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
       {:ok, restored} = CheckpointAgent.restore(payload, %{})
 
       record = restored.state.requests["req_active"]
 
-      assert record.status == :pending
+      assert record.status == :failed
+      assert record.error == :stream_interrupted
       refute Map.has_key?(record, :stream_to)
       assert Checkpoint.interrupted_request?(record)
       assert Request.stream_sink(restored, "req_active") == nil
+      assert restored.state.__strategy__.status == :idle
+      assert restored.state.__strategy__.active_request_id == nil
+      assert restored.state.__strategy__.react_worker_pid == nil
+      assert restored.state.__strategy__.react_worker_status == :missing
 
       # Nothing is delivered to the original consumer after a thaw.
       assert Request.Stream.send_event(Request.stream_sink(restored, "req_active"), %{
@@ -407,6 +492,21 @@ defmodule Jido.AI.CheckpointTest do
              }) == :ok
 
       refute_receive {_tag, %Jido.AI.Runtime.Event{}}, 50
+
+      {next_agent, directives} =
+        CheckpointAgent.cmd(
+          restored,
+          {:ai_react_start, %{query: "new query", request_id: "req_next"}}
+        )
+
+      refute Enum.any?(directives, &is_struct(&1, Jido.AI.Directive.EmitRequestError))
+      assert next_agent.state.__strategy__.active_request_id == "req_next"
+
+      pending_input_server = next_agent.state.__strategy__.pending_input_server
+
+      if is_pid(pending_input_server) do
+        Jido.AI.PendingInputServer.stop(pending_input_server)
+      end
     end
 
     test "a completed request restores without an interrupted flag" do
@@ -437,15 +537,19 @@ defmodule Jido.AI.CheckpointTest do
       legacy =
         payload
         |> put_in([:state, :requests, "req_legacy", :stream_to], {:pid, self()})
+        |> put_in([:state, :requests, "req_legacy", :status], :pending)
+        |> put_in([:state, :requests, "req_legacy", :error], nil)
         |> update_in([:state, :requests, "req_legacy"], &Map.delete(&1, :stream_interrupted))
 
       {:ok, restored} = CheckpointAgent.restore(legacy, %{})
 
       assert Request.stream_sink(restored, "req_legacy") == nil
       assert Checkpoint.interrupted_request?(restored.state.requests["req_legacy"])
+      assert restored.state.requests["req_legacy"].status == :failed
+      assert restored.state.requests["req_legacy"].error == :stream_interrupted
     end
 
-    test "await/2 on an interrupted request times out instead of blocking forever" do
+    test "await/2 on an interrupted request returns its explicit failure" do
       agent =
         CheckpointAgent.new()
         |> Request.start_request("req_interrupted", "query", stream_to: {:pid, self()})
@@ -468,17 +572,19 @@ defmodule Jido.AI.CheckpointTest do
       on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
 
       # The run backing this request died with the previous VM, so awaiting it
-      # resolves deterministically rather than hanging on a run that is gone.
+      # resolves immediately with the durable interruption error.
       handle = Request.Handle.new("req_interrupted", pid, "query")
 
-      assert {:error, :timeout} = Request.await(handle, timeout: 200)
+      assert {:error, :stream_interrupted} = Request.await(handle, timeout: 5_000)
     end
 
-    test "derived runtime values dropped from the payload are rebuilt" do
+    test "durable tool callbacks remain compatible and missing legacy tools are rebuilt" do
       agent = CheckpointAgent.new()
       {:ok, payload} = CheckpointAgent.checkpoint(agent, %{})
 
-      refute Map.has_key?(payload.state.__strategy__.config, :reqllm_tools)
+      payload_tools = payload.state.__strategy__.config.reqllm_tools
+      assert payload_tools != []
+      assert Enum.all?(payload_tools, &(&1.callback == {ReqLLM.Tool, :new}))
 
       {:ok, restored} = CheckpointAgent.restore(payload, %{})
       config = restored.state.__strategy__.config
@@ -486,6 +592,10 @@ defmodule Jido.AI.CheckpointTest do
       assert length(config.reqllm_tools) == length(config.tools)
       assert Enum.all?(config.reqllm_tools, &is_struct(&1, ReqLLM.Tool))
       assert Enum.sort(Enum.map(config.reqllm_tools, & &1.name)) == ["gate", "read"]
+
+      legacy_payload = update_in(payload.state.__strategy__.config, &Map.delete(&1, :reqllm_tools))
+      {:ok, restored_legacy} = CheckpointAgent.restore(legacy_payload, %{})
+      assert Enum.sort(Enum.map(restored_legacy.state.__strategy__.config.reqllm_tools, & &1.name)) == ["gate", "read"]
 
       # A fresh, live task supervisor replaces the one dropped at checkpoint.
       assert is_pid(restored.state.__task_supervisor_skill__.supervisor)
@@ -534,9 +644,12 @@ defmodule Jido.AI.CheckpointTest do
       {:ok, payload} = CheckpointAgent.checkpoint(live, %{})
       record = request_record(payload, request.id)
 
-      assert record.status == :pending
+      assert record.status == :failed
+      assert record.error == :stream_interrupted
       refute Map.has_key?(record, :stream_to)
       assert record.stream_interrupted == true
+      assert payload.state.__strategy__.status == :idle
+      assert payload.state.__strategy__.active_request_id == nil
       assert Checkpoint.runtime_handles(payload) == []
       assert :erlang.binary_to_term(:erlang.term_to_binary(payload), [:safe]) == payload
 

--- a/test/jido_ai/tool_adapter_test.exs
+++ b/test/jido_ai/tool_adapter_test.exs
@@ -54,6 +54,14 @@ defmodule Jido.AI.ToolAdapterTest do
       assert tool.name == "param_action"
       assert tool.description == "An action with parameters"
       assert is_map(tool.parameter_schema)
+      assert tool.callback == {ReqLLM.Tool, :new}
+    end
+
+    test "uses a serializable callback placeholder" do
+      tool = ToolAdapter.from_action(ParamAction)
+
+      assert :erlang.binary_to_term(:erlang.term_to_binary(tool), [:safe]) == tool
+      assert tool.callback == {ReqLLM.Tool, :new}
     end
 
     test "applies prefix to tool name" do

--- a/test/jido_ai/tool_adapter_test.exs
+++ b/test/jido_ai/tool_adapter_test.exs
@@ -54,14 +54,14 @@ defmodule Jido.AI.ToolAdapterTest do
       assert tool.name == "param_action"
       assert tool.description == "An action with parameters"
       assert is_map(tool.parameter_schema)
-      assert tool.callback == {ReqLLM.Tool, :new}
+      assert tool.callback == {ToolAdapter, :noop_callback}
     end
 
     test "uses a serializable callback placeholder" do
       tool = ToolAdapter.from_action(ParamAction)
 
       assert :erlang.binary_to_term(:erlang.term_to_binary(tool), [:safe]) == tool
-      assert tool.callback == {ReqLLM.Tool, :new}
+      assert {:ok, %{}} = ReqLLM.Tool.execute(tool, %{query: "value"})
     end
 
     test "applies prefix to tool name" do


### PR DESCRIPTION
Fixes #327.

## Summary

- drop stream sinks when requests complete, fail, or are cancelled
- remove stream and ReAct process handles from checkpoint payloads
- restore active streamed requests as failed with `:stream_interrupted`
- keep ReqLLM tool placeholders serializable with a durable no-op callback

## Validation

- `mix test test/jido_ai/checkpoint_test.exs test/jido_ai/tool_adapter_test.exs`