### PR TITLE
fix(reasoning/react): run structured-output repair through request_transformer

### DIFF
--- a/lib/jido_ai/output.ex
+++ b/lib/jido_ai/output.ex
@@ -244,29 +244,42 @@ defmodule Jido.AI.Output do
     |> String.slice(0, @raw_preview_bytes)
   end
 
-  defp default_repair(output, raw, reason, context) do
-    model = Map.get(context, :model)
+  @doc false
+  @spec repair_request(term(), term(), map()) :: %{
+          required(:model) => term(),
+          required(:messages) => [map()],
+          required(:llm_opts) => keyword(),
+          required(:tools) => %{}
+        }
+  def repair_request(raw, reason, context) when is_map(context) do
+    messages =
+      case Map.get(context, :messages) do
+        messages when is_list(messages) -> messages
+        _other -> default_repair_messages(raw, reason, context)
+      end
 
-    if is_nil(model) do
+    llm_opts =
+      context
+      |> Map.get(:llm_opts, [])
+      |> Keyword.delete(:tools)
+      |> Keyword.delete(:tool_choice)
+      |> Keyword.put(:stream, false)
+
+    %{
+      model: Map.get(context, :model),
+      messages: messages,
+      llm_opts: llm_opts,
+      tools: %{}
+    }
+  end
+
+  defp default_repair(output, raw, reason, context) do
+    request = repair_request(raw, reason, context)
+
+    if is_nil(request.model) do
       {:error, output_error(:missing_repair_model, raw)}
     else
-      messages = [
-        %{
-          role: :system,
-          content:
-            "Extract a JSON object that matches the provided schema from the assistant answer. Return only the structured object."
-        },
-        %{role: :user, content: repair_prompt(context, raw, reason)}
-      ]
-
-      llm_opts =
-        context
-        |> Map.get(:llm_opts, [])
-        |> Keyword.delete(:tools)
-        |> Keyword.delete(:tool_choice)
-        |> Keyword.put(:stream, false)
-
-      case ReqLLM.Generation.generate_object(model, messages, output.schema, llm_opts) do
+      case ReqLLM.Generation.generate_object(request.model, request.messages, output.schema, request.llm_opts) do
         {:ok, response} ->
           unwrap_generated_response(response)
 
@@ -274,6 +287,17 @@ defmodule Jido.AI.Output do
           {:error, output_error({:repair_failed, reason_message(error)}, raw)}
       end
     end
+  end
+
+  defp default_repair_messages(raw, reason, context) do
+    [
+      %{
+        role: :system,
+        content:
+          "Extract a JSON object that matches the provided schema from the assistant answer. Return only the structured object."
+      },
+      %{role: :user, content: repair_prompt(context, raw, reason)}
+    ]
   end
 
   defp invoke_repair(nil, output, raw, reason, context) do

--- a/lib/jido_ai/reasoning/react/request_transformer.ex
+++ b/lib/jido_ai/reasoning/react/request_transformer.ex
@@ -17,8 +17,14 @@ defmodule Jido.AI.Reasoning.ReAct.RequestTransformer do
     so xAI-only keys (e.g. `xai_api`) can be added on xAI turns without
     breaking Fireworks turns on the same agent.
 
