### PR TITLE
fix(skills): harden SKILL.md conformance

### DIFF
--- a/guides/developer/skills_system.md
+++ b/guides/developer/skills_system.md
@@ -165,15 +165,34 @@ for model-facing catalogs.
 
 Strict loading (`lenient: false`, the default) enforces the Agent Skills format:
 
+- the file is named exactly `SKILL.md`
 - the declared name exactly matches the parent directory
 - descriptions are non-empty and at most 1,024 characters
 - license is a string when present
 - compatibility is non-empty and at most 500 characters when present
 - metadata contains only string keys and string values
 - `allowed-tools` is a space-separated string when present
+- only specification fields are present at the top level
+
+Put Jido-specific file metadata under namespaced metadata keys:
+
+```yaml
+metadata:
+  jido_ai.tags: "support review"
+  jido_ai.version: "1.0.0"
+```
+
+Module-based Jido skills can continue to use native `tags`, `vsn`, `actions`,
+and `plugins` options.
 
 Lenient loading keeps interoperability behavior: it records diagnostics and can
 normalize or truncate recoverable values.
+
+The experimental Agent Skills `allowed-tools` field is advisory in Jido.AI.
+Automatic activation does not approve, enable, or restrict tools from this
+field. A host can apply an explicit policy with
+`Jido.AI.Skill.Prompt.filter_tools/2`, but that restrictive use is a host choice
+and is not the Agent Skills pre-approval meaning.
 
 ## Bounded Discovery And Trust
 
@@ -207,7 +226,8 @@ CLI failure behaviors:
 - `mix jido_ai.skill list` with no paths prints usage help
 - `mix jido_ai.skill validate` with no paths prints usage help
 - unknown commands print `mix jido_ai.skill` help guidance
-- `--strict` raises when any skill fails validation (non-zero exit)
+- validation prints collected warnings and errors
+- `--strict` raises when any skill has a warning or error (non-zero exit)
 
 ## Failure Modes
 

--- a/lib/jido_ai/skill.ex
+++ b/lib/jido_ai/skill.ex
@@ -92,6 +92,10 @@ defmodule Jido.AI.Skill do
 
   @doc """
   Returns the allowed tools for a skill.
+
+  For filesystem Agent Skills, `allowed-tools` is advisory metadata. Jido.AI
+  does not automatically approve, enable, or restrict tools from this field.
+  A host must apply its own explicit approval policy.
   """
   @spec allowed_tools(module() | Spec.t() | String.t()) :: [String.t()]
   def allowed_tools(mod) when is_atom(mod), do: mod.allowed_tools()

--- a/lib/jido_ai/skill/error.ex
+++ b/lib/jido_ai/skill/error.ex
@@ -97,10 +97,14 @@ defmodule Jido.AI.Skill.Error.Validation.InvalidField do
     class: :validation
 
   @impl true
+  def message(%{field: :frontmatter, reason: :unsupported_top_level_fields, value: fields}),
+    do: "Unsupported top-level frontmatter fields: #{Enum.map_join(fields, ", ", &inspect/1)}"
+
   def message(%{field: field, reason: reason}),
     do: "Invalid #{field}: #{format_reason(reason)}"
 
   defp format_reason(:directory_name_mismatch), do: "must match the parent directory name"
+  defp format_reason(:invalid_skill_filename), do: "file must be named exactly SKILL.md"
   defp format_reason(:too_long), do: "exceeds the maximum length"
   defp format_reason(:empty), do: "must not be empty"
   defp format_reason(:invalid_type), do: "has an invalid type"

--- a/lib/jido_ai/skill/loader.ex
+++ b/lib/jido_ai/skill/loader.ex
@@ -26,6 +26,8 @@ defmodule Jido.AI.Skill.Loader do
   @max_name_length 64
   @max_description_length 1024
   @max_compatibility_length 500
+  @allowed_frontmatter_fields ~w(name description license compatibility metadata allowed-tools)
+  @frontmatter_regex ~r/\A---\r?\n(.*?)\r?\n---(?:\r?\n(.*))?\z/s
 
   @doc """
   Loads a skill from a SKILL.md file path.
@@ -39,12 +41,11 @@ defmodule Jido.AI.Skill.Loader do
   """
   @spec load(String.t(), keyword()) :: {:ok, Spec.t()} | {:error, term()}
   def load(path, opts \\ []) do
-    lenient = Keyword.get(opts, :lenient, false)
     diagnostics = Keyword.get(opts, :diagnostics, Diagnostics.new())
 
-    with {:ok, content} <- File.read(path),
-         {:ok, {frontmatter, body}, diagnostics} <- parse_frontmatter(content, path, diagnostics, lenient) do
-      build_spec(frontmatter, body, path, diagnostics, lenient)
+    case do_load(path, opts, diagnostics) do
+      {:ok, spec, _diagnostics} -> {:ok, spec}
+      {:error, reason, _diagnostics} -> {:error, reason}
     end
   end
 
@@ -62,15 +63,9 @@ defmodule Jido.AI.Skill.Loader do
   @spec load_with_diagnostics(String.t(), keyword()) ::
           {:ok, Spec.t(), Diagnostics.t()} | {:error, term(), Diagnostics.t()}
   def load_with_diagnostics(path, opts \\ []) do
-    lenient = Keyword.get(opts, :lenient, true)
-    diagnostics = Diagnostics.new()
-
-    case load(path, lenient: lenient, diagnostics: diagnostics) do
-      # load/2 accumulates diagnostics inside the spec; pull them back out
-      # so the documented {:ok, spec, diagnostics} contract is honored.
-      {:ok, spec} -> {:ok, spec, spec.diagnostics || diagnostics}
-      {:error, reason} -> {:error, reason, diagnostics}
-    end
+    diagnostics = Keyword.get(opts, :diagnostics, Diagnostics.new())
+    opts = Keyword.put_new(opts, :lenient, true)
+    do_load(path, opts, diagnostics)
   end
 
   @doc """
@@ -94,47 +89,103 @@ defmodule Jido.AI.Skill.Loader do
   """
   @spec parse(String.t(), String.t(), keyword()) :: {:ok, Spec.t()} | {:error, term()}
   def parse(content, source_path \\ "inline", opts \\ []) do
