### PR TITLE
fix(streaming): retain generated image content

### DIFF
--- a/guides/developer/plugins_and_actions_composition.md
+++ b/guides/developer/plugins_and_actions_composition.md
@@ -223,8 +223,8 @@ Normalization and sanitization:
 
 - `ai.llm.response` and `ai.tool.result` normalize malformed `data.result` to
   `{:error, %{code: :malformed_result, ...}, []}`
-- `ai.llm.delta` strips control bytes from `data.delta` and truncates to
-  `max_delta_chars`
+- `ai.llm.delta` strips control bytes from text in `data.delta` and truncates
+  it to `max_delta_chars`. Typed content parts pass through unchanged.
 
 Policy hardening config shape (using `Jido.Agent` so you can mount/configure
 this plugin directly):

--- a/guides/developer/signals_namespaces_contracts.md
+++ b/guides/developer/signals_namespaces_contracts.md
@@ -36,7 +36,12 @@ Typed signal modules define payload contracts and canonical signal types:
 
 ## Lifecycle Notes
 
-- `ai.llm.delta` carries incremental model text. Runtime-backed strategies may include optional ordering and correlation fields (`seq`, `request_id`, `run_id`, `iteration`). Consumers that need exact transcript reconstruction should order deltas by `seq` within the same `call_id` when it is present; delivery order alone is not a durable ordering contract.
+- `ai.llm.delta` carries incremental model text or a complete content part. Use
+  `chunk_type: :content_part` for typed media. Runtime-backed strategies may
+  include optional ordering and correlation fields (`seq`, `request_id`,
+  `run_id`, `iteration`). Consumers that need exact transcript reconstruction
+  should order deltas by `seq` within the same `call_id` when it is present;
+  delivery order alone is not a durable ordering contract.
 - `ai.tool.started` is the public start-of-execution contract for tool-capable runtimes.
 - `ai.tool.result` is the terminal contract for both success and failure.
 - `ai.request.started`, `ai.request.completed`, and `ai.request.failed` are expected across reasoning strategies, including AoT, CoT/CoD, GoT, ReAct, ToT, and TRM.

--- a/guides/user/model_routing_and_policy.md
+++ b/guides/user/model_routing_and_policy.md
@@ -137,7 +137,8 @@ Fix:
 
 - Model routing applies only when `model` is omitted
 - Policy also normalizes malformed `ai.llm.response` / `ai.tool.result` envelopes
-- Policy sanitizes/truncates `ai.llm.delta` using `max_delta_chars`
+- Policy sanitizes and truncates text in `ai.llm.delta` using
+  `max_delta_chars`. Typed content parts pass through unchanged.
 
 ## When To Use / Not Use
 

--- a/guides/user/turn_and_tool_results.md
+++ b/guides/user/turn_and_tool_results.md
@@ -42,11 +42,24 @@ turn = Turn.from_response(response, model: "my-custom-tag")
 The turn struct contains:
 - `type` — `:tool_calls` or `:final_answer`
 - `text` — extracted text content
+- `content_parts` — ordered ReqLLM content parts, including generated images
 - `thinking_content` — extended thinking output (or `nil`)
 - `tool_calls` — normalized list of tool call maps
 - `usage` — token usage metadata
 - `model` — model identifier
 - `tool_results` — populated after tool execution
+
+For a text-only turn, `Turn.result/1` returns the text string. For a
+multimodal turn, it returns the ordered visible content parts:
+
+```elixir
+result = Turn.result(turn)
+images = Turn.images(turn)
+```
+
+Generated images also use `:content_part` `ai.llm.delta` signals while a
+response streams. The signal `delta` is the complete
+`ReqLLM.Message.ContentPart`.
 
 You can also build from an already-classified map:
 

--- a/lib/jido_ai/context.ex
+++ b/lib/jido_ai/context.ex
@@ -351,11 +351,11 @@ defmodule Jido.AI.Context do
   defp truncate_content(content, max), do: content |> inspect() |> truncate_string(max)
 
   defp format_entry_for_pp(%Entry{role: :user, content: content}) do
-    "[user]   #{content}"
+    "[user]   #{format_content_for_pp(content)}"
   end
 
   defp format_entry_for_pp(%Entry{role: :assistant, content: content, tool_calls: nil}) do
-    "[asst]   #{content}"
+    "[asst]   #{format_content_for_pp(content)}"
   end
 
   defp format_entry_for_pp(%Entry{role: :assistant, tool_calls: tool_calls}) when is_list(tool_calls) do
@@ -377,12 +377,14 @@ defmodule Jido.AI.Context do
   end
 
   defp format_entry_for_pp(%Entry{role: :system, content: content}) do
-    "[system] #{content}"
+    "[system] #{format_content_for_pp(content)}"
   end
 
   defp format_entry_for_pp(%Entry{role: role, content: content}) do
-    "[#{role}] #{content}"
+    "[#{role}] #{format_content_for_pp(content)}"
   end
+
+  defp format_content_for_pp(content), do: truncate_content(content, 200)
 
   # Private helpers
 
@@ -440,6 +442,10 @@ defmodule Jido.AI.Context do
   defp build_assistant_content(content, nil), do: content
   defp build_assistant_content(content, ""), do: content
 