-  The runtime always regenerates `llm_opts[:tools]` from the returned `tools`
-  field so the exposed LLM tools and execution registry stay aligned.
+  For normal ReAct turns, the runtime regenerates `llm_opts[:tools]` from the
+  returned `tools` field so the exposed LLM tools and execution registry stay
+  aligned.
+
+  Structured-output repair turns also pass through the transformer. Their
+  request contains the repair prompt and an empty tool set. The runtime applies
+  `messages`, `model`, and `llm_opts` overrides, but it keeps tools disabled for
+  the repair call.
   """
 
   alias Jido.AI.Reasoning.ReAct.{Config, State, ToolSelection}

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -1033,7 +1033,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
         validation_error: reason
       )
 
-    case output_context(state, config, runtime_context) do
+    case output_context(state, config, runtime_context, raw, reason) do
       {:ok, context} ->
         case Output.repair(output, raw, reason, context) do
           {:ok, parsed} ->
@@ -1098,23 +1098,29 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     emit_event(state, owner, ref, kind, data)
   end
 
-  defp output_context(%State{} = state, %Config{} = config, runtime_context) do
-    base_request = %{
-      messages: AIContext.to_messages(state.context),
+  defp output_context(%State{} = state, %Config{} = config, runtime_context, raw, reason) do
+    base_context = %{
+      model: config.model,
       llm_opts: Config.llm_opts(config),
-      tools: config.tools,
-      model: config.model
+      user_message: latest_query(state),
+      request_id: state.request_id,
+      run_id: state.run_id
     }
 
-    with {:ok, request} <- maybe_transform_request(base_request, state, config, runtime_context) do
-      {:ok,
-       %{
-         model: Map.get(request, :model, config.model),
-         llm_opts: request.llm_opts,
-         user_message: latest_query(state),
-         request_id: state.request_id,
-         run_id: state.run_id
-       }}
+    base_request = Output.repair_request(raw, reason, base_context)
+
+    with {:ok, request} <- maybe_transform_request(base_request, state, config, runtime_context),
+         {:ok, messages} <- normalize_request_messages(request),
+         {:ok, _tools} <- normalize_request_tools(request) do
+      context =
+        base_context
+        |> Map.put(:model, Map.get(request, :model, config.model))
+        |> Map.put(:messages, messages)
+        |> Map.put(:llm_opts, request.llm_opts)
+
+      repair_request = Output.repair_request(raw, reason, context)
+
+      {:ok, Map.merge(context, Map.take(repair_request, [:model, :messages, :llm_opts]))}
     end
   end
 
@@ -1333,7 +1339,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   end
 
   defp latest_query(%State{} = state) do
-    case AIContext.last_entry(state.context) do
+    case Enum.find(state.context.entries, &(&1.role == :user)) do
       %{role: :user, content: content} when is_binary(content) -> content
       %{role: :user, content: content} when is_list(content) -> Query.summarize(content)
       _ -> ""

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -999,7 +999,6 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   defp finalize_output(%State{} = state, _owner, _ref, %Config{output: nil}, _runtime_context), do: {:ok, state}
 
   defp finalize_output(%State{} = state, owner, ref, %Config{output: %Output{} = output} = config, runtime_context) do
-    context = output_context(state, config, runtime_context)
     {state, _} = emit_output_event(state, owner, ref, :output_started, output, :started, state.result, attempt: 0)
 
     case Output.parse(output, state.result) do
@@ -1012,7 +1011,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
         {:ok, state |> State.put_result(parsed) |> State.put_output(meta)}
 
       {:error, reason} ->
-        repair_or_fail_output(state, owner, ref, output, context, state.result, reason, 1)
+        repair_or_fail_output(state, owner, ref, config, output, runtime_context, state.result, reason, 1)
     end
   end
 
@@ -1020,8 +1019,9 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
          state,
          owner,
          ref,
+         config,
          %Output{on_validation_error: :repair, retries: retries} = output,
-         context,
+         runtime_context,
          raw,
          reason,
          attempt
@@ -1033,30 +1033,60 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
         validation_error: reason
       )
 
-    case Output.repair(output, raw, reason, context) do
-      {:ok, parsed} ->
-        meta = Output.meta(output, :repaired, raw, attempt: attempt, validation_error: reason)
+    case output_context(state, config, runtime_context) do
+      {:ok, context} ->
+        case Output.repair(output, raw, reason, context) do
+          {:ok, parsed} ->
+            meta = Output.meta(output, :repaired, raw, attempt: attempt, validation_error: reason)
 
-        {state, _} =
-          emit_output_event(state, owner, ref, :output_validated, output, :validated, parsed, attempt: attempt)
+            {state, _} =
+              emit_output_event(state, owner, ref, :output_validated, output, :validated, parsed, attempt: attempt)
 
-        {:ok, state |> State.put_result(parsed) |> State.put_output(meta)}
+            {:ok, state |> State.put_result(parsed) |> State.put_output(meta)}
 
-      {:error, repair_reason} ->
-        repair_or_fail_output(state, owner, ref, output, context, raw, repair_reason, attempt + 1)
+          {:error, repair_reason} ->
+            repair_or_fail_output(
+              state,
+              owner,
+              ref,
+              config,
+              output,
+              runtime_context,
+              raw,
+              repair_reason,
+              attempt + 1
+            )
+        end
+
+      {:error, transform_reason} ->
+        fail_output(state, owner, ref, output, raw, transform_reason, attempt, :request_transform)
     end
   end
 
-  defp repair_or_fail_output(state, owner, ref, %Output{} = output, _context, raw, reason, attempt) do
-    meta = Output.meta(output, :error, raw, attempt: max(attempt - 1, 0), error: reason)
+  defp repair_or_fail_output(
+         state,
+         owner,
+         ref,
+         _config,
+         %Output{} = output,
+         _runtime_context,
+         raw,
+         reason,
+         attempt
+       ) do
+    fail_output(state, owner, ref, output, raw, reason, max(attempt - 1, 0), :output_validation)
+  end
+
+  defp fail_output(state, owner, ref, output, raw, reason, attempt, error_type) do
+    meta = Output.meta(output, :error, raw, attempt: attempt, error: reason)
 
     {state, _} =
       emit_output_event(state, owner, ref, :output_failed, output, :error, raw,
-        attempt: max(attempt - 1, 0),
+        attempt: attempt,
         error: reason
       )
 
-    {:error, State.put_output(state, meta), reason, :output_validation}
+    {:error, State.put_output(state, meta), reason, error_type}
   end
 
   defp emit_output_event(%State{} = state, owner, ref, kind, %Output{} = output, status, raw, opts) do
@@ -1069,21 +1099,23 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
   end
 
   defp output_context(%State{} = state, %Config{} = config, runtime_context) do
-    base_request = %{llm_opts: Config.llm_opts(config), tools: config.tools, model: config.model}
-
-    {model, llm_opts} =
-      case maybe_transform_request(base_request, state, config, runtime_context) do
-        {:ok, request} -> {Map.get(request, :model, config.model), request.llm_opts}
-        {:error, _reason} -> {config.model, base_request.llm_opts}
-      end
-
-    %{
-      model: model,
-      llm_opts: llm_opts,
-      user_message: latest_query(state),
-      request_id: state.request_id,
-      run_id: state.run_id
+    base_request = %{
+      messages: AIContext.to_messages(state.context),
+      llm_opts: Config.llm_opts(config),
+      tools: config.tools,
+      model: config.model
     }
+
+    with {:ok, request} <- maybe_transform_request(base_request, state, config, runtime_context) do
+      {:ok,
+       %{
+         model: Map.get(request, :model, config.model),
+         llm_opts: request.llm_opts,
+         user_message: latest_query(state),
+         request_id: state.request_id,
+         run_id: state.run_id
+       }}
+    end
   end
 
   defp output_schema_summary(%Output{} = output) do

--- a/lib/jido_ai/reasoning/react/runner.ex
+++ b/lib/jido_ai/reasoning/react/runner.ex
@@ -184,7 +184,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
           |> State.put_status(:completed)
           |> State.put_result("Maximum iterations reached without a final answer.")
 
-        case complete_run(completed, owner, ref, config, :max_iterations) do
+        case complete_run(completed, owner, ref, config, :max_iterations, context) do
           {:ok, completed} -> completed
           {:error, failed_state, reason, error_type} -> fail_run(failed_state, owner, ref, config, reason, error_type)
         end
@@ -194,7 +194,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
           {:ok, state} ->
             case run_llm_step(state, owner, ref, config, context) do
               {:final_answer, state} ->
-                case maybe_continue_after_final_answer(state, owner, ref, config) do
+                case maybe_continue_after_final_answer(state, owner, ref, config, context) do
                   {:continue, state} ->
                     run_loop(state, owner, ref, config, context)
 
@@ -982,8 +982,8 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     state
   end
 
-  defp complete_run(%State{} = state, owner, ref, %Config{} = config, termination_reason) do
-    with {:ok, state} <- finalize_output(state, owner, ref, config) do
+  defp complete_run(%State{} = state, owner, ref, %Config{} = config, termination_reason, runtime_context) do
+    with {:ok, state} <- finalize_output(state, owner, ref, config, runtime_context) do
       {state, _} =
         emit_event(state, owner, ref, :request_completed, %{
           result: state.result,
@@ -996,10 +996,10 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     end
   end
 
-  defp finalize_output(%State{} = state, _owner, _ref, %Config{output: nil}), do: {:ok, state}
+  defp finalize_output(%State{} = state, _owner, _ref, %Config{output: nil}, _runtime_context), do: {:ok, state}
 
-  defp finalize_output(%State{} = state, owner, ref, %Config{output: %Output{} = output} = config) do
-    context = output_context(state, config)
+  defp finalize_output(%State{} = state, owner, ref, %Config{output: %Output{} = output} = config, runtime_context) do
+    context = output_context(state, config, runtime_context)
     {state, _} = emit_output_event(state, owner, ref, :output_started, output, :started, state.result, attempt: 0)
 
     case Output.parse(output, state.result) do
@@ -1068,10 +1068,18 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     emit_event(state, owner, ref, kind, data)
   end
 
-  defp output_context(%State{} = state, %Config{} = config) do
+  defp output_context(%State{} = state, %Config{} = config, runtime_context) do
+    base_request = %{llm_opts: Config.llm_opts(config), tools: config.tools, model: config.model}
+
+    {model, llm_opts} =
+      case maybe_transform_request(base_request, state, config, runtime_context) do
+        {:ok, request} -> {Map.get(request, :model, config.model), request.llm_opts}
+        {:error, _reason} -> {config.model, base_request.llm_opts}
+      end
+
     %{
-      model: config.model,
-      llm_opts: Config.llm_opts(config),
+      model: model,
+      llm_opts: llm_opts,
       user_message: latest_query(state),
       request_id: state.request_id,
       run_id: state.run_id
@@ -1556,7 +1564,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
     end
   end
 
-  defp maybe_continue_after_final_answer(%State{} = state, owner, ref, %Config{} = config) do
+  defp maybe_continue_after_final_answer(%State{} = state, owner, ref, %Config{} = config, runtime_context) do
     case seal_pending_input_server_if_empty(config) do
       :pending ->
         case drain_pending_input(state, owner, ref, config) do
@@ -1574,7 +1582,7 @@ defmodule Jido.AI.Reasoning.ReAct.Runner do
         end
 
       :sealed ->
-        case complete_run(state, owner, ref, config, :final_answer) do
+        case complete_run(state, owner, ref, config, :final_answer, runtime_context) do
           {:ok, state} -> {:complete, state}
           {:error, state, reason, error_type} -> {:error, state, reason, error_type}
         end

--- a/test/jido_ai/output_test.exs
+++ b/test/jido_ai/output_test.exs
@@ -152,4 +152,29 @@ defmodule Jido.AI.OutputTest do
     assert {:ok, %{category: :technical, confidence: 1.0, summary: "Normalized"}} =
              Output.repair(output, "invalid", :invalid, %{})
   end
+
+  test "builds a sanitized repair request and preserves explicit messages" do
+    request =
+      Output.repair_request("invalid answer", :invalid, %{
+        model: :capable,
+        user_message: "Classify the ticket",
+        llm_opts: [tools: [:tool], tool_choice: :auto, stream: true, temperature: 0.2]
+      })
+
+    assert request.model == :capable
+    assert request.tools == %{}
+    assert request.llm_opts[:stream] == false
+    assert request.llm_opts[:temperature] == 0.2
+    refute Keyword.has_key?(request.llm_opts, :tools)
+    refute Keyword.has_key?(request.llm_opts, :tool_choice)
+
+    assert Enum.any?(request.messages, fn message ->
+             message.role == :user and
+               message.content =~ "Classify the ticket" and
+               message.content =~ "invalid answer"
+           end)
+
+    messages = [%{role: :user, content: "Policy-adjusted repair prompt"}]
+    assert Output.repair_request("invalid answer", :invalid, %{messages: messages}).messages == messages
+  end
 end

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -243,6 +243,44 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     end
   end
 
+  defmodule RepairMessageTransformer do
+    def transform_request(request, _state, config, runtime_context) do
+      case Process.get({__MODULE__, :calls}, 0) + 1 do
+        1 ->
+          Process.put({__MODULE__, :calls}, 1)
+          {:ok, %{}}
+
+        call ->
+          Process.put({__MODULE__, :calls}, call)
+          send(runtime_context.test_pid, {:repair_message_transformer_request, request})
+
+          {:ok,
+           %{
+             model: "openai:gpt-4.1",
+             tools: config.tools,
+             messages: [
+               %{role: :system, content: "Apply the tenant repair policy."},
+               %{role: :user, content: "Return the normalized ticket object."}
+             ]
+           }}
+      end
+    end
+  end
+
+  defmodule InvalidRepairMessageTransformer do
+    def transform_request(_request, _state, _config, _runtime_context) do
+      case Process.get({__MODULE__, :calls}, 0) + 1 do
+        1 ->
+          Process.put({__MODULE__, :calls}, 1)
+          {:ok, %{}}
+
+        call ->
+          Process.put({__MODULE__, :calls}, call)
+          {:ok, %{messages: :invalid}}
+      end
+    end
+  end
+
   defmodule RuntimeAnthropicModelTransformer do
     def transform_request(_request, _state, _config, _runtime_context) do
       {:ok, %{model: "anthropic:claude-sonnet-4-5"}}
@@ -776,6 +814,101 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     assert_receive {:repair_transformer_request, _first_repair_request}
     assert_receive {:repair_transformer_request, _second_repair_request}
     refute_receive {:repair_transformer_request, _request}
+  end
+
+  test "structured output transformer receives and overrides the exact repair request" do
+    schema = ticket_schema()
+
+    transformed_messages = [
+      %{role: :system, content: "Apply the tenant repair policy."},
+      %{role: :user, content: "Return the normalized ticket object."}
+    ]
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      {:ok,
+       responses_stream_response(
+         [ReqLLM.StreamChunk.text("This is a billing issue with high confidence.")],
+         %{finish_reason: :stop, usage: %{input_tokens: 3, output_tokens: 8}},
+         model
+       )}
+    end)
+
+    Mimic.expect(ReqLLM.Generation, :generate_object, fn model, messages, ^schema, opts ->
+      assert model == "openai:gpt-4.1"
+      assert messages == transformed_messages
+      assert Keyword.get(opts, :stream) == false
+      refute Keyword.has_key?(opts, :tools)
+      refute Keyword.has_key?(opts, :tool_choice)
+
+      {:ok,
+       %ReqLLM.Response{
+         id: "repair-output",
+         model: "test",
+         context: nil,
+         object: %{"category" => "billing", "confidence" => 0.88, "summary" => "Billing issue"}
+       }}
+    end)
+
+    config =
+      Config.new(%{
+        model: :capable,
+        tools: %{CalculatorTool.name() => CalculatorTool},
+        output: [schema: schema],
+        request_transformer: RepairMessageTransformer
+      })
+
+    events =
+      ReAct.stream("Classify this ticket", config, context: %{test_pid: self()})
+      |> Enum.to_list()
+
+    assert Enum.any?(events, &(&1.kind == :request_completed))
+    assert_receive {:repair_message_transformer_request, repair_request}
+
+    assert repair_request.tools == %{}
+    assert Keyword.get(repair_request.llm_opts, :stream) == false
+    refute Keyword.has_key?(repair_request.llm_opts, :tools)
+    refute Keyword.has_key?(repair_request.llm_opts, :tool_choice)
+
+    assert Enum.any?(repair_request.messages, fn message ->
+             message.role == :user and
+               message.content =~ "Classify this ticket" and
+               message.content =~ "This is a billing issue with high confidence."
+           end)
+  end
+
+  test "structured output repair rejects invalid transformed messages before the provider call" do
+    schema = ticket_schema()
+    parent = self()
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      {:ok,
+       responses_stream_response(
+         [ReqLLM.StreamChunk.text("This is not structured output.")],
+         %{finish_reason: :stop, usage: %{input_tokens: 3, output_tokens: 8}},
+         model
+       )}
+    end)
+
+    Mimic.stub(ReqLLM.Generation, :generate_object, fn _model, _messages, ^schema, _opts ->
+      send(parent, :unexpected_repair_request)
+      {:error, :unexpected_repair_request}
+    end)
+
+    config =
+      Config.new(%{
+        model: :capable,
+        tools: %{},
+        output: [schema: schema],
+        request_transformer: InvalidRepairMessageTransformer
+      })
+
+    events = ReAct.stream("Classify this ticket", config) |> Enum.to_list()
+
+    refute_receive :unexpected_repair_request
+    failed = Enum.find(events, &(&1.kind == :request_failed))
+    assert failed.data.error_type == :request_transform
+    assert failed.data.error == :invalid_request_messages
+    assert Enum.any?(events, &(&1.kind == :output_failed))
   end
 
   test "passes inline model specs through to ReqLLM requests" do

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -215,8 +215,31 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
   end
 
   defmodule RepairCredentialTransformer do
-    def transform_request(_request, _state, _config, _runtime_context) do
+    def transform_request(
+          %{messages: messages, llm_opts: llm_opts, tools: tools, model: _model} = request,
+          _state,
+          _config,
+          runtime_context
+        )
+        when is_list(messages) and is_list(llm_opts) and is_map(tools) do
+      if test_pid = runtime_context[:test_pid] do
+        send(test_pid, {:repair_transformer_request, request})
+      end
+
       {:ok, %{llm_opts: [access_key_id: "test-access-key", secret_access_key: "test-secret-key"]}}
+    end
+  end
+
+  defmodule RepairFailureTransformer do
+    def transform_request(request, _state, _config, runtime_context) do
+      call = Process.get({__MODULE__, :calls}, 0) + 1
+      Process.put({__MODULE__, :calls}, call)
+      send(runtime_context.test_pid, {:repair_failure_transformer_request, call, request})
+
+      case call do
+        1 -> {:ok, %{}}
+        _ -> {:error, :repair_credentials_unavailable}
+      end
     end
   end
 
@@ -606,11 +629,153 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
       })
 
     events =
-      ReAct.stream("Classify this ticket", config, request_id: "req_repair_creds", run_id: "run_repair_creds")
+      ReAct.stream("Classify this ticket", config,
+        request_id: "req_repair_creds",
+        run_id: "run_repair_creds",
+        context: %{test_pid: self()}
+      )
       |> Enum.to_list()
 
     completed = Enum.find(events, &(&1.kind == :request_completed))
     assert completed.data.result.category == :billing
+
+    assert_receive {:repair_transformer_request, turn_request}
+    assert_receive {:repair_transformer_request, repair_request}
+    refute_receive {:repair_transformer_request, _request}
+
+    for request <- [turn_request, repair_request] do
+      assert %{messages: messages, llm_opts: llm_opts, tools: tools, model: _model} = request
+      assert is_list(messages)
+      assert is_list(llm_opts)
+      assert is_map(tools)
+    end
+  end
+
+  test "structured output does not transform a repair request when parsing succeeds" do
+    schema = ticket_schema()
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      {:ok,
+       responses_stream_response(
+         [ReqLLM.StreamChunk.text(~s({"category":"billing","confidence":0.93,"summary":"Invoice issue"}))],
+         %{finish_reason: :stop, usage: %{input_tokens: 3, output_tokens: 8}},
+         model
+       )}
+    end)
+
+    config =
+      Config.new(%{
+        model: :capable,
+        tools: %{},
+        output: [schema: schema],
+        request_transformer: RepairCredentialTransformer
+      })
+
+    events =
+      ReAct.stream("Classify this ticket", config, context: %{test_pid: self()})
+      |> Enum.to_list()
+
+    assert Enum.any?(events, &(&1.kind == :request_completed))
+    assert_receive {:repair_transformer_request, _turn_request}
+    refute_receive {:repair_transformer_request, _repair_request}
+  end
+
+  test "structured output repair propagates request_transformer errors" do
+    schema = ticket_schema()
+    parent = self()
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      {:ok,
+       responses_stream_response(
+         [ReqLLM.StreamChunk.text("This is not structured output.")],
+         %{finish_reason: :stop, usage: %{input_tokens: 3, output_tokens: 8}},
+         model
+       )}
+    end)
+
+    Mimic.stub(ReqLLM.Generation, :generate_object, fn _model, _messages, ^schema, _opts ->
+      send(parent, :unexpected_repair_request)
+
+      {:ok,
+       %ReqLLM.Response{
+         id: "unexpected-repair-output",
+         model: "test",
+         context: nil,
+         object: %{"category" => "billing", "confidence" => 0.88, "summary" => "Billing issue"}
+       }}
+    end)
+
+    config =
+      Config.new(%{
+        model: :capable,
+        tools: %{},
+        output: [schema: schema],
+        request_transformer: RepairFailureTransformer
+      })
+
+    events =
+      ReAct.stream("Classify this ticket", config, context: %{test_pid: self()})
+      |> Enum.to_list()
+
+    assert_receive {:repair_failure_transformer_request, 1, _turn_request}
+    assert_receive {:repair_failure_transformer_request, 2, _repair_request}
+    refute_receive :unexpected_repair_request
+
+    failed = Enum.find(events, &(&1.kind == :request_failed))
+    assert failed.data.error_type == :request_transform
+    assert failed.data.error == {:request_transformer, :repair_credentials_unavailable}
+    assert Enum.any?(events, &(&1.kind == :output_failed))
+    refute Enum.any?(events, &(&1.kind == :request_completed))
+  end
+
+  test "structured output transforms every repair attempt" do
+    schema = ticket_schema()
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      {:ok,
+       responses_stream_response(
+         [ReqLLM.StreamChunk.text("This is not structured output.")],
+         %{finish_reason: :stop, usage: %{input_tokens: 3, output_tokens: 8}},
+         model
+       )}
+    end)
+
+    Mimic.expect(ReqLLM.Generation, :generate_object, 2, fn _model, _messages, ^schema, _opts ->
+      attempt = Process.get({__MODULE__, :repair_attempt}, 0) + 1
+      Process.put({__MODULE__, :repair_attempt}, attempt)
+
+      case attempt do
+        1 ->
+          {:error, :temporary_repair_failure}
+
+        2 ->
+          {:ok,
+           %ReqLLM.Response{
+             id: "repair-output",
+             model: "test",
+             context: nil,
+             object: %{"category" => "billing", "confidence" => 0.88, "summary" => "Billing issue"}
+           }}
+      end
+    end)
+
+    config =
+      Config.new(%{
+        model: :capable,
+        tools: %{},
+        output: [schema: schema, retries: 2],
+        request_transformer: RepairCredentialTransformer
+      })
+
+    events =
+      ReAct.stream("Classify this ticket", config, context: %{test_pid: self()})
+      |> Enum.to_list()
+
+    assert Enum.any?(events, &(&1.kind == :request_completed))
+    assert_receive {:repair_transformer_request, _turn_request}
+    assert_receive {:repair_transformer_request, _first_repair_request}
+    assert_receive {:repair_transformer_request, _second_repair_request}
+    refute_receive {:repair_transformer_request, _request}
   end
 
   test "passes inline model specs through to ReqLLM requests" do

--- a/test/jido_ai/react/runtime_runner_test.exs
+++ b/test/jido_ai/react/runtime_runner_test.exs
@@ -214,6 +214,12 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
     end
   end
 
+  defmodule RepairCredentialTransformer do
+    def transform_request(_request, _state, _config, _runtime_context) do
+      {:ok, %{llm_opts: [access_key_id: "test-access-key", secret_access_key: "test-secret-key"]}}
+    end
+  end
+
   defmodule RuntimeAnthropicModelTransformer do
     def transform_request(_request, _state, _config, _runtime_context) do
       {:ok, %{model: "anthropic:claude-sonnet-4-5"}}
@@ -564,6 +570,47 @@ defmodule Jido.AI.Reasoning.ReAct.RuntimeRunnerTest do
 
     assert Enum.any?(events, &(&1.kind == :output_repair))
     assert Enum.any?(events, &(&1.kind == :output_validated and &1.data.status == :validated))
+  end
+
+  test "structured output repair runs llm_opts through the configured request_transformer" do
+    schema = ticket_schema()
+
+    Mimic.stub(ReqLLM.Generation, :stream_text, fn model, _messages, _opts ->
+      {:ok,
+       responses_stream_response(
+         [ReqLLM.StreamChunk.text("This is a billing issue with high confidence.")],
+         %{finish_reason: :stop, usage: %{input_tokens: 3, output_tokens: 8}},
+         model
+       )}
+    end)
+
+    Mimic.expect(ReqLLM.Generation, :generate_object, fn _model, _messages, ^schema, opts ->
+      assert Keyword.get(opts, :access_key_id) == "test-access-key"
+      assert Keyword.get(opts, :secret_access_key) == "test-secret-key"
+
+      {:ok,
+       %ReqLLM.Response{
+         id: "repair-output",
+         model: "test",
+         context: nil,
+         object: %{"category" => "billing", "confidence" => 0.88, "summary" => "Billing issue"}
+       }}
+    end)
+
+    config =
+      Config.new(%{
+        model: :capable,
+        tools: %{},
+        output: [schema: schema],
+        request_transformer: RepairCredentialTransformer
+      })
+
+    events =
+      ReAct.stream("Classify this ticket", config, request_id: "req_repair_creds", run_id: "run_repair_creds")
+      |> Enum.to_list()
+
+    completed = Enum.find(events, &(&1.kind == :request_completed))
+    assert completed.data.result.category == :billing
   end
 
   test "passes inline model specs through to ReqLLM requests" do


### PR DESCRIPTION
## Summary
- `Output.repair/4` builds its `llm_opts` from the static `Config.llm_opts`, and the ReAct runner never re-invokes the configured `request_transformer` when building that repair context. Any deployment that relies on the transformer to inject per-turn credentials (e.g. resolving IAM instance-role/IMDS credentials for Amazon Bedrock, which `req_llm` cannot do natively) gets those credentials on every normal ReAct turn but **not** on the structured-output repair call — repair fails with missing-credential errors even though the main loop works fine.
- `output_context/2` now reuses the existing `maybe_transform_request/4` helper (the same one the main turn loop already uses) to refresh `llm_opts`/`model` before building the repair context, falling back to the static config value if there's no transformer configured or if it errors — so behavior is unchanged for setups that don't use `request_transformer`.

## Test plan
- [x] Added a regression test in `test/jido_ai/react/runtime_runner_test.exs` ("structured output repair runs llm_opts through the configured request_transformer") — verified it fails against the pre-fix code (`BadMapError`, repair never receives the transformed credentials) and passes with the fix.
- [x] `mix test` — 2329 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `mix credo --min-priority high` — no issues
- [x] `mix compile --warnings-as-errors` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)