-    lenient = Keyword.get(opts, :lenient, false)
     diagnostics = Keyword.get(opts, :diagnostics, Diagnostics.new())
 
-    with {:ok, {frontmatter, body}, diagnostics} <- parse_frontmatter(content, source_path, diagnostics, lenient) do
-      build_spec(frontmatter, body, source_path, diagnostics, lenient)
+    case do_parse(content, source_path, opts, diagnostics) do
+      {:ok, spec, _diagnostics} -> {:ok, spec}
+      {:error, reason, _diagnostics} -> {:error, reason}
+    end
+  end
+
+  defp do_load(path, opts, diagnostics) do
+    lenient = Keyword.get(opts, :lenient, false)
+
+    case File.read(path) do
+      {:ok, content} ->
+        with {:ok, diagnostics} <- validate_skill_filename(path, diagnostics, lenient),
+             {:ok, {frontmatter, body}, diagnostics} <-
+               parse_frontmatter(content, path, diagnostics, lenient),
+             {:ok, spec, diagnostics} <- build_spec(frontmatter, body, path, diagnostics, lenient),
+             {:ok, diagnostics} <- check_directory_name_match(spec.name, path, diagnostics, lenient) do
+          spec = %{spec | diagnostics: diagnostics}
+          {:ok, spec, diagnostics}
+        end
+
+      {:error, reason} ->
+        {:error, reason, diagnostics}
+    end
+  end
+
+  defp do_parse(content, source_path, opts, diagnostics) do
+    lenient = Keyword.get(opts, :lenient, false)
+
+    with {:ok, {frontmatter, body}, diagnostics} <-
+           parse_frontmatter(content, source_path, diagnostics, lenient),
+         {:ok, spec, diagnostics} <- build_spec(frontmatter, body, source_path, diagnostics, lenient) do
+      {:ok, %{spec | diagnostics: diagnostics}, diagnostics}
     end
   end
 
   defp parse_frontmatter(content, path, diagnostics, lenient) do
-    case Regex.run(~r/\A---\r?\n(.*?)\r?\n---\r?\n(.*)\z/s, content) do
+    content = strip_utf8_bom(content)
+
+    case Regex.run(@frontmatter_regex, content) do
       [_, yaml, body] ->
-        case YamlElixir.read_from_string(yaml) do
-          {:ok, frontmatter} ->
-            {:ok, {frontmatter, String.trim(body)}, diagnostics}
+        decode_frontmatter(yaml, body, path, diagnostics, lenient)
 
-          {:error, reason} ->
-            if lenient do
-              diagnostics =
-                Diagnostics.add_error(diagnostics, %Error.Parse.InvalidYaml{file_path: path, reason: reason})
-
-              # Return empty frontmatter to continue in lenient mode
-              {:ok, {%{}, String.trim(body)}, diagnostics}
-            else
-              {:error, %Error.Parse.InvalidYaml{file_path: path, reason: reason}}
-            end
-        end
+      [_, yaml] ->
+        decode_frontmatter(yaml, "", path, diagnostics, lenient)
 
       nil ->
+        error = %Error.Parse.NoFrontmatter{file_path: path}
+
         if lenient do
-          diagnostics = Diagnostics.add_error(diagnostics, %Error.Parse.NoFrontmatter{file_path: path})
+          diagnostics = Diagnostics.add_error(diagnostics, error)
           {:ok, {%{}, String.trim(content)}, diagnostics}
         else
-          {:error, %Error.Parse.NoFrontmatter{file_path: path}}
+          fail(error, diagnostics)
         end
     end
   end
 
+  defp decode_frontmatter(yaml, body, path, diagnostics, lenient) do
+    result =
+      try do
+        YamlElixir.read_from_string(yaml)
+      rescue
+        exception -> {:error, {:exception, exception.__struct__, Exception.message(exception)}}
+      catch
+        kind, value -> {:error, {kind, value}}
+      end
+
+    case result do
+      {:ok, frontmatter} when is_map(frontmatter) ->
+        {:ok, {frontmatter, String.trim(body)}, diagnostics}
+
+      {:ok, _frontmatter} ->
+        invalid_frontmatter(:frontmatter_must_be_mapping, body, path, diagnostics, lenient)
+
+      {:error, reason} ->
+        invalid_frontmatter(reason, body, path, diagnostics, lenient)
+    end
+  end
+
+  defp invalid_frontmatter(reason, body, path, diagnostics, lenient) do
+    error = %Error.Parse.InvalidYaml{file_path: path, reason: reason}
+
+    if lenient do
+      {:ok, {%{}, String.trim(body)}, Diagnostics.add_error(diagnostics, error)}
+    else
+      fail(error, diagnostics)
+    end
+  end
+
+  defp strip_utf8_bom(<<0xEF, 0xBB, 0xBF, rest::binary>>), do: rest
+  defp strip_utf8_bom(content), do: content
+
   defp build_spec(frontmatter, body, path, diagnostics, lenient) do
-    # Validate fields, allowing lenient mode to proceed with defaults
-    with {:ok, name, diagnostics} <- validate_name(frontmatter["name"], diagnostics, lenient),
-         {:ok, diagnostics} <- check_directory_name_match(name, path, diagnostics, lenient),
+    with {:ok, diagnostics} <- validate_frontmatter_fields(frontmatter, diagnostics, lenient),
+         {:ok, name, diagnostics} <- validate_name(frontmatter["name"], diagnostics, lenient),
          {:ok, description, diagnostics} <- validate_description(frontmatter["description"], diagnostics, lenient),
          {:ok, license, diagnostics} <- validate_license(frontmatter["license"], diagnostics, lenient),
          {:ok, compatibility, diagnostics} <-
@@ -153,30 +204,41 @@ defmodule Jido.AI.Skill.Loader do
         body_ref: {:inline, body},
         actions: [],
         plugins: [],
