### PR TITLE
fix(tools): preserve non-strict open schemas

### DIFF
--- a/lib/jido_ai/tool_adapter.ex
+++ b/lib/jido_ai/tool_adapter.ex
@@ -284,6 +284,8 @@ defmodule Jido.AI.ToolAdapter do
   # Support released jido_action API (`to_json_schema/1`) and
   # newer branch API (`to_json_schema/2`) used by some dev setups.
   defp action_schema_to_json_schema(schema, strict?) do
+    Code.ensure_loaded!(ActionSchema)
+
     cond do
       function_exported?(ActionSchema, :to_json_schema, 2) ->
         apply(ActionSchema, :to_json_schema, [schema, [strict: strict?]])
@@ -292,7 +294,7 @@ defmodule Jido.AI.ToolAdapter do
         ActionSchema.to_json_schema(schema)
 
       true ->
-        %{}
+        raise ArgumentError, "Jido.Action.Schema does not expose to_json_schema/1 or to_json_schema/2"
     end
   end
 

--- a/lib/jido_ai/tool_adapter.ex
+++ b/lib/jido_ai/tool_adapter.ex
@@ -140,7 +140,7 @@ defmodule Jido.AI.ToolAdapter do
     ReqLLM.Tool.new!(
       name: apply_prefix(action_module.name(), prefix),
       description: action_module.description(),
-      parameter_schema: build_json_schema(action_module.schema()),
+      parameter_schema: build_json_schema(action_module.schema(), strict),
       callback: {__MODULE__, :noop_callback},
       strict: strict
     )
@@ -271,8 +271,8 @@ defmodule Jido.AI.ToolAdapter do
     Enum.filter(modules, filter_fn)
   end
 
-  defp build_json_schema(schema) do
-    case schema |> action_schema_to_json_schema() |> enforce_no_additional_properties() do
+  defp build_json_schema(schema, strict?) do
+    case schema |> action_schema_to_json_schema(strict?) |> enforce_no_additional_properties() do
       empty when empty == %{} ->
         %{"type" => "object", "properties" => %{}, "required" => [], "additionalProperties" => false}
 
@@ -283,10 +283,10 @@ defmodule Jido.AI.ToolAdapter do
 
   # Support released jido_action API (`to_json_schema/1`) and
   # newer branch API (`to_json_schema/2`) used by some dev setups.
-  defp action_schema_to_json_schema(schema) do
+  defp action_schema_to_json_schema(schema, strict?) do
     cond do
       function_exported?(ActionSchema, :to_json_schema, 2) ->
-        apply(ActionSchema, :to_json_schema, [schema, [strict: true]])
+        apply(ActionSchema, :to_json_schema, [schema, [strict: strict?]])
 
       function_exported?(ActionSchema, :to_json_schema, 1) ->
         ActionSchema.to_json_schema(schema)

--- a/lib/jido_ai/tool_adapter.ex
+++ b/lib/jido_ai/tool_adapter.ex
@@ -281,8 +281,8 @@ defmodule Jido.AI.ToolAdapter do
     end
   end
 
-  # Support released jido_action API (`to_json_schema/1`) and
-  # newer branch API (`to_json_schema/2`) used by some dev setups.
+  # Prefer the converter that accepts strictness. Keep the arity-one fallback
+  # for compatible jido_action versions that do not accept options.
   defp action_schema_to_json_schema(schema, strict?) do
     Code.ensure_loaded!(ActionSchema)
 

--- a/test/jido_ai/tool_adapter_test.exs
+++ b/test/jido_ai/tool_adapter_test.exs
@@ -63,6 +63,23 @@ defmodule Jido.AI.ToolAdapterTest do
     def strict?, do: false
   end
 
+  defmodule StrictOpenParamsAction do
+    use Jido.Action,
+      name: "strict_open_params_action",
+      description: "A strict action with card-specific parameters",
+      schema: %{
+        "type" => "object",
+        "properties" => %{
+          "id" => %{"type" => "string"},
+          "params" => %{"type" => "object", "additionalProperties" => true}
+        },
+        "required" => ["id", "params"],
+        "additionalProperties" => false
+      }
+
+    def strict?, do: true
+  end
+
   describe "from_action/2" do
     test "converts action to ReqLLM.Tool struct" do
       tool = ToolAdapter.from_action(ParamAction)
