### PR TITLE
fix(reasoning): honor action observability options

### DIFF
--- a/lib/jido_ai/reasoning/helpers.ex
+++ b/lib/jido_ai/reasoning/helpers.ex
@@ -26,6 +26,7 @@ defmodule Jido.AI.Reasoning.Helpers do
   alias Jido.Agent.StateOp
   alias Jido.Agent.StateOps
   alias Jido.Agent
+  alias Jido.Observe.Config, as: ObserveConfig
 
   @type state_op ::
           StateOp.SetState.t() | StateOp.SetPath.t() | StateOp.DeleteKeys.t() | StateOp.DeletePath.t()
@@ -41,10 +42,13 @@ defmodule Jido.AI.Reasoning.Helpers do
   @spec execute_action_instruction(Agent.t(), Jido.Instruction.t(), strategy_ctx()) ::
           {Agent.t(), [struct()]}
   def execute_action_instruction(%Agent{} = agent, %Jido.Instruction{} = instruction, ctx \\ %{}) do
+    exec_opts = ObserveConfig.action_exec_opts(ctx[:jido_instance], instruction.opts)
+
     instruction =
       %Jido.Instruction{
         instruction
-        | context:
+        | opts: exec_opts,
+          context:
             instruction.context
             |> normalize_context()
             |> Map.merge(

--- a/test/jido_ai/reasoning/helpers_test.exs
+++ b/test/jido_ai/reasoning/helpers_test.exs
@@ -44,16 +44,18 @@ defmodule Jido.AI.Reasoning.HelpersTest do
     end
 
     test "applies global action observability options" do
-      original = Application.get_env(:jido, :telemetry, [])
-      on_exit(fn -> Application.put_env(:jido, :telemetry, original) end)
-      Application.put_env(:jido, :telemetry, log_level: :debug, log_args: :none)
+      preserve_env(:jido, :telemetry)
 
-      expect_exec_opts(fn opts ->
-        assert opts[:log_level] == :warning
-        assert opts[:telemetry] == :silent
-      end)
+      for log_args <- [:none, :keys_only] do
+        Application.put_env(:jido, :telemetry, log_level: :debug, log_args: log_args)
 
-      Helpers.execute_action_instruction(test_agent(), test_instruction())
+        expect_exec_opts(fn opts ->
+          assert opts[:log_level] == :warning
+          assert opts[:telemetry] == :silent
+        end)
+
+        Helpers.execute_action_instruction(test_agent(), test_instruction())
+      end
     end
 
     test "preserves explicit instruction options" do
@@ -71,8 +73,7 @@ defmodule Jido.AI.Reasoning.HelpersTest do
     end
 
     test "uses per-instance observability options from strategy context" do
-      original = Application.get_env(:jido_ai, TestJido, [])
-      on_exit(fn -> Application.put_env(:jido_ai, TestJido, original) end)
+      preserve_env(:jido_ai, TestJido)
       Application.put_env(:jido_ai, TestJido, telemetry: [log_level: :debug, log_args: :full])
 
       expect_exec_opts(fn opts ->
@@ -92,6 +93,17 @@ defmodule Jido.AI.Reasoning.HelpersTest do
   end
 
   defp test_agent, do: %Jido.Agent{id: "test-agent", name: "test", state: %{}}
+
+  defp preserve_env(app, key) do
+    original = Application.fetch_env(app, key)
+
+    on_exit(fn ->
+      case original do
+        {:ok, value} -> Application.put_env(app, key, value)
+        :error -> Application.delete_env(app, key)
+      end
+    end)
+  end
 
   defp test_instruction do
     %Jido.Instruction{action: FailingAction, params: %{}, context: %{}}

--- a/test/jido_ai/reasoning/helpers_test.exs
+++ b/test/jido_ai/reasoning/helpers_test.exs
@@ -1,7 +1,19 @@
 defmodule Jido.AI.Reasoning.HelpersTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
+  use Mimic
 
   alias Jido.AI.Reasoning.Helpers
+
+  setup :set_mimic_from_context
+
+  setup do
+    Mimic.copy(Jido.Exec)
+    :ok
+  end
+
+  defmodule TestJido do
+    use Jido, otp_app: :jido_ai
+  end
 
   defmodule FailingAction do
     use Jido.Action,
@@ -30,5 +42,58 @@ defmodule Jido.AI.Reasoning.HelpersTest do
       assert %{reason: _} = error.details
       assert error.details != %{}
     end
+
+    test "applies global action observability options" do
+      original = Application.get_env(:jido, :telemetry, [])
+      on_exit(fn -> Application.put_env(:jido, :telemetry, original) end)
+      Application.put_env(:jido, :telemetry, log_level: :debug, log_args: :none)
+
+      expect_exec_opts(fn opts ->
+        assert opts[:log_level] == :warning
+        assert opts[:telemetry] == :silent
+      end)
+
+      Helpers.execute_action_instruction(test_agent(), test_instruction())
+    end
+
+    test "preserves explicit instruction options" do
+      expect_exec_opts(fn opts ->
+        assert opts[:log_level] == :error
+        assert opts[:telemetry] == :full
+        assert opts[:retry] == false
+      end)
+
+      instruction =
+        test_instruction()
+        |> Map.put(:opts, log_level: :error, telemetry: :full, retry: false)
+
+      Helpers.execute_action_instruction(test_agent(), instruction)
+    end
+
+    test "uses per-instance observability options from strategy context" do
+      original = Application.get_env(:jido_ai, TestJido, [])
+      on_exit(fn -> Application.put_env(:jido_ai, TestJido, original) end)
+      Application.put_env(:jido_ai, TestJido, telemetry: [log_level: :debug, log_args: :full])
+
+      expect_exec_opts(fn opts ->
+        assert opts[:log_level] == :debug
+        assert opts[:telemetry] == :full
+      end)
+
+      Helpers.execute_action_instruction(test_agent(), test_instruction(), %{jido_instance: TestJido})
+    end
+  end
+
+  defp expect_exec_opts(assertion) do
+    Mimic.expect(Jido.Exec, :run, fn %Jido.Instruction{opts: opts} ->
+      assertion.(opts)
+      {:error, :something_broke}
+    end)
+  end
+
+  defp test_agent, do: %Jido.Agent{id: "test-agent", name: "test", state: %{}}
+
+  defp test_instruction do
+    %Jido.Instruction{action: FailingAction, params: %{}, context: %{}}
   end
 end


### PR DESCRIPTION
Fixes #326.

## Summary

Apply `Jido.Observe.Config.action_exec_opts/2` before the reasoning fallback calls `Jido.Exec`.

This makes the fallback honor global and per-instance logging settings while preserving explicit instruction options.

## Validation

- `mix test test/jido_ai/reasoning/helpers_test.exs`
- `mix compile --warnings-as-errors`
- `mix doctor --summary --raise`

The local smoke suite also ran, but its existing 750 ms reasoning test timed out.