-        vsn: optional_string(frontmatter["vsn"] || frontmatter["version"]),
-        tags: parse_tags(frontmatter["tags"]),
+        vsn: file_version(metadata, frontmatter, lenient),
+        tags: file_tags(metadata, frontmatter, lenient),
         diagnostics: diagnostics
       }
 
-      {:ok, spec}
+      {:ok, spec, diagnostics}
     end
   end
 
-  # Check if the directory name exactly matches the validated skill name.
-  # Inline parse sources do not have a filesystem directory to compare.
-  defp check_directory_name_match(_name, path, diagnostics, _lenient)
-       when not is_binary(path),
-       do: {:ok, diagnostics}
-
-  defp check_directory_name_match(name, path, diagnostics, lenient) when is_binary(name) do
-    if Path.basename(path) != "SKILL.md" do
+  defp validate_skill_filename(path, diagnostics, lenient) do
+    if Path.basename(path) == "SKILL.md" do
       {:ok, diagnostics}
     else
-      do_check_directory_name_match(name, path, diagnostics, lenient)
+      warning =
+        Diagnostics.Warning.new(
+          :invalid_skill_filename,
+          "Skill file '#{Path.basename(path)}' must be named exactly 'SKILL.md'"
+        )
+
+      if lenient do
+        {:ok, Diagnostics.add_warning(diagnostics, warning)}
+      else
+        fail(
+          %Error.Validation.InvalidField{
+            field: :file_name,
+            reason: :invalid_skill_filename,
+            value: Path.basename(path)
+          },
+          diagnostics
+        )
+      end
     end
   end
 
-  defp do_check_directory_name_match(name, path, diagnostics, lenient) do
+  defp check_directory_name_match(name, path, diagnostics, lenient) do
     parent_dir = path |> Path.expand() |> Path.dirname() |> Path.basename()
 
     if parent_dir != name do
@@ -189,15 +251,49 @@ defmodule Jido.AI.Skill.Loader do
       if lenient do
         {:ok, Diagnostics.add_warning(diagnostics, warning)}
       else
-        {:error,
-         %Error.Validation.InvalidField{
-           field: :name,
-           reason: :directory_name_mismatch,
-           value: name
-         }}
+        fail(
+          %Error.Validation.InvalidField{
+            field: :name,
+            reason: :directory_name_mismatch,
+            value: name
+          },
+          diagnostics
+        )
       end
     else
       {:ok, diagnostics}
+    end
+  end
+
+  defp validate_frontmatter_fields(frontmatter, diagnostics, lenient) do
+    unsupported =
+      frontmatter
+      |> Map.keys()
+      |> Enum.reject(&(&1 in @allowed_frontmatter_fields))
+      |> Enum.sort_by(&inspect/1)
+
+    case unsupported do
+      [] ->
+        {:ok, diagnostics}
+
+      fields when lenient ->
+        warning =
+          Diagnostics.Warning.new(
+            :unsupported_top_level_fields,
+            "Unsupported top-level fields were accepted in lenient mode: #{Enum.map_join(fields, ", ", &inspect/1)}"
+          )
+
+        {:ok, Diagnostics.add_warning(diagnostics, warning)}
+
+      fields ->
+        fail(
+          %Error.Validation.InvalidField{
+            field: :frontmatter,
+            reason: :unsupported_top_level_fields,
+            value: fields
+          },
+          diagnostics
+        )
     end
   end
 
@@ -216,7 +312,7 @@ defmodule Jido.AI.Skill.Loader do
 
       {:ok, fallback, diagnostics}
     else
-      {:error, error}
+      fail(error, diagnostics)
     end
   end
 
@@ -240,7 +336,7 @@ defmodule Jido.AI.Skill.Loader do
             "Skill name exceeds #{@max_name_length} chars, truncated to: "
           )
         else
-          {:error, error}
+          fail(error, diagnostics)
         end
 
       not Regex.match?(@name_regex, name) ->
@@ -255,7 +351,7 @@ defmodule Jido.AI.Skill.Loader do
             "Invalid skill name '#{name}', normalized to: "
           )
         else
-          {:error, error}
+          fail(error, diagnostics)
         end
 
       true ->
@@ -277,7 +373,7 @@ defmodule Jido.AI.Skill.Loader do
 
       {:ok, fallback, diagnostics}
     else
-      {:error, error}
+      fail(error, diagnostics)
     end
   end
 
@@ -288,7 +384,7 @@ defmodule Jido.AI.Skill.Loader do
       diagnostics = Diagnostics.add_warning(diagnostics, warning)
       {:ok, fallback, diagnostics}
     else
-      {:error, %Error.Validation.MissingField{field: :description}}
+      fail(%Error.Validation.MissingField{field: :description}, diagnostics)
     end
   end
 
@@ -301,7 +397,7 @@ defmodule Jido.AI.Skill.Loader do
           diagnostics = Diagnostics.add_warning(diagnostics, warning)
           {:ok, fallback, diagnostics}
         else
-          {:error, %Error.Validation.MissingField{field: :description}}
+          fail(%Error.Validation.MissingField{field: :description}, diagnostics)
         end
 
       String.length(desc) > @max_description_length ->
@@ -317,12 +413,14 @@ defmodule Jido.AI.Skill.Loader do
           diagnostics = Diagnostics.add_warning(diagnostics, warning)
           {:ok, truncated, diagnostics}
         else
-          {:error,
-           %Error.Validation.InvalidField{
-             field: :description,
-             reason: :too_long,
-             value: desc
-           }}
+          fail(
+            %Error.Validation.InvalidField{
+              field: :description,
+              reason: :too_long,
+              value: desc
+            },
+            diagnostics
+          )
         end
 
       true ->
@@ -337,7 +435,7 @@ defmodule Jido.AI.Skill.Loader do
       diagnostics = Diagnostics.add_warning(diagnostics, warning)
       {:ok, fallback, diagnostics}
     else
-      {:error, %Error.Validation.MissingField{field: :description}}
+      fail(%Error.Validation.MissingField{field: :description}, diagnostics)
     end
   end
 