@@ -132,6 +149,21 @@ defmodule Jido.AI.ToolAdapterTest do
       assert tool.strict == false
       assert tool.parameter_schema["additionalProperties"] == false
       assert tool.parameter_schema["properties"]["params"]["additionalProperties"] == true
+    end
+
+    test "uses an explicit non-strict override during schema conversion" do
+      tool = ToolAdapter.from_action(StrictOpenParamsAction, strict: false)
+
+      assert tool.strict == false
+      assert tool.parameter_schema["properties"]["params"]["additionalProperties"] == true
+    end
+
+    test "preserves the open schema in the OpenAI tool payload" do
+      tool = ToolAdapter.from_action(OpenParamsAction)
+      function = ReqLLM.Tool.to_schema(tool, :openai)["function"]
+
+      refute Map.has_key?(function, "strict")
+      assert function["parameters"]["properties"]["params"]["additionalProperties"] == true
     end
 
     test "closes explicitly open nested objects when strict mode is requested" do

--- a/test/jido_ai/tool_adapter_test.exs
+++ b/test/jido_ai/tool_adapter_test.exs
@@ -46,6 +46,23 @@ defmodule Jido.AI.ToolAdapterTest do
       ]
   end
 
+  defmodule OpenParamsAction do
+    use Jido.Action,
+      name: "open_params_action",
+      description: "An action with card-specific parameters",
+      schema: %{
+        "type" => "object",
+        "properties" => %{
+          "id" => %{"type" => "string"},
+          "params" => %{"type" => "object", "additionalProperties" => true}
+        },
+        "required" => ["id", "params"],
+        "additionalProperties" => false
+      }
+
+    def strict?, do: false
+  end
+
   describe "from_action/2" do
     test "converts action to ReqLLM.Tool struct" do
       tool = ToolAdapter.from_action(ParamAction)
@@ -107,6 +124,21 @@ defmodule Jido.AI.ToolAdapterTest do
 
       # Nested objects inside array items
       assert schema["properties"]["items"]["items"]["additionalProperties"] == false
+    end
+
+    test "preserves explicitly open nested objects for non-strict tools" do
+      tool = ToolAdapter.from_action(OpenParamsAction)
+
+      assert tool.strict == false
+      assert tool.parameter_schema["additionalProperties"] == false
+      assert tool.parameter_schema["properties"]["params"]["additionalProperties"] == true
+    end
+
+    test "closes explicitly open nested objects when strict mode is requested" do
+      tool = ToolAdapter.from_action(OpenParamsAction, strict: true)
+
+      assert tool.strict == true
+      assert tool.parameter_schema["properties"]["params"]["additionalProperties"] == false
     end
 
     test "handles empty schema with valid JSON schema output" do


### PR DESCRIPTION
## Summary

- Pass each tool's effective `strict` value into JSON Schema conversion.
- Preserve explicitly open nested objects for non-strict tools.
- Close those objects when strict mode is active.
- Load `Jido.Action.Schema` before converter discovery and fail clearly when no supported converter exists.
- Add coverage for inferred strictness, explicit overrides, and the OpenAI-compatible payload.

## Root cause

`ToolAdapter.from_action/2` computed the effective strictness for the `ReqLLM.Tool`, but schema conversion always used `strict: true`. A tool could therefore report `strict: false` while its nested schema was closed. Dynamic nested parameters could then accept only an empty object.

This affected some Fireworks.ai tool calls. OpenAI models did not show the same problem.

## Behavior

Non-strict tools keep a declared `additionalProperties: true`. Strict tools replace it with `false`. Objects that omit `additionalProperties` remain closed by the adapter's normalizer.

The independent timed-test preload fix was split into #342 and is now on `main`.

## Validation

- `mix test test/jido_ai/tool_adapter_test.exs` — 32 passed
- `mix precommit` — passed
- `mix test` — 2,359 passed, 1 excluded