### PR TITLE
fix(output): normalize Zoi array items

### DIFF
--- a/lib/jido_ai/output.ex
+++ b/lib/jido_ai/output.ex
@@ -390,6 +390,10 @@ defmodule Jido.AI.Output do
     end)
   end
 
+  defp normalize_zoi_input(%Zoi.Types.Array{inner: inner}, value) when is_list(value) do
+    Enum.map(value, &normalize_zoi_input(inner, &1))
+  end
+
   defp normalize_zoi_input(%Zoi.Types.Enum{enum_type: :atom, values: values}, value) when is_binary(value) do
     values
     |> Map.new(fn

--- a/test/jido_ai/output_test.exs
+++ b/test/jido_ai/output_test.exs
@@ -36,6 +36,26 @@ defmodule Jido.AI.OutputTest do
     assert parsed == %{category: :billing, confidence: 0.91, summary: "Refund request"}
   end
 
+  test "normalizes string keys in arrays of Zoi objects" do
+    schema =
+      Zoi.object(%{
+        items:
+          Zoi.array(
+            Zoi.object(%{
+              category: Zoi.enum([:billing, :technical]),
+              summary: Zoi.string()
+            })
+          )
+      })
+
+    {:ok, output} = Output.new(schema: schema)
+
+    assert {:ok, %{items: [%{category: :billing, summary: "Refund request"}]}} =
+             Output.validate(output, %{
+               "items" => [%{"category" => "billing", "summary" => "Refund request"}]
+             })
+  end
+
   test "parses fenced JSON text" do
     {:ok, output} = Output.new(schema: @schema)
 

--- a/test/jido_ai/output_test.exs
+++ b/test/jido_ai/output_test.exs
@@ -51,9 +51,10 @@ defmodule Jido.AI.OutputTest do
     {:ok, output} = Output.new(schema: schema)
 
     assert {:ok, %{items: [%{category: :billing, summary: "Refund request"}]}} =
-             Output.validate(output, %{
-               "items" => [%{"category" => "billing", "summary" => "Refund request"}]
-             })
+             Output.parse(
+               output,
+               ~s({"items":[{"category":"billing","summary":"Refund request"}]})
+             )
   end
 
   test "parses fenced JSON text" do


### PR DESCRIPTION
Fixes #334.

## Summary

Normalize each item in a Zoi array before schema validation. This preserves the existing key and atom-enum normalization for arrays of objects.

## Validation

- `mix test test/jido_ai/output_test.exs`
- `mix compile --warnings-as-errors`
- `mix doctor --summary --raise`

The local smoke suite also ran, but its existing 750 ms reasoning test timed out twice.