@@ -365,12 +463,14 @@ defmodule Jido.AI.Skill.Loader do
 
           {:ok, String.slice(compat, 0, @max_compatibility_length), Diagnostics.add_warning(diagnostics, warning)}
         else
-          {:error,
-           %Error.Validation.InvalidField{
-             field: :compatibility,
-             reason: :too_long,
-             value: compat
-           }}
+          fail(
+            %Error.Validation.InvalidField{
+              field: :compatibility,
+              reason: :too_long,
+              value: compat
+            },
+            diagnostics
+          )
         end
 
       true ->
@@ -403,13 +503,15 @@ defmodule Jido.AI.Skill.Loader do
     {:ok, [], Diagnostics.add_warning(diagnostics, warning)}
   end
 
-  defp validate_allowed_tools(tools, _diagnostics, false) do
-    {:error,
-     %Error.Validation.InvalidField{
-       field: :allowed_tools,
-       reason: :invalid_type,
-       value: tools
-     }}
+  defp validate_allowed_tools(tools, diagnostics, false) do
+    fail(
+      %Error.Validation.InvalidField{
+        field: :allowed_tools,
+        reason: :invalid_type,
+        value: tools
+      },
+      diagnostics
+    )
   end
 
   defp parse_metadata(nil, diagnostics, _lenient), do: {:ok, %{}, diagnostics}
@@ -431,12 +533,14 @@ defmodule Jido.AI.Skill.Loader do
 
         {:ok, normalize_metadata(metadata), Diagnostics.add_warning(diagnostics, warning)}
       else
-        {:error,
-         %Error.Validation.InvalidField{
-           field: :metadata,
-           reason: :invalid_metadata,
-           value: metadata
-         }}
+        fail(
+          %Error.Validation.InvalidField{
+            field: :metadata,
+            reason: :invalid_metadata,
+            value: metadata
+          },
+          diagnostics
+        )
       end
     end
   end
@@ -451,13 +555,15 @@ defmodule Jido.AI.Skill.Loader do
     {:ok, %{}, diagnostics}
   end
 
-  defp parse_metadata(metadata, _diagnostics, false) do
-    {:error,
-     %Error.Validation.InvalidField{
-       field: :metadata,
-       reason: :invalid_type,
-       value: metadata
-     }}
+  defp parse_metadata(metadata, diagnostics, false) do
+    fail(
+      %Error.Validation.InvalidField{
+        field: :metadata,
+        reason: :invalid_type,
+        value: metadata
+      },
+      diagnostics
+    )
   end
 
   defp invalid_optional_string(field, _value, _reason, diagnostics, true) do
@@ -465,8 +571,8 @@ defmodule Jido.AI.Skill.Loader do
     {:ok, nil, Diagnostics.add_warning(diagnostics, warning)}
   end
 
-  defp invalid_optional_string(field, value, reason, _diagnostics, false) do
-    {:error, %Error.Validation.InvalidField{field: field, reason: reason, value: value}}
+  defp invalid_optional_string(field, value, reason, diagnostics, false) do
+    fail(%Error.Validation.InvalidField{field: field, reason: reason, value: value}, diagnostics)
   end
 
   defp normalize_metadata(metadata) do
@@ -480,10 +586,23 @@ defmodule Jido.AI.Skill.Loader do
   defp invalid_field_warning(:compatibility), do: :invalid_compatibility
   defp invalid_field_warning(:license), do: :invalid_license
 
-  defp parse_tags(nil), do: []
-  defp parse_tags(tags) when is_list(tags), do: Enum.map(tags, &to_string/1)
-  defp parse_tags(tag) when is_binary(tag), do: [tag]
-  defp parse_tags(tag), do: [to_string(tag)]
+  defp file_tags(%{"jido_ai.tags" => tags}, _frontmatter, _lenient),
+    do: String.split(tags, ~r/\s+/, trim: true)
+
+  defp file_tags(_metadata, frontmatter, true), do: parse_legacy_tags(frontmatter["tags"])
+  defp file_tags(_metadata, _frontmatter, false), do: []
+
+  defp file_version(%{"jido_ai.version" => version}, _frontmatter, _lenient), do: version
+
+  defp file_version(_metadata, frontmatter, true),
+    do: optional_string(frontmatter["vsn"] || frontmatter["version"])
+
+  defp file_version(_metadata, _frontmatter, false), do: nil
+
+  defp parse_legacy_tags(nil), do: []
+  defp parse_legacy_tags(tags) when is_list(tags), do: Enum.map(tags, &to_string/1)
+  defp parse_legacy_tags(tags) when is_binary(tags), do: [tags]
+  defp parse_legacy_tags(tag), do: [to_string(tag)]
 
   defp optional_string(value) when is_binary(value), do: value
   defp optional_string(_value), do: nil
@@ -515,5 +634,9 @@ defmodule Jido.AI.Skill.Loader do
 
   defp fallback_name do
     "unnamed-skill-#{:erlang.unique_integer([:positive])}"
+  end
+
+  defp fail(error, diagnostics) do
+    {:error, error, Diagnostics.add_error(diagnostics, error)}
   end
 end

--- a/lib/jido_ai/skill/prompt.ex
+++ b/lib/jido_ai/skill/prompt.ex
@@ -119,6 +119,7 @@ defmodule Jido.AI.Skill.Prompt do
   Collects all allowed tools from a list of skills.
 
   Returns the union of all `allowed_tools` from the given skills.
+  This helper only reads advisory metadata. It does not grant tool approval.
   """
   @spec collect_allowed_tools([module() | Spec.t() | String.t()]) :: [String.t()]
   def collect_allowed_tools(skills) do
@@ -134,6 +135,10 @@ defmodule Jido.AI.Skill.Prompt do
 
   Returns only the tools whose names match the union of `allowed_tools`
   from the given skills. If no skills specify allowed_tools, returns all tools.
+
+  Calling this helper is an explicit host policy. Automatic Agent Skills
+  activation does not apply this restrictive interpretation and does not treat
+  `allowed-tools` as permission to run a tool.
   """
   @spec filter_tools([module()], [module() | Spec.t() | String.t()]) :: [module()]
   def filter_tools(tools, skills) do