+  defp build_assistant_content(content, thinking) when is_list(content) and is_binary(thinking) do
+    [%{type: :thinking, thinking: thinking} | content]
+  end
+
   defp build_assistant_content(content, thinking) when is_binary(thinking) do
     [
       %{type: :thinking, thinking: thinking},
@@ -467,6 +473,19 @@ defmodule Jido.AI.Context do
 
   defp normalize_entry_content(role, content, _text_content) when role in [:user, :tool] and is_list(content),
     do: normalize_content_parts(content)
+
+  defp normalize_entry_content(:assistant, content, text_content) when is_list(content) do
+    content_parts =
+      content
+      |> Enum.reject(&(content_part_type(&1) in [:thinking, "thinking"]))
+      |> normalize_content_parts()
+
+    if Enum.any?(content_parts, &match?(%ContentPart{type: type} when type != :text, &1)) do
+      content_parts
+    else
+      text_content
+    end
+  end
 
   defp normalize_entry_content(_role, _content, text_content), do: text_content
 

--- a/lib/jido_ai/context.ex
+++ b/lib/jido_ai/context.ex
@@ -105,7 +105,7 @@ defmodule Jido.AI.Context do
   @doc """
   Append an assistant message to the thread, optionally with tool calls and thinking content.
   """
-  @spec append_assistant(t(), String.t() | nil, list() | nil, keyword()) :: t()
+  @spec append_assistant(t(), String.t() | [ContentPart.t()] | nil, list() | nil, keyword()) :: t()
   def append_assistant(thread, content, tool_calls \\ nil, opts \\ []) do
     thinking = Keyword.get(opts, :thinking)
     reasoning_details = Keyword.get(opts, :reasoning_details)
@@ -206,7 +206,7 @@ defmodule Jido.AI.Context do
   @doc """
   Get the last assistant response content.
   """
-  @spec last_assistant_content(t()) :: String.t() | nil
+  @spec last_assistant_content(t()) :: String.t() | [ContentPart.t()] | nil
   def last_assistant_content(%__MODULE__{entries: entries}) do
     # Entries are stored in reverse order, so first match is most recent
     entries

--- a/lib/jido_ai/directive/llm_stream.ex
+++ b/lib/jido_ai/directive/llm_stream.ex
@@ -3,8 +3,8 @@ defmodule Jido.AI.Directive.LLMStream do
   Directive asking the runtime to stream an LLM response via ReqLLM.
 
   Uses ReqLLM for streaming. The runtime will execute this asynchronously
-  and send partial tokens as `ai.llm.delta` signals and the final result
-  as a `ai.llm.response` signal.
+  and send text or complete content parts as `ai.llm.delta` signals. It sends
+  the final result as an `ai.llm.response` signal.
 
   ## New Fields
 
@@ -69,10 +69,10 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.LLMStream do
   @moduledoc """
   Spawns an async task to stream an LLM response and sends results back to the agent.
 
-  This implementation provides **true streaming**: as tokens arrive from the LLM,
-  they are immediately sent as `ai.llm.delta` signals. When the stream completes,
-  a final `ai.llm.response` signal is sent with the full classification (tool calls
-  or final answer).
+  This implementation provides **true streaming**: as text or complete content
+  parts arrive from the LLM, they are immediately sent as `ai.llm.delta`
+  signals. When the stream completes, a final `ai.llm.response` signal is sent
+  with the full classification (tool calls or final answer).
 
   Supports:
   - `model_alias` resolution via `Jido.AI.resolve_model/1`

--- a/lib/jido_ai/directive/llm_stream.ex
+++ b/lib/jido_ai/directive/llm_stream.ex
@@ -278,7 +278,26 @@ defimpl Jido.AgentServer.DirectiveExec, for: Jido.AI.Directive.LLMStream do
           maybe_emit_delta(obs_cfg, Observe.llm(:delta), %{duration_ms: 0}, event_meta)
         end
 
+        on_chunk = fn chunk ->
+          case Turn.stream_content_part(chunk) do
+            {:ok, content_part} ->
+              partial_signal =
+                Signal.LLMDelta.new!(%{
+                  call_id: call_id,
+                  delta: content_part,
+                  chunk_type: :content_part
+                })
+
+              Jido.AgentServer.cast(agent_pid, partial_signal)
+              maybe_emit_delta(obs_cfg, Observe.llm(:delta), %{duration_ms: 0}, event_meta)
+
+            :error ->
+              :ok
+          end
+        end
+
         case ReqLLM.StreamResponse.process_stream(stream_response,
+               on_chunk: on_chunk,
                on_result: on_content,
                on_thinking: on_thinking
              ) do

--- a/lib/jido_ai/plugins/policy.ex
+++ b/lib/jido_ai/plugins/policy.ex
@@ -27,8 +27,9 @@ defmodule Jido.AI.Plugins.Policy do
 
   - `ai.llm.response` and `ai.tool.result` normalize `data.result` into
     `{:ok, result, effects}` or `{:error, reason, effects}` tuples.
-  - `ai.llm.delta` sanitizes `data.delta` by removing control bytes and
-    truncating to `max_delta_chars` (default `4_000`).
+  - `ai.llm.delta` sanitizes text in `data.delta` by removing control bytes
+    and truncating to `max_delta_chars` (default `4_000`). Typed content parts
+    pass through unchanged.
   """
 
   use Jido.Plugin,
@@ -74,7 +75,7 @@ defmodule Jido.AI.Plugins.Policy do
   def schema do
     Zoi.object(%{
       mode: Zoi.atom(description: "Policy mode (:enforce or :monitor)") |> Zoi.default(:enforce),
-      max_delta_chars: Zoi.integer(description: "Max chars kept in ai.llm.delta payloads") |> Zoi.default(4_000),
+      max_delta_chars: Zoi.integer(description: "Max chars kept in text ai.llm.delta payloads") |> Zoi.default(4_000),
       block_on_validation_error:
         Zoi.boolean(description: "Block request/query/chat signals on validation failures")
         |> Zoi.default(true)

--- a/lib/jido_ai/reasoning/adaptive/strategy.ex
+++ b/lib/jido_ai/reasoning/adaptive/strategy.ex
@@ -153,7 +153,7 @@ defmodule Jido.AI.Reasoning.Adaptive.Strategy do
       schema:
         Zoi.object(%{
           call_id: Zoi.string(),
-          delta: Zoi.string(),
+          delta: Zoi.any(),
           chunk_type: Zoi.atom() |> Zoi.default(:content)
         }),
       doc: "Handle streaming LLM token chunk (delegated to selected strategy)",

--- a/lib/jido_ai/reasoning/algorithm_of_thoughts/machine.ex
+++ b/lib/jido_ai/reasoning/algorithm_of_thoughts/machine.ex
@@ -69,7 +69,7 @@ defmodule Jido.AI.Reasoning.AlgorithmOfThoughts.Machine do
   @type msg ::
           {:start, String.t(), String.t()}
           | {:llm_result, String.t(), term()}
-          | {:llm_partial, String.t(), String.t(), atom()}
+          | {:llm_partial, String.t(), term(), atom()}
 
   @type directive ::
           {:call_llm_stream, String.t(), list()}
@@ -121,7 +121,7 @@ defmodule Jido.AI.Reasoning.AlgorithmOfThoughts.Machine do
   end
 
   def update(%__MODULE__{status: "exploring"} = machine, {:llm_partial, call_id, delta, chunk_type}, _env) do
-    if call_id == machine.current_call_id and chunk_type == :content do
+    if call_id == machine.current_call_id and chunk_type == :content and is_binary(delta) do
       {Map.update!(machine, :streaming_text, &(&1 <> delta)), []}
     else
       {machine, []}

--- a/lib/jido_ai/reasoning/algorithm_of_thoughts/strategy.ex
+++ b/lib/jido_ai/reasoning/algorithm_of_thoughts/strategy.ex
@@ -68,7 +68,7 @@ defmodule Jido.AI.Reasoning.AlgorithmOfThoughts.Strategy do
       schema:
         Zoi.object(%{
           call_id: Zoi.string(),
-          delta: Zoi.string(),
+          delta: Zoi.any(),
           chunk_type: Zoi.atom() |> Zoi.default(:content)
         }),
       doc: "Handle streaming LLM token chunk",

--- a/lib/jido_ai/reasoning/chain_of_draft/strategy.ex
+++ b/lib/jido_ai/reasoning/chain_of_draft/strategy.ex
@@ -72,7 +72,7 @@ defmodule Jido.AI.Reasoning.ChainOfDraft.Strategy do
       schema:
         Zoi.object(%{
           call_id: Zoi.string(),
-          delta: Zoi.string(),
+          delta: Zoi.any(),
           chunk_type: Zoi.atom() |> Zoi.default(:content)
         }),
       doc: "Legacy no-op in delegated CoD mode",

--- a/lib/jido_ai/reasoning/chain_of_thought/machine.ex
+++ b/lib/jido_ai/reasoning/chain_of_thought/machine.ex
@@ -99,7 +99,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Machine do
   @type msg ::
           {:start, prompt :: String.t(), call_id :: String.t()}
           | {:llm_result, call_id :: String.t(), result :: term()}
-          | {:llm_partial, call_id :: String.t(), delta :: String.t(), chunk_type :: atom()}
+          | {:llm_partial, call_id :: String.t(), delta :: term(), chunk_type :: atom()}
 
   @type directive ::
           {:call_llm_stream, id :: String.t(), context :: list()}
@@ -177,7 +177,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Machine do
     if call_id == machine.current_call_id do
       machine =
         case chunk_type do
-          :content ->
+          :content when is_binary(delta) ->
             Map.update!(machine, :streaming_text, &(&1 <> delta))
 
           _ ->

--- a/lib/jido_ai/reasoning/chain_of_thought/strategy.ex
+++ b/lib/jido_ai/reasoning/chain_of_thought/strategy.ex
@@ -129,7 +129,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Strategy do
       schema:
         Zoi.object(%{
           call_id: Zoi.string(),
-          delta: Zoi.string(),
+          delta: Zoi.any(),
           chunk_type: Zoi.atom() |> Zoi.default(:content)
         }),
       doc: "Legacy no-op in delegated CoT mode",
@@ -473,7 +473,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Strategy do
         delta = event_field(data, :delta, "")
 
         updated =
-          if chunk_type == :content do
+          if chunk_type == :content and is_binary(delta) do
             Map.update(base_state, :streaming_text, delta, &(&1 <> delta))
           else
             base_state
@@ -486,6 +486,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Strategy do
 
       :llm_completed ->
         text = event_field(data, :text, "")
+        content_parts = event_field(data, :content_parts, [])
         usage = event_field(data, :usage, %{})
         call_id = event_field(data, :call_id, llm_call_id)
 
@@ -502,6 +503,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Strategy do
               {:ok,
                %{
                  text: text,
+                 content_parts: content_parts,
                  usage: usage
                }, []},
             metadata: runtime_signal_metadata(request_id, run_id, :generate_text)
@@ -512,10 +514,17 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Strategy do
         {updated, Enum.reject([llm_signal, usage_signal], &is_nil/1)}
 
       :request_completed ->
-        text = event_field(data, :result, "")
+        terminal_result = event_field(data, :result, "")
+        text = event_field(data, :text, if(is_binary(terminal_result), do: terminal_result, else: ""))
         usage = event_field(data, :usage, %{})
-        {steps, conclusion} = Machine.extract_steps_and_conclusion(text)
-        result = conclusion || text
+
+        {steps, conclusion, result} =
+          if is_binary(terminal_result) do
+            {steps, conclusion} = Machine.extract_steps_and_conclusion(terminal_result)
+            {steps, conclusion, conclusion || terminal_result}
+          else
+            {[], nil, terminal_result}
+          end
 
         updated =
           base_state

--- a/lib/jido_ai/reasoning/chain_of_thought/worker/strategy.ex
+++ b/lib/jido_ai/reasoning/chain_of_thought/worker/strategy.ex
@@ -8,6 +8,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Worker.Strategy do
   alias Jido.Agent.Strategy.State, as: StratState
   alias Jido.AI.Reasoning.ChainOfThought.Machine
   alias Jido.AI.Runtime.Event
+  alias Jido.AI.Turn
 
   @default_model :fast
 
@@ -354,6 +355,8 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Worker.Strategy do
         chunks = Enum.reverse(chunks)
         summary = ReqLLM.Response.Stream.summarize(chunks)
         text = summary.text
+        content_parts = Turn.content_parts_from_chunks(chunks)
+        result = Turn.result(%Turn{text: text, content_parts: content_parts})
         usage = ReqLLM.StreamResponse.usage(stream_response) || summary.usage || %{}
 
         {seq, _event} =
@@ -367,6 +370,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Worker.Strategy do
               call_id: llm_call_id,
               turn_type: :final_answer,
               text: text,
+              content_parts: content_parts,
               thinking_content: normalize_blank(summary.thinking),
               tool_calls: [],
               usage: usage
@@ -382,7 +386,8 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Worker.Strategy do
             seq,
             :request_completed,
             %{
-              result: text,
+              result: result,
+              text: text,
               termination_reason: :success,
               usage: usage
             }
@@ -463,6 +468,31 @@ defmodule Jido.AI.Reasoning.ChainOfThought.Worker.Strategy do
       )
     else
       {seq, nil}
+    end
+  end
+
+  defp maybe_emit_delta(
+         worker_pid,
+         request_id,
+         run_id,
+         llm_call_id,
+         %{__struct__: ReqLLM.StreamChunk, type: :content_part} = chunk,
+         config,
+         seq
+       ) do
+    with true <- config.capture_deltas?,
+         {:ok, content_part} <- Turn.stream_content_part(chunk) do
+      emit_runtime_event(
+        worker_pid,
+        request_id,
+        run_id,
+        seq,
+        :llm_delta,
+        %{chunk_type: :content_part, delta: content_part},
+        llm_call_id: llm_call_id
+      )
+    else
+      _other -> {seq, nil}
     end
   end
 

--- a/lib/jido_ai/reasoning/graph_of_thoughts/machine.ex
+++ b/lib/jido_ai/reasoning/graph_of_thoughts/machine.ex
@@ -638,10 +638,12 @@ defmodule Jido.AI.Reasoning.GraphOfThoughts.Machine do
     {machine, []}
   end
 
-  defp handle_llm_partial(machine, delta, _chunk_type) do
-    machine = Map.update!(machine, :streaming_text, &(&1 <> (delta || "")))
+  defp handle_llm_partial(machine, delta, :content) when is_binary(delta) do
+    machine = Map.update!(machine, :streaming_text, &(&1 <> delta))
     {machine, []}
   end
+
+  defp handle_llm_partial(machine, _delta, _chunk_type), do: {machine, []}
 
   defp handle_thought_generated(machine, content, env) do
     current_node = get_node(machine, machine.current_node_id)

--- a/lib/jido_ai/reasoning/graph_of_thoughts/strategy.ex
+++ b/lib/jido_ai/reasoning/graph_of_thoughts/strategy.ex
@@ -113,7 +113,7 @@ defmodule Jido.AI.Reasoning.GraphOfThoughts.Strategy do
       schema:
         Zoi.object(%{
           call_id: Zoi.string(),
-          delta: Zoi.string(),
+          delta: Zoi.any(),
           chunk_type: Zoi.atom() |> Zoi.default(:content)
         }),
       doc: "Handle streaming LLM token chunk",

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -284,6 +284,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
                     model: turn.model,
                     turn_type: turn.type,
                     text: turn.text,
+                    content_parts: turn.content_parts,
                     thinking_content: turn.thinking_content,
                     reasoning_details: Map.get(turn, :reasoning_details),
                     tool_calls: turn.tool_calls,
@@ -296,7 +297,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
               state =
                 AIContext.append_assistant(
                   state.context,
-                  turn.text,
+                  Turn.assistant_content(turn),
                   case turn.type do
                     :tool_calls -> turn.tool_calls
                     _ -> nil
@@ -315,7 +316,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
                   completed =
                     state
                     |> State.put_status(:completed)
-                    |> State.put_result(turn.text)
+                    |> State.put_result(Turn.result(turn))
 
                   {:final_answer, completed}
               end
@@ -1386,6 +1387,11 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   defp visible_chunk?(%ReqLLM.StreamChunk{type: :content, text: text}, trace_cfg), do: delta_captured?(text, trace_cfg)
   defp visible_chunk?(%ReqLLM.StreamChunk{type: :thinking, text: text}, trace_cfg), do: delta_captured?(text, trace_cfg)
   defp visible_chunk?(%ReqLLM.StreamChunk{type: :tool_call}, trace_cfg), do: trace_cfg[:capture_deltas?] == true
+
+  defp visible_chunk?(%{__struct__: ReqLLM.StreamChunk, type: :content_part} = chunk, trace_cfg) do
+    trace_cfg[:capture_deltas?] == true and match?({:ok, _content_part}, Turn.stream_content_part(chunk))
+  end
+
   defp visible_chunk?(_chunk, _trace_cfg), do: false
 
   defp delta_captured?(text, trace_cfg), do: trace_cfg[:capture_deltas?] == true and is_binary(text) and text != ""
@@ -1394,6 +1400,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     []
     |> Keyword.put(:on_chunk, fn chunk ->
       note_stream_chunk_activity(chunk, state_key, usage_key, owner, ref, trace_cfg, heartbeat_interval_ms)
+      maybe_emit_content_part_delta(chunk, state_key, owner, ref, trace_cfg, model)
     end)
     |> maybe_put_stream_callback(trace_cfg, :on_result, fn text ->
       emit_stream_delta(state_key, owner, ref, :content, text, model)
@@ -1410,6 +1417,15 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     case trace_cfg[:capture_deltas?] do
       true -> Keyword.put(opts, callback_key, callback_fun)
       _ -> opts
+    end
+  end
+
+  defp maybe_emit_content_part_delta(chunk, state_key, owner, ref, trace_cfg, model) do
+    with true <- trace_cfg[:capture_deltas?] == true,
+         {:ok, content_part} <- Turn.stream_content_part(chunk) do
+      emit_stream_delta(state_key, owner, ref, :content_part, content_part, model)
+    else
+      _other -> :ok
     end
   end
 
@@ -1607,7 +1623,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
       Turn.needs_tools?(turn) ->
         :ok
 
-      turn.text != "" ->
+      Turn.result(turn) != "" ->
         :ok
 
       invalid_blank_terminal_finish_reason?(turn.finish_reason) ->

--- a/lib/jido_ai/reasoning/react/strategy.ex
+++ b/lib/jido_ai/reasoning/react/strategy.ex
@@ -319,7 +319,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       schema:
         Zoi.object(%{
           call_id: Zoi.string(),
-          delta: Zoi.string(),
+          delta: Zoi.any(),
           chunk_type: Zoi.atom() |> Zoi.default(:content)
         }),
       doc: "Legacy no-op in delegated ReAct mode",
@@ -1171,9 +1171,11 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       :llm_completed ->
         turn_type = event_field(data, :turn_type, :final_answer)
         text = event_field(data, :text, "")
+        content_parts = event_field(data, :content_parts, [])
         tool_calls = event_field(data, :tool_calls, [])
         thinking = event_field(data, :thinking_content)
         assistant_tool_calls = if turn_type == :tool_calls, do: tool_calls, else: nil
+        content = Turn.assistant_content(%Turn{text: text, content_parts: content_parts})
 
         append_ai_message_event(
           agent,
@@ -1181,7 +1183,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           context_ref,
           %{
             role: :assistant,
-            content: text,
+            content: content,
             tool_calls: assistant_tool_calls,
             thinking: thinking
           },
@@ -1599,11 +1601,14 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
 
         updated =
           case chunk_type do
-            :thinking ->
+            :thinking when is_binary(delta) ->
               Map.update(base_state, :streaming_thinking, delta, &(&1 <> delta))
 
-            _ ->
+            :content when is_binary(delta) ->
               Map.update(base_state, :streaming_text, delta, &(&1 <> delta))
+
+            _other ->
+              base_state
           end
 
         signal =
@@ -1617,12 +1622,14 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
       :llm_completed ->
         turn_type = event_field(data, :turn_type, :final_answer)
         text = event_field(data, :text, "")
+        content_parts = event_field(data, :content_parts, [])
         thinking_content = event_field(data, :thinking_content)
         reasoning_details = event_field(data, :reasoning_details)
         tool_calls = event_field(data, :tool_calls, [])
         usage = event_field(data, :usage, %{})
         call_id = llm_call_id || event_field(data, :call_id, "")
         model = event_field(data, :model, config_model(state))
+        result = Turn.result(%Turn{text: text, content_parts: content_parts})
 
         pending_tool_calls =
           Enum.map(tool_calls, fn tc ->
@@ -1646,6 +1653,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
           |> append_assistant_to_run_context(
             turn_type,
             text,
+            content_parts,
             tool_calls,
             thinking_content,
             reasoning_details,
@@ -1655,7 +1663,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
             merge_usage(existing, usage || %{})
           end)
           |> maybe_append_thinking_trace(thinking_content)
-          |> maybe_put_result(turn_type, text)
+          |> maybe_put_result(turn_type, result)
 
         llm_signal =
           Signal.LLMResponse.new!(%{
@@ -1665,6 +1673,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
                %{
                  type: turn_type,
                  text: text,
+                 content_parts: content_parts,
                  thinking_content: thinking_content,
                  reasoning_details: reasoning_details,
                  tool_calls: tool_calls,
@@ -2136,6 +2145,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
          state,
          turn_type,
          text,
+         content_parts,
          tool_calls,
          thinking_content,
          reasoning_details,
@@ -2146,6 +2156,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
     case context do
       %AIContext{} = context ->
         assistant_tool_calls = if turn_type == :tool_calls, do: tool_calls, else: nil
+        content = Turn.assistant_content(%Turn{text: text, content_parts: content_parts})
 
         assistant_opts =
           []
@@ -2156,7 +2167,7 @@ defmodule Jido.AI.Reasoning.ReAct.Strategy do
         Map.put(
           state,
           :run_context,
-          AIContext.append_assistant(context, text, assistant_tool_calls, assistant_opts)
+          AIContext.append_assistant(context, content, assistant_tool_calls, assistant_opts)
         )
 
       _ ->

--- a/lib/jido_ai/reasoning/tree_of_thoughts/machine.ex
+++ b/lib/jido_ai/reasoning/tree_of_thoughts/machine.ex
@@ -185,7 +185,7 @@ defmodule Jido.AI.Reasoning.TreeOfThoughts.Machine do
           | {:thoughts_generated, call_id :: String.t(), thoughts :: [String.t()]}
           | {:thoughts_evaluated, call_id :: String.t(), scores :: %{String.t() => float()}}
           | {:llm_result, call_id :: String.t(), result :: term()}
-          | {:llm_partial, call_id :: String.t(), delta :: String.t(), chunk_type :: atom()}
+          | {:llm_partial, call_id :: String.t(), delta :: term(), chunk_type :: atom()}
 
   @type directive ::
           {:generate_thoughts, id :: String.t(), context :: list(), count :: pos_integer()}
@@ -342,7 +342,7 @@ defmodule Jido.AI.Reasoning.TreeOfThoughts.Machine do
     if call_id == machine.current_call_id do
       machine =
         case chunk_type do
-          :content ->
+          :content when is_binary(delta) ->
             Map.update!(machine, :streaming_text, &(&1 <> delta))
 
           _ ->

--- a/lib/jido_ai/reasoning/tree_of_thoughts/strategy.ex
+++ b/lib/jido_ai/reasoning/tree_of_thoughts/strategy.ex
@@ -160,7 +160,7 @@ defmodule Jido.AI.Reasoning.TreeOfThoughts.Strategy do
       schema:
         Zoi.object(%{
           call_id: Zoi.string(),
-          delta: Zoi.string(),
+          delta: Zoi.any(),
           chunk_type: Zoi.atom() |> Zoi.default(:content)
         }),
       doc: "Handle streaming LLM token chunk",

--- a/lib/jido_ai/reasoning/trm/machine.ex
+++ b/lib/jido_ai/reasoning/trm/machine.ex
@@ -181,7 +181,7 @@ defmodule Jido.AI.Reasoning.TRM.Machine do
           | {:reasoning_result, call_id :: String.t(), result :: term()}
           | {:supervision_result, call_id :: String.t(), result :: term()}
           | {:improvement_result, call_id :: String.t(), result :: term()}
-          | {:llm_partial, call_id :: String.t(), delta :: String.t(), chunk_type :: atom()}
+          | {:llm_partial, call_id :: String.t(), delta :: term(), chunk_type :: atom()}
 
   @type directive ::
           {:reason, id :: String.t(), context :: map()}
@@ -316,7 +316,7 @@ defmodule Jido.AI.Reasoning.TRM.Machine do
     if call_id == machine.current_call_id do
       machine =
         case chunk_type do
-          :content ->
+          :content when is_binary(delta) ->
             Map.update!(machine, :streaming_text, &(&1 <> delta))
 
           _ ->

--- a/lib/jido_ai/reasoning/trm/strategy.ex
+++ b/lib/jido_ai/reasoning/trm/strategy.ex
@@ -121,7 +121,7 @@ defmodule Jido.AI.Reasoning.TRM.Strategy do
       schema:
         Zoi.object(%{
           call_id: Zoi.string(),
-          delta: Zoi.string(),
+          delta: Zoi.any(),
           chunk_type: Zoi.atom() |> Zoi.default(:content)
         }),
       doc: "Handle streaming LLM token chunk",

--- a/lib/jido_ai/signals/helpers.ex
+++ b/lib/jido_ai/signals/helpers.ex
@@ -75,15 +75,20 @@ defmodule Jido.AI.Signal.Helpers do
   def correlation_id(_), do: nil
 
   @doc """
-  Sanitizes streaming deltas by removing control bytes and truncating payload size.
+  Sanitizes text deltas by removing control bytes and truncating payload size.
+
+  Non-text deltas, such as complete content parts, pass through unchanged.
   """
-  @spec sanitize_delta(term(), non_neg_integer()) :: String.t()
-  def sanitize_delta(delta, max_chars \\ 4_000) when is_integer(max_chars) and max_chars > 0 do
+  @spec sanitize_delta(term(), pos_integer()) :: term()
+  def sanitize_delta(delta, max_chars \\ 4_000)
+
+  def sanitize_delta(delta, max_chars) when is_binary(delta) and is_integer(max_chars) and max_chars > 0 do
     delta
-    |> to_string()
     |> String.replace(~r/[\x00-\x08\x0B\x0C\x0E-\x1F]/u, "")
     |> String.slice(0, max_chars)
   end
+
+  def sanitize_delta(delta, max_chars) when is_integer(max_chars) and max_chars > 0, do: delta
 
   defp first_present(values), do: Enum.find(values, &(not is_nil(&1)))
 end

--- a/lib/jido_ai/signals/llm_delta.ex
+++ b/lib/jido_ai/signals/llm_delta.ex
@@ -8,8 +8,12 @@ defmodule Jido.AI.Signal.LLMDelta do
     default_source: "/ai/llm",
     schema: [
       call_id: [type: :string, required: true, doc: "Correlation ID for the LLM call"],
-      delta: [type: :string, required: true, doc: "Text chunk from the stream"],
-      chunk_type: [type: :atom, default: :content, doc: "Type: :content or :thinking"],
+      delta: [type: :any, required: true, doc: "Text or complete content part from the stream"],
+      chunk_type: [
+        type: :atom,
+        default: :content,
+        doc: "Type: :content, :content_part, or :thinking"
+      ],
       metadata: [type: :map, default: %{}, doc: "Optional request/run metadata for correlation"],
       seq: [type: :integer, doc: "Monotonic runtime sequence number for this delta, when available"],
       run_id: [type: :string, doc: "Runtime run identifier, when available"],

--- a/lib/jido_ai/turn.ex
+++ b/lib/jido_ai/turn.ex
@@ -6,7 +6,7 @@ defmodule Jido.AI.Turn do
   directives:
 
   - Response classification (`:tool_calls` or `:final_answer`)
-  - Extracted text and optional thinking content
+  - Ordered multimodal content, extracted text, and optional thinking content
   - Normalized tool calls
   - Usage/model metadata
   - Optional executed tool results
@@ -45,6 +45,7 @@ defmodule Jido.AI.Turn do
   @type t :: %__MODULE__{
           type: response_type(),
           text: String.t(),
+          content_parts: [ContentPart.t()],
           thinking_content: String.t() | nil,
           reasoning_details: list() | nil,
           tool_calls: list(term()),
@@ -57,6 +58,7 @@ defmodule Jido.AI.Turn do
 
   defstruct type: :final_answer,
             text: "",
+            content_parts: [],
             thinking_content: nil,
             reasoning_details: nil,
             tool_calls: [],
@@ -85,17 +87,19 @@ defmodule Jido.AI.Turn do
 
   def from_response(%ReqLLM.Response{} = response, opts) do
     classified = ReqLLM.Response.classify(response)
+    message = response.message || %{}
 
     %__MODULE__{
       type: normalize_type(classified.type),
       text: normalize_text(classified.text),
+      content_parts: normalize_content_parts(Map.get(message, :content)),
       thinking_content: normalize_optional_string(classified.thinking),
-      reasoning_details: normalize_reasoning_details(Map.get(response.message || %{}, :reasoning_details)),
+      reasoning_details: normalize_reasoning_details(Map.get(message, :reasoning_details)),
       tool_calls: normalize_tool_calls(classified.tool_calls),
       usage: normalize_usage(ReqLLM.Response.usage(response)),
       model: Keyword.get(opts, :model, response.model),
       finish_reason: normalize_finish_reason(classified.finish_reason),
-      message_metadata: normalize_metadata(response.message.metadata),
+      message_metadata: normalize_metadata(Map.get(message, :metadata)),
       tool_results: []
     }
   end
@@ -109,6 +113,7 @@ defmodule Jido.AI.Turn do
     %__MODULE__{
       type: classify_type(tool_calls, finish_reason),
       text: extract_from_content(content),
+      content_parts: normalize_content_parts(content),
       thinking_content: extract_thinking_content(content),
       reasoning_details: normalize_reasoning_details(get_field(message, :reasoning_details)),
       tool_calls: tool_calls,
@@ -130,6 +135,7 @@ defmodule Jido.AI.Turn do
     %__MODULE__{
       type: normalize_type(get_field(map, :type, :final_answer)),
       text: normalize_text(get_field(map, :text, "")),
+      content_parts: map |> get_field(:content_parts, []) |> normalize_content_parts(),
       thinking_content: normalize_optional_string(get_field(map, :thinking_content)),
       reasoning_details: normalize_reasoning_details(get_field(map, :reasoning_details)),
       tool_calls: map |> get_field(:tool_calls, []) |> normalize_tool_calls(),
@@ -156,8 +162,55 @@ defmodule Jido.AI.Turn do
   def assistant_message(%__MODULE__{} = turn) do
     [metadata: turn.message_metadata]
     |> maybe_put_keyword(:tool_calls, assistant_tool_calls(turn))
-    |> then(&Context.assistant(turn.text, &1))
+    |> then(&Context.assistant(assistant_content(turn), &1))
     |> maybe_add(:reasoning_details, turn.reasoning_details)
+  end
+
+  @doc """
+  Returns the ordered visible content for assistant-message projection.
+  """
+  @spec assistant_content(t()) :: String.t() | [ContentPart.t()]
+  def assistant_content(%__MODULE__{} = turn) do
+    content_parts = visible_content_parts(turn.content_parts)
+
+    if multimodal?(content_parts), do: content_parts, else: turn.text
+  end
+
+  @doc """
+  Returns generated image content parts in response order.
+  """
+  @spec images(t()) :: [ContentPart.t()]
+  def images(%__MODULE__{content_parts: content_parts}) do
+    Enum.filter(content_parts, &match?(%ContentPart{type: type} when type in [:image, :image_url], &1))
+  end
+
+  @doc """
+  Returns text for text-only turns or ordered content parts for multimodal turns.
+  """
+  @spec result(t()) :: String.t() | [ContentPart.t()]
+  def result(%__MODULE__{} = turn) do
+    content_parts = visible_content_parts(turn.content_parts)
+
+    if multimodal?(content_parts), do: content_parts, else: turn.text
+  end
+
+  @doc false
+  @spec stream_content_part(term()) :: {:ok, ContentPart.t()} | :error
+  def stream_content_part(%{
+        __struct__: ReqLLM.StreamChunk,
+        type: :content_part,
+        content_part: %ContentPart{} = content_part
+      }),
+      do: {:ok, content_part}
+
+  def stream_content_part(_chunk), do: :error
+
+  @doc false
+  @spec content_parts_from_chunks(Enumerable.t()) :: [ContentPart.t()]
+  def content_parts_from_chunks(chunks) do
+    chunks
+    |> Enum.reduce([], &prepend_stream_content/2)
+    |> Enum.reverse()
   end
 
   @doc """
@@ -416,6 +469,7 @@ defmodule Jido.AI.Turn do
     %{
       type: turn.type,
       text: turn.text,
+      content_parts: turn.content_parts,
       thinking_content: turn.thinking_content,
       tool_calls: turn.tool_calls,
       usage: turn.usage,
@@ -454,6 +508,36 @@ defmodule Jido.AI.Turn do
 
   defp normalize_optional_string(value) when is_binary(value) and value != "", do: value
   defp normalize_optional_string(_), do: nil
+
+  defp visible_content_parts(content_parts) when is_list(content_parts) do
+    Enum.reject(content_parts, &match?(%ContentPart{type: :thinking}, &1))
+  end
+
+  defp visible_content_parts(_content_parts), do: []
+
+  defp multimodal?(content_parts) do
+    Enum.any?(content_parts, &match?(%ContentPart{type: type} when type != :text, &1))
+  end
+
+  defp prepend_stream_content(
+         %ReqLLM.StreamChunk{type: :content, text: text},
+         [%ContentPart{type: :text, text: existing} = part | rest]
+       )
+       when is_binary(text) and text != "" and is_binary(existing) do
+    [%{part | text: existing <> text} | rest]
+  end
+
+  defp prepend_stream_content(%ReqLLM.StreamChunk{type: :content, text: text}, content_parts)
+       when is_binary(text) and text != "" do
+    [ContentPart.text(text) | content_parts]
+  end
+
+  defp prepend_stream_content(chunk, content_parts) do
+    case stream_content_part(chunk) do
+      {:ok, content_part} -> [content_part | content_parts]
+      :error -> content_parts
+    end
+  end
 
   defp normalize_reasoning_details(reasoning_details) when is_list(reasoning_details) and reasoning_details != [],
     do: reasoning_details

--- a/test/jido_ai/directive/exec_runtime_test.exs
+++ b/test/jido_ai/directive/exec_runtime_test.exs
@@ -38,6 +38,12 @@ defmodule Jido.AI.Directive.ExecRuntimeTest do
   defp assert_ok_result({:ok, value, []}), do: value
   defp assert_error_result({:error, error, []}), do: error
 
+  defp content_part_chunk(content_part) do
+    ReqLLM.StreamChunk.meta(%{})
+    |> Map.put(:type, :content_part)
+    |> Map.put(:content_part, content_part)
+  end
+
   describe "LLMGenerate DirectiveExec" do
     test "emits usage and llm response signals on success" do
       supervisor = DirectiveSupport.start_task_supervisor!()
@@ -230,6 +236,7 @@ defmodule Jido.AI.Directive.ExecRuntimeTest do
     test "emits deltas, usage, and final response on successful stream processing" do
       supervisor = DirectiveSupport.start_task_supervisor!()
       on_exit(fn -> DirectiveSupport.stop_task_supervisor(supervisor) end)
+      image = ReqLLM.Message.ContentPart.image(<<1, 2, 3>>, "image/png")
 
       Mimic.copy(ReqLLM.StreamResponse)
 
@@ -241,6 +248,7 @@ defmodule Jido.AI.Directive.ExecRuntimeTest do
       end)
 
       Mimic.stub(ReqLLM.StreamResponse, :process_stream, fn :stream_response, callbacks ->
+        callbacks[:on_chunk].(content_part_chunk(image))
         callbacks[:on_thinking].("thinking chunk")
         callbacks[:on_result].("content chunk")
 
@@ -273,8 +281,17 @@ defmodule Jido.AI.Directive.ExecRuntimeTest do
 
       signal_1 = DirectiveSupport.assert_signal_cast("ai.llm.delta")
       signal_2 = DirectiveSupport.assert_signal_cast("ai.llm.delta")
+      signal_3 = DirectiveSupport.assert_signal_cast("ai.llm.delta")
 
-      assert Enum.sort([signal_1.data.chunk_type, signal_2.data.chunk_type]) == [:content, :thinking]
+      signals = [signal_1, signal_2, signal_3]
+
+      assert Enum.sort_by(Enum.map(signals, & &1.data.chunk_type), &Atom.to_string/1) == [
+               :content,
+               :content_part,
+               :thinking
+             ]
+
+      assert Enum.find(signals, &(&1.data.chunk_type == :content_part)).data.delta == image
 
       usage_signal = DirectiveSupport.assert_signal_cast("ai.usage")
       assert usage_signal.data.call_id == "llm_stream_ok"

--- a/test/jido_ai/plugins/policy_test.exs
+++ b/test/jido_ai/plugins/policy_test.exs
@@ -2,7 +2,9 @@ defmodule Jido.AI.Plugins.PolicyTest do
   use ExUnit.Case, async: true
 
   alias Jido.AI.Plugins.Policy
+  alias Jido.AI.Signal.LLMDelta
   alias Jido.Signal
+  alias ReqLLM.Message.ContentPart
 
   defp ctx(policy_state) do
     %{
@@ -65,6 +67,16 @@ defmodule Jido.AI.Plugins.PolicyTest do
                Policy.handle_signal(signal, ctx(%{mode: :enforce, max_delta_chars: 5}))
 
       assert rewritten.data.delta == "abcde"
+    end
+
+    test "preserves complete content parts in ai.llm.delta signals" do
+      image = ContentPart.image(<<1, 2, 3>>, "image/png")
+      signal = LLMDelta.new!(%{call_id: "c1", chunk_type: :content_part, delta: image})
+
+      assert {:ok, {:continue, rewritten}} =
+               Policy.handle_signal(signal, ctx(%{mode: :enforce, max_delta_chars: 5}))
+
+      assert rewritten.data.delta == image
     end
   end
 end

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -335,6 +335,41 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
            }
   end
 
+  test "retains generated images in stream deltas and the final result" do
+    image = ContentPart.image(<<1, 2, 3>>, "image/png")
+    chunk = content_part_chunk(image)
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      {:ok, responses_stream_response([chunk], %{finish_reason: :stop}, model)}
+    end)
+
+    Mimic.stub(ReqLLM.StreamResponse, :process_stream, fn stream_response, opts ->
+      Enum.each(stream_response.stream, opts[:on_chunk])
+
+      {:ok,
+       %{
+         message: %{content: [image], metadata: %{}},
+         finish_reason: :stop,
+         usage: %{},
+         model: stream_response.model
+       }}
+    end)
+
+    config = Config.new(%{model: :capable, tools: %{}})
+    events = ReAct.stream("Draw an image", config) |> Enum.to_list()
+
+    delta = Enum.find(events, &(&1.kind == :llm_delta))
+    assert delta.data.chunk_type == :content_part
+    assert delta.data.delta == image
+
+    llm_completed = Enum.find(events, &(&1.kind == :llm_completed))
+    assert llm_completed.data.content_parts == [image]
+
+    request_completed = Enum.find(events, &(&1.kind == :request_completed))
+    assert request_completed.data.result == [image]
+    assert ReAct.collect_stream(events).result == [image]
+  end
+
   test "propagates usage from streaming meta chunks into request completion" do
     Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
       {:ok,
@@ -2122,6 +2157,12 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
       model: model,
       context: Keyword.get(opts, :context, ReqLLM.Context.new([]))
     }
+  end
+
+  defp content_part_chunk(content_part) do
+    ReqLLM.StreamChunk.meta(%{})
+    |> Map.put(:type, :content_part)
+    |> Map.put(:content_part, content_part)
   end
 
   defp exited_pid do

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -370,6 +370,74 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     assert ReAct.collect_stream(events).result == [image]
   end
 
+  test "replays generated images and thinking as flat content on the next tool round" do
+    parent = self()
+    image = ContentPart.image_url("https://example.com/generated.png")
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, messages, _opts ->
+      count = :persistent_term.get({__MODULE__, :llm_call_count}, 0) + 1
+      :persistent_term.put({__MODULE__, :llm_call_count}, count)
+
+      case count do
+        1 ->
+          {:ok,
+           responses_stream_response(
+             [ReqLLM.StreamChunk.tool_call("calculator", %{"a" => 2, "b" => 3}, %{id: "tc_image"})],
+             %{finish_reason: :tool_calls},
+             model
+           )}
+
+        2 ->
+          send(parent, {:second_round_messages, messages})
+
+          {:ok,
+           responses_stream_response(
+             [ReqLLM.StreamChunk.text("Done")],
+             %{finish_reason: :stop},
+             model
+           )}
+      end
+    end)
+
+    Mimic.stub(ReqLLM.StreamResponse, :process_stream, fn stream_response, opts ->
+      {:ok, response} = process_stream_response(stream_response, opts)
+
+      if :persistent_term.get({__MODULE__, :llm_call_count}, 0) == 1 do
+        {:ok,
+         put_in(response, [:message, :content], [
+           %{type: :thinking, thinking: "I made an image before using the tool."},
+           image
+         ])}
+      else
+        {:ok, response}
+      end
+    end)
+
+    config =
+      Config.new(%{
+        model: :capable,
+        tools: %{CalculatorTool.name() => CalculatorTool},
+        tool_max_retries: 0
+      })
+
+    events = ReAct.stream("Make an image, then calculate", config) |> Enum.to_list()
+
+    assert_receive {:second_round_messages, messages}
+
+    assistant_message =
+      Enum.find(messages, fn
+        %{role: :assistant, tool_calls: [_ | _]} -> true
+        _message -> false
+      end)
+
+    assert assistant_message.content == [
+             %{type: :thinking, thinking: "I made an image before using the tool."},
+             image
+           ]
+
+    assert Enum.find(events, &(&1.kind == :request_completed)).data.result == "Done"
+  end
+
   test "propagates usage from streaming meta chunks into request completion" do
     Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
       {:ok,

--- a/test/jido_ai/strategy/chain_of_thought_test.exs
+++ b/test/jido_ai/strategy/chain_of_thought_test.exs
@@ -6,6 +6,7 @@ defmodule Jido.AI.Reasoning.ChainOfThought.StrategyTest do
   alias Jido.AI.Reasoning.ChainOfThought.Machine
   alias Jido.AI.Directive
   alias Jido.AI.Reasoning.ChainOfThought.Strategy, as: ChainOfThought
+  alias ReqLLM.Message.ContentPart
 
   defp create_agent(opts \\ []) do
     %Jido.Agent{
@@ -269,6 +270,50 @@ defmodule Jido.AI.Reasoning.ChainOfThought.StrategyTest do
       assert signal.data.seq == 23
       assert signal.data.run_id == request_id
       assert signal.data.request_id == request_id
+    end
+
+    test "passes complete content parts and preserves a multimodal result" do
+      agent = create_agent()
+      request_id = "req_cot_content_part"
+      image = ContentPart.image(<<1, 2, 3>>, "image/png")
+
+      delta_event =
+        worker_event(:llm_delta, request_id, 24, %{
+          chunk_type: :content_part,
+          delta: image
+        })
+
+      {agent, []} =
+        ChainOfThought.cmd(
+          agent,
+          [instruction(:cot_worker_event, %{request_id: request_id, event: delta_event})],
+          %{}
+        )
+
+      assert_receive {:"$gen_cast", {:signal, signal}}
+      assert signal.type == "ai.llm.delta"
+      assert signal.data.chunk_type == :content_part
+      assert signal.data.delta == image
+
+      completed_event =
+        worker_event(:request_completed, request_id, 25, %{
+          result: [image],
+          text: "",
+          termination_reason: :success,
+          usage: %{}
+        })
+
+      {agent, []} =
+        ChainOfThought.cmd(
+          agent,
+          [instruction(:cot_worker_event, %{request_id: request_id, event: completed_event})],
+          %{}
+        )
+
+      state = StratState.get(agent, %{})
+      assert state[:result] == [image]
+      assert state[:raw_response] == ""
+      assert state[:steps] == []
     end
 
     test "request_failed worker event transitions to error state" do

--- a/test/jido_ai/strategy/react_test.exs
+++ b/test/jido_ai/strategy/react_test.exs
@@ -10,6 +10,7 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
   alias Jido.AI.Reasoning.ReAct.Strategy, as: ReAct
   alias Jido.Thread
   alias Jido.Thread.Agent, as: ThreadAgent
+  alias ReqLLM.Message.ContentPart
 
   defmodule TestCalculator do
     use Jido.Action,
@@ -1262,6 +1263,49 @@ defmodule Jido.AI.Reasoning.ReAct.StrategyTest do
       assert signal.data.run_id == request_id
       assert signal.data.request_id == request_id
       assert signal.data.iteration == 1
+    end
+
+    test "passes complete content parts without appending them to text state" do
+      agent = create_agent(tools: [TestCalculator])
+      request_id = "req_content_part"
+      image = ContentPart.image(<<1, 2, 3>>, "image/png")
+
+      delta_event =
+        runtime_event(:llm_delta, request_id, 18, %{
+          chunk_type: :content_part,
+          delta: image
+        })
+
+      {agent, []} =
+        ReAct.cmd(
+          agent,
+          [instruction(:ai_react_worker_event, %{request_id: request_id, event: delta_event})],
+          %{}
+        )
+
+      assert_receive {:"$gen_cast", {:signal, signal}}
+      assert signal.type == "ai.llm.delta"
+      assert signal.data.chunk_type == :content_part
+      assert signal.data.delta == image
+      assert StratState.get(agent, %{}).streaming_text == ""
+
+      completed_event =
+        runtime_event(:llm_completed, request_id, 19, %{
+          turn_type: :final_answer,
+          text: "",
+          content_parts: [image],
+          tool_calls: [],
+          usage: %{}
+        })
+
+      {agent, []} =
+        ReAct.cmd(
+          agent,
+          [instruction(:ai_react_worker_event, %{request_id: request_id, event: completed_event})],
+          %{}
+        )
+
+      assert StratState.get(agent, %{}).result == [image]
     end
 
     test "uses runtime event model for LLM delta telemetry" do

--- a/test/jido_ai/thread_test.exs
+++ b/test/jido_ai/thread_test.exs
@@ -319,6 +319,34 @@ defmodule Jido.AI.ContextTest do
       assert text_block == %{type: :text, text: "The answer is 42."}
     end
 
+    test "keeps multimodal assistant content flat when thinking is present" do
+      image = ContentPart.image_url("https://example.com/generated.png")
+      content = [ContentPart.text("Generated:"), image]
+
+      thread =
+        AIContext.new()
+        |> AIContext.append_assistant(content, nil, thinking: "I will make an image.")
+
+      [message] = AIContext.to_messages(thread)
+
+      assert message.content == [
+               %{type: :thinking, thinking: "I will make an image."},
+               ContentPart.text("Generated:"),
+               image
+             ]
+
+      rebuilt = AIContext.new() |> AIContext.append_messages([message])
+      [entry] = rebuilt.entries
+
+      assert entry.content == content
+      assert entry.thinking == "I will make an image."
+      assert AIContext.to_messages(rebuilt) == [message]
+
+      output = capture_io(fn -> assert :ok = AIContext.pp(rebuilt) end)
+      assert output =~ "[asst]"
+      assert output =~ "image_url"
+    end
+
     test "projects assistant message without thinking as plain string" do
       thread =
         AIContext.new()

--- a/test/jido_ai/turn_test.exs
+++ b/test/jido_ai/turn_test.exs
@@ -63,6 +63,8 @@ defmodule Jido.AI.TurnTest do
 
       assert turn.type == :final_answer
       assert turn.text == "hello\nworld"
+      assert Turn.assistant_content(turn) == "hello\nworld"
+      assert Turn.result(turn) == "hello\nworld"
       assert turn.thinking_content == "let me think"
       assert turn.tool_calls == []
       assert turn.usage == %{input_tokens: 10, output_tokens: 5}
@@ -161,6 +163,64 @@ defmodule Jido.AI.TurnTest do
       assert turn.usage == %{input_tokens: 4, output_tokens: 2}
       assert turn.model == "anthropic:claude-haiku-4-5"
       assert turn.message_metadata == %{response_id: "resp_1"}
+    end
+
+    test "retains generated images from canonical and map responses" do
+      image = ContentPart.image(<<1, 2, 3>>, "image/png")
+      image_url = ContentPart.image_url("https://example.com/generated.png")
+
+      response = %ReqLLM.Response{
+        id: "resp_image",
+        model: "openrouter:google/gemini-3-pro-image",
+        context: ReqLLM.Context.new(),
+        message: ReqLLM.Context.assistant([ContentPart.text("Generated:"), image, image_url]),
+        stream?: false,
+        stream: nil,
+        usage: %{},
+        finish_reason: :stop,
+        provider_meta: %{},
+        error: nil
+      }
+
+      turn = Turn.from_response(response)
+
+      assert turn.text == "Generated:"
+      assert turn.content_parts == [ContentPart.text("Generated:"), image, image_url]
+      assert Turn.images(turn) == [image, image_url]
+      assert Turn.result(turn) == turn.content_parts
+      assert Turn.assistant_message(turn).content == turn.content_parts
+      assert Turn.to_result_map(turn).content_parts == turn.content_parts
+
+      map_turn =
+        Turn.from_response(%{
+          message: %{
+            content: [
+              %{"type" => "image_url", "url" => "https://example.com/generated.png"},
+              %{"type" => "text", "text" => "Caption"}
+            ]
+          },
+          finish_reason: :stop
+        })
+
+      assert map_turn.content_parts == [image_url, ContentPart.text("Caption")]
+      assert Turn.result(map_turn) == map_turn.content_parts
+    end
+
+    test "retains ordered complete content parts from stream chunks" do
+      image = ContentPart.image(<<1, 2, 3>>, "image/png")
+
+      chunks = [
+        ReqLLM.StreamChunk.text("Before "),
+        ReqLLM.StreamChunk.text("image"),
+        content_part_chunk(image),
+        ReqLLM.StreamChunk.text("After")
+      ]
+
+      assert Turn.content_parts_from_chunks(chunks) == [
+               ContentPart.text("Before image"),
+               image,
+               ContentPart.text("After")
+             ]
     end
 
     test "propagates finish_reason from ReqLLM.Response for incomplete responses" do
@@ -791,5 +851,11 @@ defmodule Jido.AI.TurnTest do
 
       refute log =~ "Executing"
     end
+  end
+
+  defp content_part_chunk(content_part) do
+    ReqLLM.StreamChunk.meta(%{})
+    |> Map.put(:type, :content_part)
+    |> Map.put(:content_part, content_part)
   end
 end


### PR DESCRIPTION
## Summary

- Keep ordered ReqLLM content parts on each turn.
- Emit complete generated media parts as `:content_part` stream deltas.
- Preserve multimodal results in ReAct and Chain of Thought flows.
- Keep text-only result and context values as strings.

## Validation

- `mix compile --warnings-as-errors`
- `mix test` — 2,352 passed, 1 excluded
- focused turn, directive, ReAct, and Chain of Thought tests

Closes #336