### PR TITLE
feat(skills): support binary resource attachments

### DIFF
--- a/guides/developer/skills_system.md
+++ b/guides/developer/skills_system.md
@@ -164,6 +164,39 @@ the skill to refresh the authorized listing.
 Agent Skills integration is disabled by default so an application never starts
 trusting repository instructions merely by upgrading a dependency.
 
+### Binary resource attachments
+
+Binary resources are disabled by default. Set `resource_policy: [binary: :allow]`
+to permit images and files from an activated skill. `max_file_bytes` applies to
+all resources. `max_text_bytes` applies only to text, including UTF-8 scripts.
+
+`Resources.load/3` returns the raw bytes with a derived `kind` (`:text`, `:image`,
+or `:file`), MIME type, filename, byte size, and selector. `load_text/3` remains
+a text-only compatibility API. The filesystem and runtime provider paths use
+one shared validator.
+
+PNG, JPEG, GIF, WebP, and PDF signatures must agree with their MIME type and
+known filename extension. The signature check identifies the format; it does
+not decode or fully validate the file. Other binary files use file attachments
+when binary loading is allowed. The filesystem loader uses
+`application/octet-stream` for unknown formats.
+
+A provider must return the filename and MIME type with binary content:
+
+```elixir
+{:ok, %{resource_id: id, content: bytes, size: byte_size(bytes),
+        filename: "report.pdf", mime_type: "application/pdf"}}
+```
+
+`load_skill_resource` keeps text results in the existing `content` field. For
+images and files, it returns metadata and `__content_parts__`. Raw bytes stay in
+these content parts and are excluded from the JSON tool payload. `Turn` and
+`Context` preserve the attachment for ReqLLM. The selected model and provider
+must support the attachment type; ReqLLM reports unsupported attachments.
+
+Activation, provider ID authorization, path traversal checks, symlink rejection,
+and file size limits apply to both text and binary resource loads.
+
 ## Manual Lifecycle: Load, Register, Resolve, Retire
 
 ```elixir
@@ -317,9 +350,9 @@ content is never cached by Jido.
 
 Filesystem resources reject absolute paths, traversal, the root `SKILL.md`,
 symlinks, hard-link aliases of `SKILL.md`, oversized files, oversized text, and
-binary or non-UTF-8 content. Provider-backed resources validate only the opaque
+binary content unless the policy allows it. Provider-backed resources validate only the opaque
 ID type, emptiness, length, listing authorization, response identity, declared
-size, loaded text size, and binary/non-UTF-8 content. Missing, invalid,
+size, loaded text size, and the binary permission policy. Missing, invalid,
 oversized, binary, provider-failed, and malformed resources return structured
 action errors.
 

--- a/lib/jido_ai/actions/skill/load_resource.ex
+++ b/lib/jido_ai/actions/skill/load_resource.ex
@@ -1,6 +1,6 @@
 defmodule Jido.AI.Actions.Skill.LoadResource do
   @moduledoc """
-  Loads one text resource from an activated skill.
+  Loads one resource from an activated skill.
 
   The action uses the same runtime session as `load_skill`. It cannot access a
   skill that is not active in that session. It applies the resource policy that
@@ -9,13 +9,14 @@ defmodule Jido.AI.Actions.Skill.LoadResource do
   Filesystem skills load by `relative_path` and retain the legacy `path` alias.
   Runtime specs configured with `:resource_provider` load by opaque
   `resource_id`; the provider is invoked on every authorized load and its output
-  is validated before returning text to the model.
+  is validated before returning content to the model. Binary resources require
+  an explicit resource policy and use content parts for attachment transport.
   """
 
   use Jido.Action,
     name: "load_skill_resource",
     description: """
-    Loads one UTF-8 text resource from an activated skill. Use resource_id for
+    Loads one text, image, or file resource from an activated skill. Use resource_id for
     provider-backed runtime skills. Use relative_path for filesystem skills;
     path remains accepted as a compatibility alias.
     """,
@@ -169,7 +170,7 @@ defmodule Jido.AI.Actions.Skill.LoadResource do
   defp load_resource(name, path, %{root_dir: root_dir} = activation, _context) when is_binary(root_dir) do
     policy = Map.get(activation, :resource_policy, ResourcePolicy.default())
 
-    case Resources.load_text(root_dir, path, policy) do
+    case Resources.load(root_dir, path, policy) do
       {:ok, resource} ->
         {:ok, format_loaded_resource(name, resource)}
 
@@ -179,6 +180,28 @@ defmodule Jido.AI.Actions.Skill.LoadResource do
   end
 
   defp load_resource(name, path, _activation, _context), do: resource_error(name, path, :not_found)
+
+  defp format_loaded_resource(name, %{kind: kind} = resource) when kind in [:image, :file] do
+    part =
+      case kind do
+        :image -> ReqLLM.Message.ContentPart.image(resource.content, resource.mime_type)
+        :file -> ReqLLM.Message.ContentPart.file(resource.content, resource.filename, resource.mime_type)
+      end
+
+    metadata = %{
+      skill: name,
+      kind: kind,
+      filename: resource.filename,
+      size: resource.size,
+      mime_type: resource.mime_type,
+      __content_parts__: [part]
+    }
+
+    case resource.selector do
+      {:resource_id, id} -> Map.put(metadata, :resource_id, id)
+      {:path, path} -> Map.put(metadata, :path, path)
+    end
+  end
 
   defp format_loaded_resource(name, %{resource_id: resource_id} = resource) do
     %{
@@ -309,7 +332,7 @@ defmodule Jido.AI.Actions.Skill.LoadResource do
     error_with_selector(
       %{
         type: :binary_resource,
-        message: "#{subject} is not safe UTF-8 text",
+        message: "#{subject} requires a resource policy that allows binary content",
         skill: name
       },
       selector_key,

--- a/lib/jido_ai/skill/resource_policy.ex
+++ b/lib/jido_ai/skill/resource_policy.ex
@@ -4,7 +4,8 @@ defmodule Jido.AI.Skill.ResourcePolicy do
 
   A policy bounds file count, directory traversal, the encoded general-resource
   list, file size, and text returned to model context. Binary content is
-  rejected by the text API.
+  rejected by default. Set `binary: :allow` to permit image and file attachments
+  through the generic resource loader. Text-only APIs always reject binary data.
   """
 
   @default_max_resources 256
@@ -38,7 +39,7 @@ defmodule Jido.AI.Skill.ResourcePolicy do
           max_listing_bytes: pos_integer(),
           max_file_bytes: pos_integer(),
           max_text_bytes: pos_integer(),
-          binary: :reject
+          binary: :reject | :allow
         }
 
   @doc """
@@ -97,7 +98,7 @@ defmodule Jido.AI.Skill.ResourcePolicy do
       max_listing_bytes: positive?(policy.max_listing_bytes),
       max_file_bytes: positive?(policy.max_file_bytes),
       max_text_bytes: positive?(policy.max_text_bytes),
-      binary: policy.binary == :reject
+      binary: policy.binary in [:reject, :allow]
     ]
 
     case Enum.find(checks, fn {_key, valid?} -> not valid? end) do

--- a/lib/jido_ai/skill/resource_provider.ex
+++ b/lib/jido_ai/skill/resource_provider.ex
@@ -33,7 +33,7 @@ defmodule Jido.AI.Skill.ResourceProvider do
 
   Jido validates and normalizes every result, reapplies `ResourcePolicy`, rejects
   entries that cannot be encoded for listing, rejects malformed identifiers and
-  binary content, and invokes the provider on every resource load so content
+  binary content unless explicitly allowed, and invokes the provider on every resource load so content
   remains fresh. Listing truncation is ordered: the first entry that violates
   count, declared-size, or encoded-listing limits is excluded, as is everything
   after it. Resource IDs are opaque and are never parsed, normalized, joined,
@@ -127,18 +127,20 @@ defmodule Jido.AI.Skill.ResourceProvider do
   end
 
   @doc """
-  Loads one provider-backed UTF-8 text resource by opaque ID.
+  Loads one provider-backed resource by opaque ID.
+
+  Binary responses require `binary: :allow`, `filename`, and `mime_type`.
   """
   @spec load(provider(), Spec.t(), String.t(), ResourcePolicy.t(), map()) ::
-          {:ok, %{content: String.t(), resource_id: String.t(), size: non_neg_integer(), mime_type: String.t() | nil}}
+          {:ok, Resources.loaded_resource()}
           | {:error, term()}
   def load(provider, %Spec{} = spec, resource_id, %ResourcePolicy{} = policy, context) when is_binary(resource_id) do
     with :ok <- validate_resource_id(resource_id),
          request = %{operation: :load, skill: spec, resource_id: resource_id, policy: policy},
          {:ok, result} <- invoke(provider, request, public_context(context)),
          {:ok, resource} <- validate_load_result(result, resource_id),
-         :ok <- Resources.validate_loaded_text(loaded_resource(resource), policy) do
-      {:ok, resource}
+         {:ok, normalized} <- Resources.validate_loaded_resource(loaded_resource(resource), policy) do
+      {:ok, Map.merge(resource, normalized)}
     end
   end
 
@@ -356,13 +358,14 @@ defmodule Jido.AI.Skill.ResourceProvider do
     resource_id = fetch_entry_value(result, :resource_id)
     size = fetch_entry_value(result, :size)
     mime_type = fetch_entry_value(result, :mime_type)
+    filename = fetch_entry_value(result, :filename)
 
     with :ok <- validate_load_shape(content, size),
          :ok <- validate_resource_id(resource_id),
          :ok <- matching_id(resource_id, requested_id),
          :ok <- valid_optional_string(:mime_type, mime_type),
          :ok <- matching_size(content, size) do
-      {:ok, %{content: content, resource_id: resource_id, size: size, mime_type: mime_type}}
+      {:ok, %{content: content, resource_id: resource_id, size: size, mime_type: mime_type, filename: filename}}
     else
       {:error, reason} -> {:error, reason}
     end
@@ -375,6 +378,7 @@ defmodule Jido.AI.Skill.ResourceProvider do
       content: resource.content,
       size: resource.size,
       mime_type: resource.mime_type,
+      filename: resource.filename,
       selector: {:resource_id, resource.resource_id}
     }
   end

--- a/lib/jido_ai/skill/resources.ex
+++ b/lib/jido_ai/skill/resources.ex
@@ -43,9 +43,12 @@ defmodule Jido.AI.Skill.Resources do
   @type loaded_resource :: %{
           required(:content) => binary(),
           required(:size) => non_neg_integer(),
+          optional(:kind) => :text | :image | :file,
           optional(:mime_type) => String.t() | nil,
           optional(:filename) => String.t() | nil,
-          optional(:selector) => {:path, String.t()} | {:resource_id, String.t()}
+          optional(:selector) => {:path, String.t()} | {:resource_id, String.t()},
+          optional(:relative_path) => String.t(),
+          optional(:resource_id) => String.t()
         }
 
   @type resource_type :: :scripts | :references | :assets
@@ -119,22 +122,130 @@ defmodule Jido.AI.Skill.Resources do
   end
 
   @doc """
-  Validates a loaded resource against the current text-only resource policy.
+  Validates loaded bytes and returns a normalized text, image, or file resource.
+
+  Every resource is subject to `max_file_bytes`. Only text is subject to
+  `max_text_bytes`. Binary resources require `binary: :allow`, a filename, and
+  a MIME type. Known image and PDF signatures must match their metadata.
   """
-  @spec validate_loaded_text(loaded_resource(), ResourcePolicy.t()) :: :ok | {:error, term()}
-  def validate_loaded_text(%{content: content, size: size}, %ResourcePolicy{} = policy)
+  @spec validate_loaded_resource(loaded_resource(), ResourcePolicy.t()) ::
+          {:ok, loaded_resource()} | {:error, term()}
+  def validate_loaded_resource(%{content: content, size: size} = resource, %ResourcePolicy{} = policy)
       when is_binary(content) and is_integer(size) and size >= 0 do
-    with :ok <- within_size(size, policy.max_file_bytes, :file),
-         :ok <- within_size(size, policy.max_text_bytes, :text),
-         true <- text_content?(content) do
-      :ok
+    with true <- byte_size(content) == size,
+         :ok <- within_size(size, policy.max_file_bytes, :file),
+         {:ok, kind, mime_type} <- classify_resource(resource),
+         :ok <- validate_resource_kind(kind, resource, policy) do
+      {:ok, resource |> Map.put(:kind, kind) |> Map.put(:mime_type, mime_type)}
     else
-      false -> {:error, :binary_resource}
+      false -> {:error, :resource_size_mismatch}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  def validate_loaded_text(_resource, %ResourcePolicy{}), do: {:error, :malformed_resource}
+  def validate_loaded_resource(_resource, %ResourcePolicy{}), do: {:error, :malformed_resource}
+
+  @doc """
+  Validates text only, retaining the existing `:ok` return contract.
+  """
+  @spec validate_loaded_text(loaded_resource(), ResourcePolicy.t()) :: :ok | {:error, term()}
+  def validate_loaded_text(resource, %ResourcePolicy{} = policy) do
+    case validate_loaded_resource(resource, %{policy | binary: :reject}) do
+      {:ok, %{kind: :text}} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp classify_resource(%{content: content} = resource) do
+    signature = signature_mime(content)
+    mime_type = normalize_mime(Map.get(resource, :mime_type))
+    extension_mime = filename_mime(Map.get(resource, :filename))
+
+    cond do
+      not valid_mime?(mime_type) ->
+        {:error, :invalid_resource_mime_type}
+
+      known_binary_mime?(mime_type) and mime_type != signature ->
+        {:error, :resource_mime_mismatch}
+
+      known_binary_mime?(extension_mime) and extension_mime != signature ->
+        {:error, :resource_mime_mismatch}
+
+      signature && mime_type not in [nil, signature] ->
+        {:error, :resource_mime_mismatch}
+
+      signature ->
+        kind = if String.starts_with?(signature, "image/"), do: :image, else: :file
+        {:ok, kind, signature}
+
+      text_content?(content) ->
+        {:ok, :text, mime_type}
+
+      is_binary(mime_type) and String.starts_with?(mime_type, "text/") ->
+        {:error, :resource_mime_mismatch}
+
+      true ->
+        {:ok, :file, mime_type}
+    end
+  end
+
+  defp validate_resource_kind(:text, resource, policy) do
+    within_size(resource.size, policy.max_text_bytes, :text)
+  end
+
+  defp validate_resource_kind(_kind, _resource, %ResourcePolicy{binary: :reject}),
+    do: {:error, :binary_resource}
+
+  defp validate_resource_kind(_kind, resource, %ResourcePolicy{binary: :allow}) do
+    cond do
+      not valid_filename?(Map.get(resource, :filename)) -> {:error, :invalid_resource_filename}
+      is_nil(Map.get(resource, :mime_type)) -> {:error, :invalid_resource_mime_type}
+      true -> :ok
+    end
+  end
+
+  defp valid_filename?(name) when is_binary(name) do
+    name != "" and byte_size(name) <= 1_024 and String.valid?(name) and
+      not String.contains?(name, ["/", "\\", "\0"]) and name not in [".", ".."]
+  end
+
+  defp valid_filename?(_name), do: false
+
+  defp normalize_mime(mime) when is_binary(mime), do: String.downcase(mime)
+  defp normalize_mime(mime), do: mime
+
+  defp valid_mime?(nil), do: true
+
+  defp valid_mime?(mime) when is_binary(mime) do
+    byte_size(mime) <= 255 and String.valid?(mime) and
+      Regex.match?(~r/\A[a-zA-Z0-9!#$&^_.+-]+\/[a-zA-Z0-9!#$&^_.+-]+\z/, mime)
+  end
+
+  defp valid_mime?(_mime), do: false
+
+  defp known_binary_mime?(mime),
+    do: mime in ["image/png", "image/jpeg", "image/gif", "image/webp", "application/pdf"]
+
+  defp signature_mime(<<137, "PNG", 13, 10, 26, 10, _rest::binary>>), do: "image/png"
+  defp signature_mime(<<255, 216, 255, _rest::binary>>), do: "image/jpeg"
+  defp signature_mime(<<"GIF87a", _rest::binary>>), do: "image/gif"
+  defp signature_mime(<<"GIF89a", _rest::binary>>), do: "image/gif"
+  defp signature_mime(<<"RIFF", _size::binary-size(4), "WEBP", _rest::binary>>), do: "image/webp"
+  defp signature_mime(<<"%PDF-", _rest::binary>>), do: "application/pdf"
+  defp signature_mime(_content), do: nil
+
+  defp filename_mime(name) when is_binary(name) do
+    case String.downcase(Path.extname(name)) do
+      ".png" -> "image/png"
+      ext when ext in [".jpg", ".jpeg"] -> "image/jpeg"
+      ".gif" -> "image/gif"
+      ".webp" -> "image/webp"
+      ".pdf" -> "application/pdf"
+      _ -> nil
+    end
+  end
+
+  defp filename_mime(_name), do: nil
 
   @doc """
   Lists all resources and keeps conventional groups for compatibility.
@@ -186,6 +297,39 @@ defmodule Jido.AI.Skill.Resources do
     case load_text(skill_root, relative_path, ResourcePolicy.default()) do
       {:ok, %{content: content}} -> {:ok, content}
       {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Loads one resource as text or, with explicit permission, as an image or file.
+
+  The result contains raw bytes and metadata. Callers must keep binary bytes
+  out of JSON and use a supported attachment transport.
+  """
+  @spec load(String.t(), String.t(), ResourcePolicy.t() | keyword() | map()) ::
+          {:ok, loaded_resource()} | {:error, term()}
+  def load(skill_root, relative_path, policy_or_opts \\ [])
+      when is_binary(skill_root) and is_binary(relative_path) do
+    with {:ok, policy} <- ResourcePolicy.new(policy_or_opts),
+         {:ok, absolute_path, normalized_path, stat} <-
+           resolve_loadable_file(skill_root, relative_path),
+         :ok <- within_size(stat.size, policy.max_file_bytes, :file),
+         {:ok, content} <- read_bounded(absolute_path, policy.max_file_bytes, :file, stat) do
+      mime_type =
+        signature_mime(content) || filename_mime(normalized_path) ||
+          if(text_content?(content), do: nil, else: "application/octet-stream")
+
+      validate_loaded_resource(
+        %{
+          content: content,
+          size: byte_size(content),
+          filename: Path.basename(normalized_path),
+          relative_path: normalized_path,
+          mime_type: mime_type,
+          selector: {:path, normalized_path}
+        },
+        policy
+      )
     end
   end
 

--- a/test/jido_ai/skill/binary_resources_test.exs
+++ b/test/jido_ai/skill/binary_resources_test.exs
@@ -1,0 +1,179 @@
+defmodule Jido.AI.Skill.BinaryResourcesTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.AI.Actions.Skill.{LoadResource, LoadSkill}
+  alias Jido.AI.{Context, Turn}
+  alias Jido.AI.Skill.{Activation, AgentIntegration, Registry, ResourcePolicy, ResourceProvider, Resources, Spec}
+  alias ReqLLM.Message.ContentPart
+
+  @moduletag :tmp_dir
+  @png <<137, "PNG", 13, 10, 26, 10, 0, 255>>
+  @pdf "%PDF-1.7\nA small PDF fixture."
+  @specimen %Spec{name: "binary-skill", description: "Binary resource test", body_ref: {:inline, "Instructions"}}
+
+  setup do
+    start_supervised!(Registry)
+    :ok
+  end
+
+  test "text and scripts use the text limit, while images and files use the file limit" do
+    policy = %ResourcePolicy{binary: :allow, max_text_bytes: 4}
+
+    assert {:error, {:resource_too_large, :text, 5, 4}} =
+             Resources.validate_loaded_resource(resource("hello", "script.ex", nil), policy)
+
+    for {bytes, name, mime, kind} <- [
+          {@png, "plot.png", "image/png", :image},
+          {<<255, 216, 255, 0>>, "plot.jpg", "image/jpeg", :image},
+          {"GIF89a", "plot.gif", "image/gif", :image},
+          {<<"RIFF", 0, 0, 0, 0, "WEBP">>, "plot.webp", "image/webp", :image},
+          {@pdf, "report.pdf", "application/pdf", :file},
+          {<<0, 255, 1>>, "program.bin", "application/octet-stream", :file}
+        ] do
+      input = resource(bytes, name, mime)
+      assert {:ok, %{kind: ^kind, content: ^bytes}} = Resources.validate_loaded_resource(input, policy)
+      assert {:error, :binary_resource} = Resources.validate_loaded_resource(input, ResourcePolicy.default())
+
+      assert {:error, {:resource_too_large, :file, _, 1}} =
+               Resources.validate_loaded_resource(input, %{policy | max_file_bytes: 1})
+    end
+  end
+
+  test "text wrappers remain text-only under an allow policy" do
+    policy = %ResourcePolicy{binary: :allow}
+    assert :ok = Resources.validate_loaded_text(resource("x = 1", "code.ex", nil), policy)
+
+    assert {:error, :binary_resource} =
+             Resources.validate_loaded_text(resource(@pdf, "doc.pdf", "application/pdf"), policy)
+  end
+
+  test "shared validation rejects inconsistent size, MIME and filename metadata" do
+    policy = %ResourcePolicy{binary: :allow}
+    valid = resource(@png, "plot.png", "image/png")
+
+    assert {:ok, %{mime_type: "image/png"}} =
+             Resources.validate_loaded_resource(%{valid | mime_type: "IMAGE/PNG"}, policy)
+
+    assert {:error, :resource_size_mismatch} = Resources.validate_loaded_resource(%{valid | size: 0}, policy)
+
+    assert {:error, :resource_mime_mismatch} =
+             Resources.validate_loaded_resource(%{valid | mime_type: "image/jpeg"}, policy)
+
+    assert {:error, :resource_mime_mismatch} =
+             Resources.validate_loaded_resource(%{valid | filename: "doc.pdf"}, policy)
+
+    assert {:error, :resource_mime_mismatch} =
+             Resources.validate_loaded_resource(resource("plain text", "plot.png", "image/png"), policy)
+
+    assert {:error, :invalid_resource_mime_type} = Resources.validate_loaded_resource(%{valid | mime_type: nil}, policy)
+
+    for name <- [nil, "", "../plot.png", "bad\0.png", false] do
+      assert {:error, :invalid_resource_filename} =
+               Resources.validate_loaded_resource(%{valid | filename: name}, policy)
+    end
+  end
+
+  test "filesystem and provider resources use the same content contract", %{tmp_dir: root} do
+    policy = %ResourcePolicy{binary: :allow, max_text_bytes: 1}
+    File.write!(Path.join(root, "report.pdf"), @pdf)
+    assert {:ok, from_file} = Resources.load(root, "report.pdf", policy)
+    provider = fn _, _ -> {:ok, Map.put(resource(@pdf, "report.pdf", "application/pdf"), :resource_id, "opaque")} end
+    assert {:ok, from_provider} = ResourceProvider.load(provider, @specimen, "opaque", policy, %{})
+
+    for key <- [:kind, :content, :size, :mime_type, :filename] do
+      assert from_file[key] == from_provider[key]
+    end
+
+    assert from_file.selector == {:path, "report.pdf"}
+    assert from_provider.selector == {:resource_id, "opaque"}
+  end
+
+  test "filesystem loader rejects mismatched names, symlinks and traversal", %{tmp_dir: root} do
+    File.write!(Path.join(root, "wrong.png"), @pdf)
+    File.write!(Path.join(root, "program.bin"), <<0, 255>>)
+    File.ln_s!("program.bin", Path.join(root, "link.bin"))
+    assert {:error, :resource_mime_mismatch} = Resources.load(root, "wrong.png", binary: :allow)
+    assert {:error, _} = Resources.load(root, "link.bin", binary: :allow)
+    assert {:error, _} = Resources.load(root, "../outside", binary: :allow)
+
+    assert {:ok, %{kind: :file, mime_type: "application/octet-stream"}} =
+             Resources.load(root, "program.bin", binary: :allow)
+  end
+
+  test "existing provider text responses need no filename" do
+    provider = fn _, _ -> {:ok, %{resource_id: "text", content: "Guide", size: 5}} end
+
+    assert {:ok, %{kind: :text, content: "Guide", filename: nil}} =
+             ResourceProvider.load(provider, @specimen, "text", ResourcePolicy.default(), %{})
+  end
+
+  test "binary provider responses retain ID and size checks" do
+    policy = %ResourcePolicy{binary: :allow}
+    input = Map.put(resource(@png, "plot.png", "image/png"), :resource_id, "id")
+    provider = fn _, _ -> {:ok, %{input | size: 1}} end
+    assert {:error, :resource_size_mismatch} = ResourceProvider.load(provider, @specimen, "id", policy, %{})
+    provider = fn _, _ -> {:ok, input} end
+    assert {:error, :resource_id_mismatch} = ResourceProvider.load(provider, @specimen, "other", policy, %{})
+  end
+
+  test "images and PDFs pass from LoadResource through Turn into Context without bytes in JSON", %{tmp_dir: root} do
+    File.write!(Path.join(root, "SKILL.md"), "instructions")
+    spec = %{@specimen | source: {:file, Path.join(root, "SKILL.md")}}
+    assert {:ok, _} = Activation.activate(spec, session_id: "binary-session", resource_policy: [binary: :allow])
+
+    for {bytes, name, kind} <- [{@png, "plot.png", :image}, {@pdf, "report.pdf", :file}] do
+      File.write!(Path.join(root, name), bytes)
+
+      assert {:ok, output, []} =
+               Turn.execute_module(LoadResource, %{name: spec.name, path: name}, %{agent_id: "binary-session"})
+
+      refute Map.has_key?(output, :content)
+      assert [%ContentPart{type: ^kind, data: ^bytes}] = output.__content_parts__
+
+      assert [%ContentPart{type: :text, text: json}, %ContentPart{type: ^kind, data: ^bytes}] =
+               parts = Turn.format_tool_result_content({:ok, output})
+
+      assert {:ok, _} = Jason.decode(json)
+      refute String.contains?(json, bytes)
+      thread = Context.append_tool_result(Context.new(), "call-1", LoadResource.name(), parts)
+      assert [%{content: ^parts}] = Context.to_messages(thread)
+    end
+  end
+
+  test "provider-backed actions emit attachments only for authorized IDs" do
+    parent = self()
+    input = Map.put(resource(@png, "plot.png", "image/png"), :resource_id, "allowed")
+
+    provider = fn
+      %{operation: :list}, _ ->
+        {:ok, %{resources: [%{id: "allowed", name: "plot.png", size: byte_size(@png)}], complete: true}}
+
+      %{operation: :load}, _ ->
+        send(parent, :loaded)
+        {:ok, input}
+    end
+
+    assert {:ok, integration} =
+             AgentIntegration.prepare(
+               specs: [@specimen],
+               resource_provider: provider,
+               resource_policy: [binary: :allow]
+             )
+
+    context = Map.put(integration.tool_context, :agent_id, "provider-binary-session")
+    assert {:ok, _} = LoadSkill.run(%{name: @specimen.name}, context)
+
+    assert {:error, %{type: :resource_not_found}} =
+             LoadResource.run(%{name: @specimen.name, resource_id: "denied"}, context)
+
+    refute_received :loaded
+
+    assert {:ok, %{resource_id: "allowed", filename: "plot.png", __content_parts__: [%ContentPart{type: :image}]}} =
+             LoadResource.run(%{name: @specimen.name, resource_id: "allowed"}, context)
+
+    assert_received :loaded
+  end
+
+  defp resource(content, filename, mime_type),
+    do: %{content: content, size: byte_size(content), filename: filename, mime_type: mime_type}
+end

--- a/test/jido_ai/skill/resources_test.exs
+++ b/test/jido_ai/skill/resources_test.exs
@@ -126,8 +126,8 @@ defmodule Jido.AI.Skill.ResourcesTest do
       assert {:ok, %ResourcePolicy{max_text_bytes: 12}} =
                ResourcePolicy.new(max_text_bytes: 12)
 
-      assert {:error, {:invalid_resource_policy, :binary}} =
-               ResourcePolicy.new(binary: :allow)
+      assert {:ok, %ResourcePolicy{binary: :allow}} = ResourcePolicy.new(binary: :allow)
+      assert {:error, {:invalid_resource_policy, :binary}} = ResourcePolicy.new(binary: :unknown)
     end
   end
 


### PR DESCRIPTION
Skill resources can contain images, PDFs, and other binary files, but `LoadResource` currently accepts only text. This change adds an explicit `binary: :allow` policy and sends binary resources through the existing ReqLLM content parts. The default policy still rejects binary content.

Filesystem and provider loads use one resource validator. It checks byte limits, declared size, filenames, and known MIME signatures. Text keeps the existing result fields and text limit. Images and files return metadata plus content parts, so raw bytes stay out of tool-result JSON. Existing text-only APIs remain available.

The guide covers policy setup, provider response fields, and attachment limits. The new tests cover filesystem and provider parity, MIME conflicts, default rejection, size limits, and a complete `LoadResource -> Turn -> Context` path.

Validation:
- Full suite on the updated provider branch: 2,493 passed, 1 excluded.
- Focused resource and activation tests: 71 passed.
- `mix precommit` passed.

Closes #359.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_ai/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791128545&installation_model_id=434874&pr_number=360&repository=agentjido%2Fjido_ai&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_ai%2Fpull%2F360&signature=87470961505d1e890889597936e139ba90cdf7cef7385b164aece77ca1473f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->