--- a/lib/mix/tasks/jido_ai.skill.ex
+++ b/lib/mix/tasks/jido_ai.skill.ex
@@ -273,7 +273,7 @@ defmodule Mix.Tasks.JidoAi.Skill do
 
   defp find_skill_files(path) do
     cond do
-      File.regular?(path) && Path.basename(path) == "SKILL.md" -> [path]
+      File.regular?(path) -> [path]
       File.dir?(path) -> Path.wildcard(Path.join([path, "**", "SKILL.md"]))
       true -> []
     end

--- a/lib/mix/tasks/jido_ai.skill.ex
+++ b/lib/mix/tasks/jido_ai.skill.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.JidoAi.Skill do
 
   use Mix.Task
 
-  alias Jido.AI.Skill.{Loader, Spec}
+  alias Jido.AI.Skill.{Diagnostics, Loader, Spec}
 
   @impl Mix.Task
   def run(args) do
@@ -172,19 +172,35 @@ defmodule Mix.Tasks.JidoAi.Skill do
 
   defp validate_skills(paths, opts) do
     files = Enum.flat_map(paths, &find_skill_files/1)
-    results = Enum.map(files, fn path -> {path, Loader.load(path)} end)
+    results = Enum.map(files, fn path -> {path, validate_skill(path)} end)
 
-    valid = Enum.filter(results, fn {_, result} -> match?({:ok, _}, result) end)
-    errors = Enum.filter(results, fn {_, result} -> match?({:error, _}, result) end)
+    valid = Enum.filter(results, fn {_, result} -> match?({:ok, _, _}, result) end)
+    errors = Enum.filter(results, fn {_, result} -> match?({:error, _, _}, result) end)
+    warning_count = Enum.sum(for {_, result} <- results, do: result_warning_count(result))
 
     if opts[:json] do
       data = %{
         valid: length(valid),
         errors: length(errors),
+        warnings: warning_count,
         results:
           Enum.map(results, fn
-            {path, {:ok, spec}} -> %{path: path, valid: true, name: spec.name}
-            {path, {:error, reason}} -> %{path: path, valid: false, error: format_error(reason)}
+            {path, {:ok, spec, diagnostics}} ->
+              %{
+                path: path,
+                valid: true,
+                name: spec.name,
+                warnings: warning_messages(diagnostics)
+              }
+
+            {path, {:error, reason, diagnostics}} ->
+              %{
+                path: path,
+                valid: false,
+                error: format_error(reason),
+                warnings: warning_messages(diagnostics),
+                diagnostic_errors: diagnostic_error_messages(diagnostics)
+              }
           end)
       }
 
@@ -196,31 +212,68 @@ defmodule Mix.Tasks.JidoAi.Skill do
       Mix.shell().info("")
 
       Enum.each(results, fn
-        {path, {:ok, spec}} ->
+        {path, {:ok, spec, diagnostics}} ->
           Mix.shell().info("  #{IO.ANSI.green()}✓#{IO.ANSI.reset()} #{path} (#{spec.name})")
+          print_warnings(diagnostics)
 
-        {path, {:error, reason}} ->
+        {path, {:error, reason, diagnostics}} ->
           Mix.shell().info("  #{IO.ANSI.red()}✗#{IO.ANSI.reset()} #{path}")
           Mix.shell().info("    #{IO.ANSI.red()}#{format_error(reason)}#{IO.ANSI.reset()}")
+          print_warnings(diagnostics)
       end)
 
       Mix.shell().info("")
 
       Mix.shell().info(
-        "#{IO.ANSI.green()}Valid: #{length(valid)}#{IO.ANSI.reset()}, #{IO.ANSI.red()}Errors: #{length(errors)}#{IO.ANSI.reset()}"
+        "#{IO.ANSI.green()}Valid: #{length(valid)}#{IO.ANSI.reset()}, #{IO.ANSI.yellow()}Warnings: #{warning_count}#{IO.ANSI.reset()}, #{IO.ANSI.red()}Errors: #{length(errors)}#{IO.ANSI.reset()}"
       )
 
       Mix.shell().info("")
     end
 
-    if opts[:strict] && errors != [] do
-      Mix.raise("Validation failed with #{length(errors)} error(s)")
+    strict_failures =
+      Enum.count(results, fn {_path, result} ->
+        match?({:error, _, _}, result) or result_warning_count(result) > 0
+      end)
+
+    if opts[:strict] && strict_failures > 0 do
+      Mix.raise("Validation failed for #{strict_failures} skill(s)")
     end
+  end
+
+  defp validate_skill(path) do
+    case Loader.load_with_diagnostics(path, lenient: true) do
+      {:ok, spec, diagnostics} ->
+        case diagnostics.errors do
+          [reason | _] -> {:error, reason, diagnostics}
+          [] -> {:ok, spec, diagnostics}
+        end
+
+      {:error, reason, diagnostics} ->
+        {:error, reason, diagnostics}
+    end
+  end
+
+  defp result_warning_count({:ok, _spec, diagnostics}), do: Diagnostics.warning_count(diagnostics)
+  defp result_warning_count({:error, _reason, diagnostics}), do: Diagnostics.warning_count(diagnostics)
+
+  defp warning_messages(diagnostics) do
+    Enum.map(diagnostics.warnings, &Diagnostics.Warning.format/1)
+  end
+
+  defp diagnostic_error_messages(diagnostics) do
+    Enum.map(diagnostics.errors, &format_error/1)
+  end
+
+  defp print_warnings(diagnostics) do
+    Enum.each(warning_messages(diagnostics), fn warning ->
+      Mix.shell().info("    #{IO.ANSI.yellow()}#{warning}#{IO.ANSI.reset()}")
+    end)
   end
 
   defp find_skill_files(path) do
     cond do
-      File.regular?(path) && String.ends_with?(path, "SKILL.md") -> [path]
+      File.regular?(path) && Path.basename(path) == "SKILL.md" -> [path]
       File.dir?(path) -> Path.wildcard(Path.join([path, "**", "SKILL.md"]))
       true -> []
     end

