### PR TITLE
test: preload LLMDB for timed strategy suites

### DIFF
--- a/test/jido_ai/skills/reasoning/actions/run_strategy_action_fast_test.exs
+++ b/test/jido_ai/skills/reasoning/actions/run_strategy_action_fast_test.exs
@@ -18,6 +18,13 @@ defmodule Jido.AI.Actions.Reasoning.RunStrategyFastTest do
   setup :set_mimic_from_context
   setup :stub_req_llm
 
+  setup_all do
+    # Complete the one-time catalog load before a strategy request starts its
+    # 750 ms timeout budget.
+    _ = LLMDB.providers()
+    :ok
+  end
+
   defp stub_req_llm(context), do: FakeReqLLM.setup_stubs(context)
 
   test "executes representative strategy path for fast gate" do

--- a/test/jido_ai/skills/reasoning/actions/run_strategy_action_test.exs
+++ b/test/jido_ai/skills/reasoning/actions/run_strategy_action_test.exs
@@ -19,6 +19,13 @@ defmodule Jido.AI.Actions.Reasoning.RunStrategyTest do
   setup :set_mimic_from_context
   setup :stub_req_llm
 
+  setup_all do
+    # Complete the one-time catalog load before a strategy request starts its
+    # 750 ms timeout budget.
+    _ = LLMDB.providers()
+    :ok
+  end
+
   defp stub_req_llm(context), do: FakeReqLLM.setup_stubs(context)
 
   defp assert_strategy_response({:ok, payload}, strategy) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,4 +6,10 @@ Mimic.copy(ReqLLM.Providers.OpenAICodex)
 Mimic.copy(ReqLLM.StreamResponse)
 Mimic.copy(Jido.AgentServer)
 
+# Load the LLMDB model catalog before any test runs so that the first model
+# lookup does not pay the one-time snapshot load inside a test's timeout
+# budget. The isolated fast gate (`mix test.fast`) otherwise exceeds the
+# 750 ms `RunStrategyFastTest` budget on hosts where the load is slow.
+{:ok, _} = LLMDB.load()
+
 ExUnit.start(exclude: [:flaky], capture_log: true)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,10 +6,4 @@ Mimic.copy(ReqLLM.Providers.OpenAICodex)
 Mimic.copy(ReqLLM.StreamResponse)
 Mimic.copy(Jido.AgentServer)
 
-# Load the LLMDB model catalog before any test runs so that the first model
-# lookup does not pay the one-time snapshot load inside a test's timeout
-# budget. The isolated fast gate (`mix test.fast`) otherwise exceeds the
-# 750 ms `RunStrategyFastTest` budget on hosts where the load is slow.
-{:ok, _} = LLMDB.load()
-
 ExUnit.start(exclude: [:flaky], capture_log: true)


### PR DESCRIPTION
## Summary

- Preload the packaged LLMDB model catalog before the timed strategy suites.
- Keep the one-time catalog load outside each strategy request's timeout budget.
- Do not change global test setup.
- Split this independent test-harness fix from #341.

## Root cause

The first model lookup performs a one-time LLMDB snapshot load. In the isolated `mix test.fast` gate, that load can occur inside `RunStrategyFastTest` and exceed its 750 ms request timeout. The full suite can hide the problem when an earlier test loads the catalog first.

## Impact

The affected strategy suites no longer depend on test order or catalog cold-load speed. Unrelated tests do not pay for a global preload.

## Validation

- `mix test test/jido_ai/skills/reasoning/actions/run_strategy_action_fast_test.exs` — 2 passed
- `mix test test/jido_ai/skills/reasoning/actions/run_strategy_action_test.exs` — 9 passed
- `mix test.fast` — 4 passed
- `mix precommit` — passed
- Comparison without the preload reproduced the `RunStrategyFastTest` timeout on this host.