--- a/priv/skills/code-review/SKILL.md
+++ b/priv/skills/code-review/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Jido.AI >= 2.0
 allowed-tools: read_file grep git_diff
 metadata:
   author: jido-team
-  version: "1.0.0"
+  jido_ai.version: "1.0.0"
 ---
 
 # Code Review

--- a/priv/skills/unit-converter/SKILL.md
+++ b/priv/skills/unit-converter/SKILL.md
@@ -5,11 +5,8 @@ license: Apache-2.0
 allowed-tools: convert_temperature convert_distance convert_weight
 metadata:
   author: jido-examples
-  version: "1.0"
-tags:
-  - conversion
-  - units
-  - utility
+  jido_ai.version: "1.0"
+  jido_ai.tags: "conversion units utility"
 ---
 
 # Unit Converter Skill

--- a/test/fixtures/agent_skills_conformance/README.md
+++ b/test/fixtures/agent_skills_conformance/README.md
@@ -1,0 +1,16 @@
+# Agent Skills conformance fixtures
+
+These fixtures follow the Agent Skills specification and the public
+`skills-ref` validator cases reviewed on 2026-08-26.
+
+Jido.AI makes these documented compatibility choices:
+
+- Filesystem loading requires the exact filename `SKILL.md`, as required by the
+  specification. The reference parser also accepts lowercase `skill.md`.
+- Skill names use the ASCII `a-z`, `0-9`, and hyphen grammar stated in the
+  specification table. The reference validator also accepts lowercase Unicode
+  letters and numbers.
+- Strict runtime loading rejects unknown top-level fields. Lenient parsing keeps
+  them only for diagnostics and migration.
+- An optional UTF-8 BOM is accepted for interoperability.
+

--- a/test/fixtures/agent_skills_conformance/spec-valid/SKILL.md
+++ b/test/fixtures/agent_skills_conformance/spec-valid/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: spec-valid
+description: Valid fixture for Agent Skills conformance tests.
+license: Apache-2.0
+compatibility: Jido.AI 2.x
+metadata:
+  jido_ai.tags: "review security"
+  jido_ai.version: "1.0.0"
+allowed-tools: read_file grep
+---
+
+# Valid Skill
+
+Use this fixture to test strict filesystem loading.
+

--- a/test/jido_ai/skill/conformance_test.exs
+++ b/test/jido_ai/skill/conformance_test.exs
@@ -1,0 +1,170 @@
+defmodule Jido.AI.Skill.ConformanceTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.AI.Skill.{Diagnostics, Error, Loader, Spec}
+
+  @fixture Path.expand("../../fixtures/agent_skills_conformance/spec-valid/SKILL.md", __DIR__)
+
+  describe "specification fixture" do
+    test "loads all standard fields and namespaced Jido metadata" do
+      assert {:ok, %Spec{} = spec} = Loader.load(@fixture)
+      assert spec.name == "spec-valid"
+      assert spec.allowed_tools == ["read_file", "grep"]
+      assert spec.tags == ["review", "security"]
+      assert spec.vsn == "1.0.0"
+      assert spec.metadata["jido_ai.tags"] == "review security"
+    end
+  end
+
+  describe "document boundaries" do
+    test "accepts an empty body and a closing delimiter at EOF" do
+      content = "---\nname: empty-body\ndescription: Empty body is valid.\n---"
+
+      assert {:ok, %Spec{body_ref: {:inline, ""}}} = Loader.parse(content)
+    end
+
+    test "accepts CRLF input" do
+      content = "---\r\nname: crlf\r\ndescription: CRLF input is valid.\r\n---\r\nBody.\r\n"
+
+      assert {:ok, %Spec{body_ref: {:inline, "Body."}}} = Loader.parse(content)
+    end
+
+    test "accepts an optional UTF-8 BOM" do
+      content = <<0xEF, 0xBB, 0xBF>> <> "---\nname: bom\ndescription: BOM input is valid.\n---\n"
+
+      assert {:ok, %Spec{name: "bom"}} = Loader.parse(content)
+    end
+
+    test "returns structured errors for YAML scalars and sequences" do
+      for content <- ["---\nhello\n---\n", "---\n- hello\n---\n"] do
+        assert {:error,
+                %Error.Parse.InvalidYaml{
+                  reason: :frontmatter_must_be_mapping
+                }} = Loader.parse(content)
+      end
+    end
+
+    test "returns a structured error for malformed YAML" do
+      assert {:error, %Error.Parse.InvalidYaml{}} =
+               Loader.parse("---\nname: [broken\ndescription: Invalid\n---\n")
+    end
+  end
+
+  describe "strict schema" do
+    test "accepts names at the exact length boundaries" do
+      one = "a"
+      sixty_four = String.duplicate("a", 64)
+
+      assert {:ok, %Spec{name: ^one}} = Loader.parse(skill(one))
+      assert {:ok, %Spec{name: ^sixty_four}} = Loader.parse(skill(sixty_four))
+    end
+
+    test "rejects names over 64 characters and invalid hyphen forms" do
+      invalid_names = [String.duplicate("a", 65), "-leading", "trailing-", "two--hyphens", "UPPER"]
+
+      for name <- invalid_names do
+        assert {:error, %Error.Validation.InvalidName{name: ^name}} = Loader.parse(skill(name))
+      end
+    end
+
+    test "rejects unsupported top-level fields" do
+      content = """
+      ---
+      name: portable
+      description: Uses only portable fields.
+      tags: [review]
+      version: "1.0"
+      ---
+      """
+
+      assert {:error,
+              %Error.Validation.InvalidField{
+                field: :frontmatter,
+                reason: :unsupported_top_level_fields,
+                value: ["tags", "version"]
+              }} = Loader.parse(content)
+
+      assert {:ok, %Spec{diagnostics: diagnostics}} = Loader.parse(content, "inline", lenient: true)
+      assert Enum.any?(diagnostics.warnings, &(&1.type == :unsupported_top_level_fields))
+    end
+
+    test "requires string metadata keys and values" do
+      content = "---\nname: typed-metadata\ndescription: Metadata must be strings.\nmetadata:\n  version: 2\n---\n"
+
+      assert {:error,
+              %Error.Validation.InvalidField{
+                field: :metadata,
+                reason: :invalid_metadata
+              }} = Loader.parse(content)
+    end
+
+    test "requires allowed-tools to be a space-separated string" do
+      content = "---\nname: typed-tools\ndescription: Tools must be a string.\nallowed-tools: [read, grep]\n---\n"
+
+      assert {:error,
+              %Error.Validation.InvalidField{
+                field: :allowed_tools,
+                reason: :invalid_type
+              }} = Loader.parse(content)
+    end
+  end
+
+  describe "filesystem layout" do
+    @tag :tmp_dir
+    test "requires the exact SKILL.md filename", %{tmp_dir: tmp_dir} do
+      skill_dir = Path.join(tmp_dir, "exact-name")
+      File.mkdir_p!(skill_dir)
+      path = Path.join(skill_dir, "skill.md")
+      File.write!(path, skill("exact-name"))
+
+      assert {:error,
+              %Error.Validation.InvalidField{
+                field: :file_name,
+                reason: :invalid_skill_filename
+              }} = Loader.load(path)
+    end
+
+    @tag :tmp_dir
+    test "requires the parent directory to match the declared name", %{tmp_dir: tmp_dir} do
+      skill_dir = Path.join(tmp_dir, "actual-name")
+      File.mkdir_p!(skill_dir)
+      path = Path.join(skill_dir, "SKILL.md")
+      File.write!(path, skill("declared-name"))
+
+      assert {:error,
+              %Error.Validation.InvalidField{
+                field: :name,
+                reason: :directory_name_mismatch
+              }} = Loader.load(path)
+    end
+
+    test "keeps in-memory parsing independent of the source filename" do
+      assert {:ok, %Spec{name: "in-memory"}} =
+               Loader.parse(skill("in-memory"), "/not/a/matching/file.md")
+    end
+  end
+
+  describe "diagnostic preservation" do
+    @tag :tmp_dir
+    test "returns earlier diagnostics when a later strict validation fails", %{tmp_dir: tmp_dir} do
+      diagnostics =
+        Diagnostics.new()
+        |> Diagnostics.add_warning(Diagnostics.Warning.new(:earlier_warning, "Keep this warning"))
+
+      skill_dir = Path.join(tmp_dir, "diagnostics")
+      File.mkdir_p!(skill_dir)
+      path = Path.join(skill_dir, "SKILL.md")
+      File.write!(path, skill("wrong-name"))
+
+      assert {:error, %Error.Validation.InvalidField{}, returned} =
+               Loader.load_with_diagnostics(path, lenient: false, diagnostics: diagnostics)
+
+      assert Enum.any?(returned.warnings, &(&1.type == :earlier_warning))
+      assert Diagnostics.error_count(returned) == 1
+    end
+  end
+
+  defp skill(name) do
+    "---\nname: #{name}\ndescription: A valid skill description.\n---\n"
+  end
+end

--- a/test/jido_ai/skill/loader_test.exs
+++ b/test/jido_ai/skill/loader_test.exs
@@ -79,13 +79,19 @@ defmodule Jido.AI.Skill.LoaderTest do
     Body.
     """
 
-    File.write!(Path.join(@fixtures_path, "valid.md"), valid_skill)
-    File.write!(Path.join(@fixtures_path, "minimal.md"), minimal_skill)
-    File.write!(Path.join(@fixtures_path, "no_frontmatter.md"), no_frontmatter)
-    File.write!(Path.join(@fixtures_path, "invalid_yaml.md"), invalid_yaml)
-    File.write!(Path.join(@fixtures_path, "invalid_name.md"), invalid_name)
-    File.write!(Path.join(@fixtures_path, "missing_name.md"), missing_name)
-    File.write!(Path.join(@fixtures_path, "allowed_tools_list.md"), allowed_tools_list)
+    for {directory, content} <- [
+          {"test-skill", valid_skill},
+          {"minimal", minimal_skill},
+          {"no-frontmatter", no_frontmatter},
+          {"invalid-yaml", invalid_yaml},
+          {"invalid-name", invalid_name},
+          {"missing-name", missing_name},
+          {"tools-list", allowed_tools_list}
+        ] do
+      skill_dir = Path.join(@fixtures_path, directory)
+      File.mkdir_p!(skill_dir)
+      File.write!(Path.join(skill_dir, "SKILL.md"), content)
+    end
 
     on_exit(fn ->
       File.rm_rf!(@fixtures_path)
@@ -96,7 +102,7 @@ defmodule Jido.AI.Skill.LoaderTest do
 
   describe "load/1" do
     test "loads a valid SKILL.md file" do
-      path = Path.join(@fixtures_path, "valid.md")
+      path = fixture("test-skill")
       assert {:ok, %Spec{} = spec} = Loader.load(path)
 
       assert spec.name == "test-skill"
@@ -110,7 +116,7 @@ defmodule Jido.AI.Skill.LoaderTest do
     end
 
     test "loads minimal skill with only required fields" do
-      path = Path.join(@fixtures_path, "minimal.md")
+      path = fixture("minimal")
       assert {:ok, %Spec{} = spec} = Loader.load(path)
 
       assert spec.name == "minimal"
@@ -124,27 +130,27 @@ defmodule Jido.AI.Skill.LoaderTest do
     end
 
     test "returns error for no frontmatter" do
-      path = Path.join(@fixtures_path, "no_frontmatter.md")
+      path = fixture("no-frontmatter")
       assert {:error, %Error.Parse.NoFrontmatter{}} = Loader.load(path)
     end
 
     test "returns error for invalid YAML" do
-      path = Path.join(@fixtures_path, "invalid_yaml.md")
+      path = fixture("invalid-yaml")
       assert {:error, %Error.Parse.InvalidYaml{}} = Loader.load(path)
     end
 
     test "returns error for invalid name format" do
-      path = Path.join(@fixtures_path, "invalid_name.md")
+      path = fixture("invalid-name")
       assert {:error, %Error.Validation.InvalidName{name: "Invalid_Name!"}} = Loader.load(path)
     end
 
     test "returns error for missing name" do
-      path = Path.join(@fixtures_path, "missing_name.md")
+      path = fixture("missing-name")
       assert {:error, %Error.Validation.MissingField{field: :name}} = Loader.load(path)
     end
 
     test "normalizes allowed-tools lists only in lenient mode" do
-      path = Path.join(@fixtures_path, "allowed_tools_list.md")
+      path = fixture("tools-list")
 
       assert {:error, %Error.Validation.InvalidField{field: :allowed_tools, reason: :invalid_type}} =
                Loader.load(path)
@@ -157,12 +163,12 @@ defmodule Jido.AI.Skill.LoaderTest do
 
   describe "load!/1" do
     test "returns spec for valid file" do
-      path = Path.join(@fixtures_path, "valid.md")
+      path = fixture("test-skill")
       assert %Spec{name: "test-skill"} = Loader.load!(path)
     end
 
     test "raises for invalid file" do
-      path = Path.join(@fixtures_path, "no_frontmatter.md")
+      path = fixture("no-frontmatter")
       assert_raise Error.Parse.NoFrontmatter, fn -> Loader.load!(path) end
     end
   end
@@ -436,4 +442,6 @@ defmodule Jido.AI.Skill.LoaderTest do
       assert Enum.any?(diagnostics.warnings, &(&1.type == :invalid_name_format))
     end
   end
+
+  defp fixture(directory), do: Path.join([@fixtures_path, directory, "SKILL.md"])
 end

--- a/test/jido_ai/skill/mix_task_test.exs
+++ b/test/jido_ai/skill/mix_task_test.exs
@@ -114,6 +114,7 @@ defmodule Mix.Tasks.JidoAi.SkillTest do
       assert {:ok, decoded} = Jason.decode(json)
       assert decoded["valid"] == 1
       assert decoded["errors"] == 1
+      assert decoded["warnings"] >= 0
       assert Enum.any?(decoded["results"], &(&1["path"] == valid and &1["valid"] == true))
       assert Enum.any?(decoded["results"], &(&1["path"] == invalid and &1["valid"] == false))
     end
@@ -121,8 +122,29 @@ defmodule Mix.Tasks.JidoAi.SkillTest do
     test "raises in strict mode when validation errors are present", %{invalid_skill_path: invalid} do
       flush_shell_messages()
 
-      assert_raise Mix.Error, "Validation failed with 1 error(s)", fn ->
+      assert_raise Mix.Error, "Validation failed for 1 skill(s)", fn ->
         invoke_task(["validate", invalid, "--strict"])
+      end
+    end
+
+    test "prints warnings and fails strict validation when warnings are present", %{valid_skill_path: path} do
+      File.write!(path, """
+      ---
+      name: demo-skill
+      description: Demo skill with a migration warning.
+      tags: [legacy]
+      ---
+      """)
+
+      messages = run_task_with_output(["validate", path])
+      output = format_messages(messages)
+      assert output =~ "unsupported_top_level_fields"
+      assert output =~ "Warnings: 1"
+
+      flush_shell_messages()
+
+      assert_raise Mix.Error, "Validation failed for 1 skill(s)", fn ->
+        invoke_task(["validate", path, "--strict"])
       end
     end
 

--- a/test/jido_ai/skill/mix_task_test.exs
+++ b/test/jido_ai/skill/mix_task_test.exs
@@ -72,6 +72,21 @@ defmodule Mix.Tasks.JidoAi.SkillTest do
 
       assert Enum.any?(errors, &String.contains?(&1, "Usage: mix jido_ai.skill list <path> [<path>...]"))
     end
+
+    test "reports an explicit skill file with an invalid filename", %{
+      valid_skill_path: valid_skill_path,
+      valid_dir: valid_dir
+    } do
+      invalid_filename = Path.join(valid_dir, "fooSKILL.md")
+      File.cp!(valid_skill_path, invalid_filename)
+
+      messages = run_task_with_output(["list", invalid_filename])
+      output = format_messages(messages)
+
+      assert output =~ "Skills found: 0"
+      assert output =~ "Errors: 1"
+      assert output =~ "invalid_skill_filename"
+    end
   end
 
   describe "show command" do
@@ -145,6 +160,27 @@ defmodule Mix.Tasks.JidoAi.SkillTest do
 
       assert_raise Mix.Error, "Validation failed for 1 skill(s)", fn ->
         invoke_task(["validate", path, "--strict"])
+      end
+    end
+
+    test "validates an explicit skill file with an invalid filename", %{
+      valid_skill_path: valid_skill_path,
+      valid_dir: valid_dir
+    } do
+      invalid_filename = Path.join(valid_dir, "fooSKILL.md")
+      File.cp!(valid_skill_path, invalid_filename)
+
+      messages = run_task_with_output(["validate", invalid_filename])
+      output = format_messages(messages)
+
+      assert output =~ invalid_filename
+      assert output =~ "invalid_skill_filename"
+      assert output =~ "Warnings: 1"
+
+      flush_shell_messages()
+
+      assert_raise Mix.Error, "Validation failed for 1 skill(s)", fn ->
+        invoke_task(["validate", invalid_filename, "--strict"])
       end
     end
 


### PR DESCRIPTION
## Summary\n\n- separate in-memory parsing from strict filesystem layout validation\n- support empty bodies, closing delimiters at EOF, CRLF input, and UTF-8 BOM input\n- return structured errors for non-mapping and malformed YAML\n- require exact SKILL.md filenames, matching parent directories, and standard top-level fields\n- migrate bundled Jido metadata to namespaced metadata keys\n- preserve diagnostics through failures and report CLI warnings\n- document allowed-tools as advisory metadata\n- add a specification and reference conformance suite\n\n## Validation\n\n- mix precommit\n- mix q\n- mix docs\n- mix test: 2382 passed, 1 excluded\n\nCloses #349\nPart of #348